### PR TITLE
[CI] Add MST to release build date

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -180,7 +180,7 @@ jobs:
         id: build_date
         run: |
           # Convert timestamp to MST date in Y-m-d format
-          FORMATED_DATE=$(TZ='America/Phoenix' date '+%B %-d %Y %T')
+          FORMATED_DATE=$(TZ='America/Phoenix' date '+%B %-d %Y %T MST')
 
           # Make date available to other steps
           echo "date=$(echo $FORMATED_DATE)" >> $GITHUB_OUTPUT;


### PR DESCRIPTION
# Description

Add MST timezone to the build date in the release version workflow.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->