### PR TITLE
[CI] Update all workflows' OS and PHP

### DIFF
--- a/.github/workflows/phparkitect.yml
+++ b/.github/workflows/phparkitect.yml
@@ -31,20 +31,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/phparkitect
-          composer install --prefer-dist --no-progress
+      - name: Install PHPArkitect Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phparkitect
 
       - name: Run PHPArkitect
         run: |

--- a/.github/workflows/phparkitect.yml
+++ b/.github/workflows/phparkitect.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/phparkitect.yml
+++ b/.github/workflows/phparkitect.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -31,20 +31,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/phpcodesniffer
-          composer install --prefer-dist --no-progress
+      - name: Install PHP Code Sniffer Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phpcodesniffer
 
       - name: Run PHP Code Sniffer
         run: |

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -31,20 +31,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/phpcsfixer
-          composer install --prefer-dist --no-progress
+      - name: Install PHP CS Fixer Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phpcsfixer
 
       - name: Run PHP CS Fixer
         run: |

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -31,22 +31,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/phpstan
-          composer install --prefer-dist --no-progress
-          cd ../suggested
-          composer install --prefer-dist --no-progress
+      - name: Install PHPStan Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phpstan
+
+      - name: Install Suggested Packages Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/suggested
 
       - name: Run PHPStan
         run: |

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,27 +29,30 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl
+          extensions: mbstring, intl, sodium, fileinfo
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies for PHPUnit
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/phpunit
-          composer install --prefer-dist --no-progress
-          cd ../suggested
-          composer install --prefer-dist --no-progress
+      - name: Install PHPUnit Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/phpunit
+
+      - name: Install Suggested Packages Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/suggested
 
       - name: Make build logs dir
         run: mkdir -p .github/ci/phpunit/build/logs

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, sodium, fileinfo, pdo, pdo-mysql, pdo-sqlite, pdo-pgsql
+          extensions: mbstring, intl, sodium, fileinfo, pdo, pdo-mysql, pdo-sqlite, pdo-pgsql, xdebug
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,15 +12,15 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
-        php: [ '8.4', '8.5' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+        php: [ '8.4', '8.5', '8.6' ]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest' ]
+        # os: [ 'ubuntu-latest', 'windows-latest' ]
         php: [ '8.4', '8.5', '8.6' ]
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ 'ubuntu-latest' ]
-        # os: [ 'ubuntu-latest', 'windows-latest' ]
+        # os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
         php: [ '8.4', '8.5', '8.6' ]
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})
@@ -30,7 +30,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, xdebug
+          extensions: mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, pdo_sqlite, pdo_pgsql, pdo_mysql xdebug
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, sodium, fileinfo, pdo, pdo-mysql, pdo-sqlite, pdo-pgsql, xdebug
+          extensions: mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite, php-pgsql, xdebug
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, sodium, fileinfo
+          extensions: mbstring, intl, sodium, fileinfo, pdo, pdo-mysql, pdo-sqlite, pdo-pgsql
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -22,6 +22,8 @@ jobs:
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})
 
+    continue-on-error: ${{ matrix.php == '8.6' }}
+
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # os: [ 'ubuntu-latest' ]
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest' ]
+        # os: [ 'ubuntu-latest', 'windows-latest' ]
         php: [ '8.4', '8.5', '8.6' ]
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite, php-pgsql, xdebug
+          extensions: mbstring, intl, sodium, fileinfo, pdo, php-mysql, php-sqlite3, php-pgsql, xdebug
           ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -31,22 +31,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/psalm
-          composer install --prefer-dist --no-progress
-          cd ../suggested
-          composer install --prefer-dist --no-progress
+      - name: Install Psalm Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/psalm
+
+      - name: Install Suggested Packages Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/suggested
 
       - name: Run Psalm with Shepherd
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -12,12 +12,12 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
+        os: [ 'ubuntu-latest' ]
         php: [ '8.4' ]
 
     name: PHP ${{ matrix.php }}

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -31,20 +31,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v3
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
         with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
-      - name: Install dependencies
-        run: |
-          composer install --prefer-dist --no-progress
-          cd .github/ci/rector
-          composer install --prefer-dist --no-progress
+      - name: Install Rector Composer dependencies
+        uses: ramsey/composer-install@v3
+        with:
+          composer-options: ${{ matrix.php == '8.6' && '--ignore-platform-req=php+' || '' }} --prefer-dist --no-progress
+          custom-cache-suffix: $(date -u "+%Y-%m")
+          working-directory: .github/ci/rector
 
       - name: Run Rector
         run: |

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl
-          ini-values: zend.assertions=1
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -12,15 +12,15 @@ permissions:
 jobs:
   build:
 
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: true
       matrix:
-        operating-system: [ 'ubuntu-22.04' ]
-        php: [ '8.4', '8.5' ]
+        os: [ 'ubuntu-latest', 'windows-latest' ]
+        php: [ '8.4', '8.5', '8.6' ]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})
 
     steps:
       - name: Setup PHP

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-latest' ]
+        # os: [ 'ubuntu-latest', 'windows-latest' ]
         php: [ '8.4', '8.5', '8.6' ]
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -29,8 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring, intl
-          ini-values: zend.assertions=1
+          extensions: mbstring, intl, sodium, fileinfo
       - name: Checkout code
         uses: actions/checkout@v6
 

--- a/.github/workflows/validate-composer.yml
+++ b/.github/workflows/validate-composer.yml
@@ -22,6 +22,8 @@ jobs:
 
     name: PHP ${{ matrix.php }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || 'Windows'  }})
 
+    continue-on-error: ${{ matrix.php == '8.6' }}
+
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
[CI] Update all workflows for pull requests, or pushes, to run on ubuntu-latest and windows-latest for phpunit and validate-composer. Also adding PHP 8.6 for phpunit and validate-composer workflows.

**NOTE** Due to issues with Windows we're not turning that on for now. We will revisit in the future date.