### PR TITLE
[Dispatcher] Update arguments to require argument name

### DIFF
--- a/src/Valkyrja/Dispatcher/Contract/Dispatcher.php
+++ b/src/Valkyrja/Dispatcher/Contract/Dispatcher.php
@@ -25,8 +25,8 @@ interface Dispatcher
     /**
      * Dispatch a callable.
      *
-     * @param Dispatch                     $dispatch  The dispatch
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param Dispatch                            $dispatch  The dispatch
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return mixed
      */

--- a/src/Valkyrja/Dispatcher/Data/CallableDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/CallableDispatch.php
@@ -28,7 +28,7 @@ class CallableDispatch extends Dispatch implements Contract
 
     /**
      * @param callable                                   $callable     The callable
-     * @param array<array-key, mixed>|null               $arguments    The arguments
+     * @param array<non-empty-string, mixed>|null        $arguments    The arguments
      * @param array<non-empty-string, class-string>|null $dependencies The dependencies
      */
     public function __construct(

--- a/src/Valkyrja/Dispatcher/Data/ClassDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/ClassDispatch.php
@@ -25,7 +25,7 @@ class ClassDispatch extends Dispatch implements Contract
 {
     /**
      * @param class-string                               $class        The class name
-     * @param array<array-key, mixed>|null               $arguments    The arguments
+     * @param array<non-empty-string, mixed>|null        $arguments    The arguments
      * @param array<non-empty-string, class-string>|null $dependencies The dependencies
      */
     public function __construct(

--- a/src/Valkyrja/Dispatcher/Data/Contract/CallableDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/Contract/CallableDispatch.php
@@ -39,14 +39,14 @@ interface CallableDispatch extends Dispatch
     /**
      * Get the arguments.
      *
-     * @return array<array-key, mixed>|null
+     * @return array<non-empty-string, mixed>|null
      */
     public function getArguments(): array|null;
 
     /**
      * Create a new dispatch with the specified arguments.
      *
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return static
      */

--- a/src/Valkyrja/Dispatcher/Data/Contract/ClassDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/Contract/ClassDispatch.php
@@ -37,14 +37,14 @@ interface ClassDispatch extends Dispatch
     /**
      * Get the arguments.
      *
-     * @return array<array-key, mixed>|null
+     * @return array<non-empty-string, mixed>|null
      */
     public function getArguments(): array|null;
 
     /**
      * Create a new dispatch with the specified arguments.
      *
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return static
      */

--- a/src/Valkyrja/Dispatcher/Data/MethodDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/MethodDispatch.php
@@ -30,7 +30,7 @@ class MethodDispatch extends ClassDispatch implements Contract
     /**
      * @param class-string                               $class        The class name
      * @param non-empty-string                           $method       The method name
-     * @param array<array-key, mixed>|null               $arguments    The arguments
+     * @param array<non-empty-string, mixed>|null        $arguments    The arguments
      * @param array<non-empty-string, class-string>|null $dependencies The dependencies
      */
     public function __construct(

--- a/src/Valkyrja/Dispatcher/Data/PropertyDispatch.php
+++ b/src/Valkyrja/Dispatcher/Data/PropertyDispatch.php
@@ -26,7 +26,7 @@ class PropertyDispatch extends ClassDispatch implements Contract
     /**
      * @param class-string                               $class        The class name
      * @param non-empty-string                           $property     The property name
-     * @param array<array-key, mixed>|null               $arguments    The arguments
+     * @param array<non-empty-string, mixed>|null        $arguments    The arguments
      * @param array<non-empty-string, class-string>|null $dependencies The dependencies
      */
     public function __construct(

--- a/src/Valkyrja/Dispatcher/Dispatcher.php
+++ b/src/Valkyrja/Dispatcher/Dispatcher.php
@@ -65,8 +65,8 @@ class Dispatcher implements Contract
     /**
      * Dispatch a class method.
      *
-     * @param MethodDispatch               $dispatch  The dispatch
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param MethodDispatch                      $dispatch  The dispatch
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return mixed
      */
@@ -129,8 +129,8 @@ class Dispatcher implements Contract
     /**
      * Dispatch a class.
      *
-     * @param ClassDispatch                $dispatch  The dispatch
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param ClassDispatch                       $dispatch  The dispatch
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return mixed
      */
@@ -147,8 +147,8 @@ class Dispatcher implements Contract
     /**
      * Dispatch a function.
      *
-     * @param CallableDispatch             $dispatch  The dispatch
-     * @param array<array-key, mixed>|null $arguments The arguments
+     * @param CallableDispatch                    $dispatch  The dispatch
+     * @param array<non-empty-string, mixed>|null $arguments The arguments
      *
      * @return mixed
      */
@@ -181,9 +181,9 @@ class Dispatcher implements Contract
      * Get a dispatch's arguments.
      *
      * @param CallableDispatch|ClassDispatch|MethodDispatch $dispatch  The dispatch
-     * @param array<array-key, mixed>|null                  $arguments [optional] The arguments
+     * @param array<non-empty-string, mixed>|null           $arguments [optional] The arguments
      *
-     * @return array<array-key, mixed>|null
+     * @return array<non-empty-string, mixed>|null
      */
     protected function getArguments(CallableDispatch|ClassDispatch|MethodDispatch $dispatch, array|null $arguments = null): array|null
     {
@@ -201,10 +201,10 @@ class Dispatcher implements Contract
 
         // Iterate through the arguments
         /** @var mixed $argument */
-        foreach ($arguments as $argument) {
+        foreach ($arguments as $key => $argument) {
             // Append the argument to the arguments list
             /** @psalm-suppress MixedAssignment */
-            $dependencies[] = $this->getArgumentValue($argument);
+            $dependencies[$key] = $this->getArgumentValue($argument);
         }
 
         return $dependencies;

--- a/src/Valkyrja/Event/Dispatcher.php
+++ b/src/Valkyrja/Event/Dispatcher.php
@@ -113,7 +113,7 @@ class Dispatcher implements Contract
     {
         // Dispatch the listener with the event
         /** @var mixed $dispatch */
-        $dispatch = $this->dispatcher->dispatch($listener->getDispatch(), [$event]);
+        $dispatch = $this->dispatcher->dispatch($listener->getDispatch(), ['event' => $event]);
 
         // If the event is a dispatch collectable event
         if ($event instanceof DispatchCollectableEvent) {

--- a/src/Valkyrja/Http/Routing/Constant/Regex.php
+++ b/src/Valkyrja/Http/Routing/Constant/Regex.php
@@ -74,4 +74,7 @@ final class Regex
     public const string START_OPTIONAL_CAPTURE_GROUP = self::START_NON_CAPTURE_GROUP . self::PATH . self::END_OPTIONAL_CAPTURE_GROUP;
     public const string END_CAPTURE_GROUP            = ')';
     public const string END_OPTIONAL_CAPTURE_GROUP   = ')?';
+
+    public const string START_CAPTURE_GROUP_NAME = '?<';
+    public const string END_CAPTURE_GROUP_NAME   = '>';
 }

--- a/src/Valkyrja/Http/Routing/Data/Contract/Parameter.php
+++ b/src/Valkyrja/Http/Routing/Data/Contract/Parameter.php
@@ -25,14 +25,14 @@ interface Parameter
     /**
      * Get the name.
      *
-     * @return string
+     * @return non-empty-string
      */
     public function getName(): string;
 
     /**
      * Create a new parameter with the specified name.
      *
-     * @param string $name The name
+     * @param non-empty-string $name The name
      *
      * @return static
      */
@@ -41,14 +41,14 @@ interface Parameter
     /**
      * Get the regex.
      *
-     * @return string
+     * @return non-empty-string
      */
     public function getRegex(): string;
 
     /**
      * Create a new parameter with the specified regex.
      *
-     * @param string $regex The regex
+     * @param non-empty-string $regex The regex
      *
      * @return static
      */

--- a/src/Valkyrja/Http/Routing/Data/Parameter.php
+++ b/src/Valkyrja/Http/Routing/Data/Parameter.php
@@ -25,6 +25,8 @@ use Valkyrja\Type\Data\Cast;
 class Parameter implements Contract
 {
     /**
+     * @param non-empty-string                        $name    The parameter's name
+     * @param non-empty-string                        $regex   The parameter's regex
      * @param array<scalar|object>|scalar|object|null $default The default value
      */
     public function __construct(

--- a/src/Valkyrja/Http/Routing/Processor/Processor.php
+++ b/src/Valkyrja/Http/Routing/Processor/Processor.php
@@ -133,6 +133,8 @@ class Processor implements Contract
         $parameterRegex = ($isOptional ? Regex::START_OPTIONAL_CAPTURE_GROUP : '')
             // Start the actual value's capture group
             . (! $parameter->shouldCapture() ? Regex::START_NON_CAPTURE_GROUP : Regex::START_CAPTURE_GROUP)
+            // Add the parameter name only for a capture group (non capture groups won't be captured so we don't need them to be attributed to a param name)
+            . ($parameter->shouldCapture() ? Regex::START_CAPTURE_GROUP_NAME . $parameter->getName() . Regex::END_CAPTURE_GROUP_NAME : '')
             // Set the parameter's regex to match the value
             . $parameter->getRegex()
             // End the capture group

--- a/tests/Unit/Event/DispatcherTest.php
+++ b/tests/Unit/Event/DispatcherTest.php
@@ -33,7 +33,7 @@ class DispatcherTest extends TestCase
     /**
      * Callback test.
      */
-    public static function dispatchCallback(): string
+    public static function dispatchCallback(DispatchCollectableEventClass|StoppableEventClass $event): string
     {
         self::$dispatched = true;
 

--- a/tests/Unit/Http/Routing/Processor/ProcessorTest.php
+++ b/tests/Unit/Http/Routing/Processor/ProcessorTest.php
@@ -81,7 +81,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($route->getPath(), $routeAfterProcessing->getPath());
         self::assertSame($route->getName(), $routeAfterProcessing->getName());
-        self::assertSame('/^\/([a-zA-Z]+)$/', $routeAfterProcessing->getRegex());
+        self::assertSame('/^\/(?<value>[a-zA-Z]+)$/', $routeAfterProcessing->getRegex());
     }
 
     public function testDynamicRouteInvalidPath(): void
@@ -148,7 +148,7 @@ class ProcessorTest extends TestCase
 
         self::assertSame($route->getPath(), $routeAfterProcessing->getPath());
         self::assertSame($route->getName(), $routeAfterProcessing->getName());
-        self::assertSame('/^(?:\/)?([a-zA-Z]+)?$/', $routeAfterProcessing->getRegex());
+        self::assertSame('/^(?:\/)?(?<optional>[a-zA-Z]+)?$/', $routeAfterProcessing->getRegex());
     }
 
     public function testDynamicRouteWithNonCaptureParam(): void


### PR DESCRIPTION
# Description

Update the dispatcher to require dispatch arguments to have the argument name as the key of the array.
This also involves updating the routing layer of Http to pass arguments in from regex matching as string-key/value pairs. So regexes have been updated
Event dispatching has also been updated to require the event parameter in dispatches.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->