### PR TITLE
[CI] Fix the name of the date step

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -116,7 +116,7 @@ jobs:
         env:
           RELEASE_NOTES: ${{ steps.generated-notes.outputs.release-notes }}
 
-      - name: Extract release date from git tag
+      - name: Get date for release
         id: release_date
         run: |
           # Convert timestamp to MST date in Y-m-d format


### PR DESCRIPTION
[CI] Fix the name of the date step since we no longer extract the date from the git tag.