### PR TITLE
[CI] Fix composer check in release workflow

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -83,6 +83,9 @@ jobs:
         run: |
           cd $COMPOSER_PATH
 
+          # First install so update would be as clean as possible
+          composer install
+
           COMPOSER=$(composer update 2>&1)
           NO_CHANGES_TEXT="Nothing to install, update or remove"
 


### PR DESCRIPTION
# Description

Adding a composer install so as to not muddy the output of composer update with installs based on the composer lock file already. We just want to know if there's anything to update.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->