### PR TITLE
[CI] Update the unrelease url in create-version-branch workflow

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -142,8 +142,9 @@ jobs:
       - name: Update CHANGELOG.md
         env:
           BRANCH: ${{ needs.get-version.outputs.branch }}
+          VERSION: ${{ needs.get-version.outputs.version }}
         run: |
-          echo -e "# Release Notes for $BRANCH\n## [Unreleased](https://github.com/valkyrjaio/valkyrja/compare/$BRANCH...master)" > CHANGELOG.md
+          echo -e "# Release Notes for $BRANCH\n## [Unreleased](https://github.com/valkyrjaio/valkyrja/compare/$VERSION.0.0...$BRANCH)" > CHANGELOG.md
 
       - name: Commit version specific updates
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
# Description

Unreleased url should be the current major version branch, compared to the latest version's release.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->