### PR TITLE
[CI] Add git identity to github actions bot

### DIFF
--- a/.github/workflows/merge-major-version.yml
+++ b/.github/workflows/merge-major-version.yml
@@ -89,6 +89,11 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
+      - name: Configure Git Identity
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Merge ${{ github.ref_name }} into ${{ needs.process-version.outputs.merge-into-branch }}
         env:
           FROM_BRANCH: ${{ github.ref_name }}
@@ -103,7 +108,7 @@ jobs:
             git add "$IGNORED_FILE"
           done
 
-      - name: Commit README.md badge change
+      - name: Commit merge
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "[Merge] Merge branch `${{ github.ref_name }}` into `${{ needs.process-version.outputs.merge-into-branch }}"


### PR DESCRIPTION
# Description

Add the GitHub actions bot as the identity for the merge.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->