### PR TITLE
[CI] Add cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick-commits.yml
+++ b/.github/workflows/cherry-pick-commits.yml
@@ -1,0 +1,52 @@
+name: Cherry-pick pull-requests to Branches
+
+on:
+  workflow_dispatch:
+    inputs:
+      hash:
+        description: 'Hash to cherry-pick'
+        required: true
+
+run-name: Cherry Pick ${{ inputs.hash }} To ${{ github.ref_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick ${{ inputs.hash }} to ${{ github.ref_name }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Ensure using master or major version branch
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [[ "$BRANCH" == "master" ] || [ $BRANCH =~ ^(2[5-9].x)$ ]]; then
+            echo "All new major release version branches must be made from latest master."
+            echo "Using master or major version branch. Proceed."
+
+            exit 0
+          else
+            echo "Using invalid branch. Exiting."
+
+            exit 1
+          fi
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.VALKYRJA_GHA_APP_ID }}
+          private-key: ${{ secrets.VALKYRJA_GHA_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Cherry Pick ${{ inputs.hash }} to ${{ github.ref_name }}
+        run: |
+          git cherry-pick ${{ inputs.hash }}
+          git push origin ${{ github.ref_name }}


### PR DESCRIPTION
# Description

This will take over for the merge workflow and allow us to deprecate it. The merge workflow has issues with merging changes up especially when changes are made that should stay in those lower version branches.

This will be a safer way to grab changes from lower branches (bugfixes) and apply them up to higher branches as necessary.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->