### PR TITLE
[CI] Add a check in merge workflow to not allow master

### DIFF
--- a/.github/workflows/merge-major-version.yml
+++ b/.github/workflows/merge-major-version.yml
@@ -21,6 +21,19 @@ jobs:
       merge-into-branch: ${{ steps.determine-merge-branch.outputs.branch }}
 
     steps:
+      - name: Ensure not using master
+        id: determine-merge-branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [ "$BRANCH" == "master" ]; then
+            echo "Cannot use master to merge up. Master is highest."
+
+            exit 1
+          else
+            echo "Not using master. Proceed."
+          fi
+
       - name: Generate a token
         id: generate-token
         uses: actions/create-github-app-token@v2


### PR DESCRIPTION
# Description

Don't allow master to be used in the merge major version workflow.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->