### PR TITLE
[Application] Add Http module data cache file that doesn't include Cli

### DIFF
--- a/src/Valkyrja/Application/Cli/Command/CacheCommand.php
+++ b/src/Valkyrja/Application/Cli/Command/CacheCommand.php
@@ -55,10 +55,17 @@ class CacheCommand
     ): Output {
         /** @var non-empty-string $cacheFilePath */
         $cacheFilePath = $env::APP_CACHE_FILE_PATH;
+        /** @var non-empty-string $httpCacheFilePath */
+        $httpCacheFilePath = $env::APP_HTTP_CACHE_FILE_PATH;
 
         // If the cache file already exists, delete it
         if (is_file($cacheFilePath)) {
             @unlink($cacheFilePath);
+        }
+
+        // If the cache file already exists, delete it
+        if (is_file($httpCacheFilePath)) {
+            @unlink($httpCacheFilePath);
         }
 
         $data = new Data(
@@ -67,11 +74,19 @@ class CacheCommand
             cli: $cliCollection->getData(),
             http: $routerCollection->getData(),
         );
+        // Same data just no cli data
+        $dataHttp = new Data(
+            container: $container->getData(),
+            event: $eventCollection->getData(),
+            http: $routerCollection->getData(),
+        );
 
         // Get the results of the cache attempt
         $result = @file_put_contents($cacheFilePath, serialize($data), LOCK_EX);
+        // Get the results of the cache attempt
+        $resultHttp = @file_put_contents($cacheFilePath, serialize($dataHttp), LOCK_EX);
 
-        if ($result === false) {
+        if ($result === false || $resultHttp === false) {
             return $outputFactory
                 ->createOutput(exitCode: ExitCode::ERROR)
                 ->withMessages(

--- a/src/Valkyrja/Application/Cli/Command/ClearCacheCommand.php
+++ b/src/Valkyrja/Application/Cli/Command/ClearCacheCommand.php
@@ -38,10 +38,17 @@ class ClearCacheCommand
     {
         /** @var non-empty-string $cacheFilePath */
         $cacheFilePath = $env::APP_CACHE_FILE_PATH;
+        /** @var non-empty-string $httpCacheFilePath */
+        $httpCacheFilePath = $env::APP_HTTP_CACHE_FILE_PATH;
 
         // If the cache file already exists, delete it
         if (is_file($cacheFilePath)) {
             @unlink($cacheFilePath);
+        }
+
+        // If the http cache file already exists, delete it
+        if (is_file($httpCacheFilePath)) {
+            @unlink($httpCacheFilePath);
         }
 
         return $outputFactory

--- a/src/Valkyrja/Application/Entry/App.php
+++ b/src/Valkyrja/Application/Entry/App.php
@@ -44,15 +44,19 @@ abstract class App
     /**
      * Start the application.
      *
-     * @param non-empty-string $dir The directory
+     * @param non-empty-string      $dir           The directory
+     * @param non-empty-string|null $cacheFilepath The cache file path
      */
-    public static function start(string $dir, Env $env): Application
+    public static function start(string $dir, Env $env, string|null $cacheFilepath = null): Application
     {
         static::defaultExceptionHandler();
         static::appStart();
         static::directory(dir: $dir);
 
-        return static::app(env: $env);
+        return static::app(
+            env: $env,
+            cacheFilepath: $cacheFilepath
+        );
     }
 
     /**
@@ -62,9 +66,13 @@ abstract class App
      */
     public static function http(string $dir, Env $env): void
     {
+        /** @var non-empty-string $cacheFilepath */
+        $cacheFilepath = $env::APP_HTTP_CACHE_FILE_PATH;
+
         $app = static::start(
             dir: $dir,
             env: $env,
+            cacheFilepath: $cacheFilepath
         );
 
         $container = $app->getContainer();
@@ -128,11 +136,15 @@ abstract class App
      *  use the default config out of the root config directory, but
      *  when you're on a production environment definitely have
      *  your config cached and the flag set in your env class.
+     *
+     * @param non-empty-string|null $cacheFilepath The cache file path
      */
-    public static function app(Env $env): Application
+    public static function app(Env $env, string|null $cacheFilepath = null): Application
     {
-        /** @var non-empty-string $cacheFilepath */
-        $cacheFilepath = $env::APP_CACHE_FILE_PATH;
+        /** @var non-empty-string $appCacheFilePath */
+        $appCacheFilePath = $env::APP_CACHE_FILE_PATH;
+
+        $cacheFilepath ??= $appCacheFilePath;
 
         if (is_file($cacheFilepath)) {
             $configData = static::getData(cacheFilePath: $cacheFilepath);

--- a/src/Valkyrja/Application/Env.php
+++ b/src/Valkyrja/Application/Env.php
@@ -118,6 +118,8 @@ class Env
     public const string APP_DIR = __DIR__ . '/..';
     /** @var non-empty-string */
     public const string APP_CACHE_FILE_PATH = __DIR__ . '/../storage/framework/cache/cache.php';
+    /** @var non-empty-string */
+    public const string APP_HTTP_CACHE_FILE_PATH = __DIR__ . '/../storage/framework/cache/http-cache.php';
 
     /************************************************************
      *


### PR DESCRIPTION
# Description

The big Q here is: "Is this really needed? The option exists to create a different app for Cli/Http, or even have separate Env files.
In all honesty may want to be able to set a mode (Cli/Http) where Http would turn off Cli, etc for faster running. Could make this just a configuration through the env file. So it could be true for each core module, but ability to turn off exists.

I think I like that better tbh.

If the env for HTTP_MODULE is false don't get HttpControllers.
If the env for CLI_MODULE is false don't get CliControllers. See `Valkyrja` app.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->