### PR TITLE
[Git] Remove outdated files and directories from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,7 @@
 /.idea
 /.phpunit.cache
-/build
-/coverage-html
-/metrics
 /vendor
 composer.lock
 .DS_Store
-.php_cs.cache
-.php-cs-fixer.cache
-.phpunit.result.cache
 dbname*
-phpunit.xml
 Thumbs.db


### PR DESCRIPTION
[Git] Remove outdated files and directories from .gitignore. CI related code was moved to their own directories under .github.