### PR TITLE
[Http] Update data route object to require dispatch

### DIFF
--- a/src/Valkyrja/Http/Routing/Attribute/Route.php
+++ b/src/Valkyrja/Http/Routing/Attribute/Route.php
@@ -14,7 +14,17 @@ declare(strict_types=1);
 namespace Valkyrja\Http\Routing\Attribute;
 
 use Attribute;
+use Valkyrja\Dispatcher\Data\Contract\MethodDispatch;
+use Valkyrja\Http\Message\Enum\RequestMethod;
+use Valkyrja\Http\Middleware\Contract\RouteDispatchedMiddleware;
+use Valkyrja\Http\Middleware\Contract\RouteMatchedMiddleware;
+use Valkyrja\Http\Middleware\Contract\SendingResponseMiddleware;
+use Valkyrja\Http\Middleware\Contract\TerminatedMiddleware;
+use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddleware;
+use Valkyrja\Http\Routing\Data\Contract\Parameter;
 use Valkyrja\Http\Routing\Data\Route as ParentRoute;
+use Valkyrja\Http\Struct\Request\Contract\RequestStruct;
+use Valkyrja\Http\Struct\Response\Contract\ResponseStruct;
 
 /**
  * Attribute Route.
@@ -24,4 +34,49 @@ use Valkyrja\Http\Routing\Data\Route as ParentRoute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Route extends ParentRoute
 {
+    /**
+     * @param non-empty-string                          $path                      The path
+     * @param non-empty-string                          $name                      The name
+     * @param non-empty-string|null                     $regex                     The regex
+     * @param RequestMethod[]                           $requestMethods            The request methods
+     * @param Parameter[]                               $parameters                The parameters
+     * @param class-string<RouteMatchedMiddleware>[]    $routeMatchedMiddleware    The route matched middleware
+     * @param class-string<RouteDispatchedMiddleware>[] $routeDispatchedMiddleware The route dispatched middleware
+     * @param class-string<ThrowableCaughtMiddleware>[] $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<SendingResponseMiddleware>[] $sendingResponseMiddleware The sending response middleware
+     * @param class-string<TerminatedMiddleware>[]      $terminatedMiddleware      The terminated middleware
+     * @param class-string<RequestStruct>|null          $requestStruct             The request struct
+     * @param class-string<ResponseStruct>|null         $responseStruct            The response struct
+     */
+    public function __construct(
+        protected string $path,
+        protected string $name,
+        protected MethodDispatch $dispatch = new \Valkyrja\Dispatcher\Data\MethodDispatch(self::class, 'getPath'),
+        protected array $requestMethods = [RequestMethod::HEAD, RequestMethod::GET],
+        protected string|null $regex = null,
+        protected array $parameters = [],
+        protected array $routeMatchedMiddleware = [],
+        protected array $routeDispatchedMiddleware = [],
+        protected array $throwableCaughtMiddleware = [],
+        protected array $sendingResponseMiddleware = [],
+        protected array $terminatedMiddleware = [],
+        protected string|null $requestStruct = null,
+        protected string|null $responseStruct = null,
+    ) {
+        parent::__construct(
+            path: $path,
+            name: $name,
+            dispatch: $dispatch,
+            requestMethods: $requestMethods,
+            regex: $regex,
+            parameters: $parameters,
+            routeMatchedMiddleware: $routeMatchedMiddleware,
+            routeDispatchedMiddleware: $routeDispatchedMiddleware,
+            throwableCaughtMiddleware: $throwableCaughtMiddleware,
+            sendingResponseMiddleware: $sendingResponseMiddleware,
+            terminatedMiddleware: $terminatedMiddleware,
+            requestStruct: $requestStruct,
+            responseStruct: $responseStruct,
+        );
+    }
 }

--- a/src/Valkyrja/Http/Routing/Data/Route.php
+++ b/src/Valkyrja/Http/Routing/Data/Route.php
@@ -52,7 +52,7 @@ class Route implements Contract
     public function __construct(
         protected string $path,
         protected string $name,
-        protected MethodDispatch $dispatch = new \Valkyrja\Dispatcher\Data\MethodDispatch(self::class, 'getPath'),
+        protected MethodDispatch $dispatch,
         protected array $requestMethods = [RequestMethod::HEAD, RequestMethod::GET],
         protected string|null $regex = null,
         protected array $parameters = [],

--- a/tests/Unit/Http/Middleware/Handler/HandlerTestCase.php
+++ b/tests/Unit/Http/Middleware/Handler/HandlerTestCase.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Middleware\Handler;
 
 use Valkyrja\Container\Container;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Message\Request\ServerRequest;
 use Valkyrja\Http\Message\Response\Response;
 use Valkyrja\Http\Routing\Data\Route;
@@ -45,6 +46,10 @@ class HandlerTestCase extends TestCase
 
         $this->request  = new ServerRequest();
         $this->response = new Response();
-        $this->route    = new Route('/', 'name');
+        $this->route    = new Route(
+            '/',
+            'name',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
     }
 }

--- a/tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
+++ b/tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Tests\Unit\Http\Routing\Cli\Command;
 
 use Valkyrja\Cli\Command\VersionCommand;
 use Valkyrja\Cli\Interaction\Factory\OutputFactory;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 use Valkyrja\Http\Routing\Collection\Collection;
 use Valkyrja\Http\Routing\Data\Route;
@@ -36,6 +37,7 @@ class ListCommandTest extends TestCase
         $route = new Route(
             path: $path,
             name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             regex: $regex,
         );
 

--- a/tests/Unit/Http/Routing/Data/RouteTest.php
+++ b/tests/Unit/Http/Routing/Data/RouteTest.php
@@ -46,12 +46,16 @@ class RouteTest extends TestCase
         $path = '/';
         $name = 'route';
 
-        $route = new Route(path: $path, name: $name);
+        $route = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
 
         self::assertSame($path, $route->getPath());
         self::assertSame($name, $route->getName());
-        self::assertSame(Route::class, $route->getDispatch()->getClass());
-        self::assertSame('getPath', $route->getDispatch()->getMethod());
+        self::assertSame(self::class, $route->getDispatch()->getClass());
+        self::assertSame('dispatch', $route->getDispatch()->getMethod());
         self::assertSame([RequestMethod::HEAD, RequestMethod::GET], $route->getRequestMethods());
         self::assertNull($route->getRegex());
         self::assertEmpty($route->getParameters());
@@ -70,7 +74,11 @@ class RouteTest extends TestCase
         $path2 = '/another';
         $name  = 'route';
 
-        $route  = new Route(path: $path, name: $name);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $route2 = $route->withPath($path2);
         $route3 = $route->withAddedPath('version');
         $route4 = $route2->withAddedPath('/more');
@@ -94,7 +102,11 @@ class RouteTest extends TestCase
         $name  = 'route';
         $name2 = 'route2';
 
-        $route  = new Route(path: $path, name: $name);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $route2 = $route->withName($name2);
         $route3 = $route->withAddedName('.version');
         $route4 = $route2->withAddedName('.more');
@@ -141,7 +153,11 @@ class RouteTest extends TestCase
         $methods        = [RequestMethod::GET, RequestMethod::POST];
         $methods2       = [RequestMethod::PUT, RequestMethod::POST];
 
-        $route  = new Route(path: $path, name: $name);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $route2 = $route->withRequestMethods(...$methods);
         $route3 = $route->withRequestMethods(...$methods2);
         $route4 = $route->withRequestMethod(RequestMethod::DELETE);
@@ -189,7 +205,12 @@ class RouteTest extends TestCase
         $parameter3 = new Parameter(name: 'test3', regex: Regex::ALPHA);
         $parameter4 = new Parameter(name: 'test4', regex: Regex::ALPHA);
 
-        $route  = new Route(path: $path, name: $name, parameters: [$parameter]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            parameters: [$parameter]
+        );
         $route2 = $route->withParameter($parameter2);
         $route3 = $route->withParameters($parameter3);
         $route4 = $route->withAddedParameter($parameter2);
@@ -214,7 +235,12 @@ class RouteTest extends TestCase
         $middleware  = RouteMatchedMiddlewareClass::class;
         $middleware2 = RouteMatchedMiddlewareChangedClass::class;
 
-        $route  = new Route(path: $path, name: $name, routeMatchedMiddleware: [$middleware]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            routeMatchedMiddleware: [$middleware]
+        );
         $route2 = $route->withRouteMatchedMiddleware($middleware2);
         $route3 = $route->withAddedRouteMatchedMiddleware($middleware2);
 
@@ -233,7 +259,12 @@ class RouteTest extends TestCase
         $middleware  = RouteDispatchedMiddlewareClass::class;
         $middleware2 = RouteDispatchedMiddlewareChangedClass::class;
 
-        $route  = new Route(path: $path, name: $name, routeDispatchedMiddleware: [$middleware]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            routeDispatchedMiddleware: [$middleware]
+        );
         $route2 = $route->withRouteDispatchedMiddleware($middleware2);
         $route3 = $route->withAddedRouteDispatchedMiddleware($middleware2);
 
@@ -252,7 +283,12 @@ class RouteTest extends TestCase
         $middleware  = ThrowableCaughtMiddlewareClass::class;
         $middleware2 = ThrowableCaughtMiddlewareChangedClass::class;
 
-        $route  = new Route(path: $path, name: $name, throwableCaughtMiddleware: [$middleware]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            throwableCaughtMiddleware: [$middleware]
+        );
         $route2 = $route->withThrowableCaughtMiddleware($middleware2);
         $route3 = $route->withAddedThrowableCaughtMiddleware($middleware2);
 
@@ -271,7 +307,12 @@ class RouteTest extends TestCase
         $middleware  = SendingResponseMiddlewareClass::class;
         $middleware2 = SendingResponseMiddlewareChangedClass::class;
 
-        $route  = new Route(path: $path, name: $name, sendingResponseMiddleware: [$middleware]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            sendingResponseMiddleware: [$middleware]
+        );
         $route2 = $route->withSendingResponseMiddleware($middleware2);
         $route3 = $route->withAddedSendingResponseMiddleware($middleware2);
 
@@ -290,7 +331,12 @@ class RouteTest extends TestCase
         $middleware  = TerminatedMiddlewareClass::class;
         $middleware2 = TerminatedMiddlewareChangedClass::class;
 
-        $route  = new Route(path: $path, name: $name, terminatedMiddleware: [$middleware]);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            terminatedMiddleware: [$middleware]
+        );
         $route2 = $route->withTerminatedMiddleware($middleware2);
         $route3 = $route->withAddedTerminatedMiddleware($middleware2);
 
@@ -309,7 +355,12 @@ class RouteTest extends TestCase
         $requestStruct  = IndexedJsonRequestStructEnum::class;
         $requestStruct2 = IndexedParsedBodyRequestStructEnum::class;
 
-        $route  = new Route(path: $path, name: $name, requestStruct: $requestStruct);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            requestStruct: $requestStruct
+        );
         $route2 = $route->withRequestStruct($requestStruct2);
 
         self::assertNotSame($route, $route2);
@@ -325,7 +376,12 @@ class RouteTest extends TestCase
         $responseStruct  = ResponseStructEnum::class;
         $responseStruct2 = IndexedResponseStructEnum::class;
 
-        $route  = new Route(path: $path, name: $name, responseStruct: $responseStruct);
+        $route  = new Route(
+            path: $path,
+            name: $name,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            responseStruct: $responseStruct
+        );
         $route2 = $route->withResponseStruct($responseStruct2);
 
         self::assertNotSame($route, $route2);

--- a/tests/Unit/Http/Routing/Factory/ResponseFactoryTest.php
+++ b/tests/Unit/Http/Routing/Factory/ResponseFactoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Routing\Factory;
 
 use Override;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Factory\ResponseFactory as MessageResponseFactory;
 use Valkyrja\Http\Routing\Collection\Collection;
@@ -38,7 +39,11 @@ class ResponseFactoryTest extends TestCase
     {
         parent::setUp();
 
-        $route           = new Route(path: '/', name: self::ROUTE_NAME);
+        $route           = new Route(
+            path: '/',
+            name: self::ROUTE_NAME,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $collection      = new Collection();
         $responseFactory = new MessageResponseFactory();
         $url             = new Url(

--- a/tests/Unit/Http/Routing/Middleware/RequestStructMiddlewareTest.php
+++ b/tests/Unit/Http/Routing/Middleware/RequestStructMiddlewareTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Routing\Middleware;
 
 use JsonException;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Request\JsonServerRequest;
 use Valkyrja\Http\Message\Request\ServerRequest;
@@ -34,7 +35,11 @@ class RequestStructMiddlewareTest extends TestCase
     public function testRouteMatchedNoRequestStruct(): void
     {
         $request = new ServerRequest();
-        $route   = new Route(path: '/', name: 'route');
+        $route   = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $handler = new RouteMatchedHandler();
 
         $middleware = new RequestStructMiddleware();
@@ -61,7 +66,12 @@ class RequestStructMiddlewareTest extends TestCase
                 4 => 'test4',
             ]
         );
-        $route   = new Route(path: '/', name: 'route', requestStruct: IndexedJsonRequestStructEnum::class);
+        $route   = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            requestStruct: IndexedJsonRequestStructEnum::class
+        );
         $handler = new RouteMatchedHandler();
 
         $middleware = new RequestStructMiddleware();
@@ -88,7 +98,12 @@ class RequestStructMiddlewareTest extends TestCase
                 3 => 'test3',
             ]
         );
-        $route   = new Route(path: '/', name: 'route', requestStruct: IndexedJsonRequestStructEnum::class);
+        $route   = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            requestStruct: IndexedJsonRequestStructEnum::class
+        );
         $handler = new RouteMatchedHandler();
 
         $middleware = new RequestStructMiddleware();
@@ -115,7 +130,12 @@ class RequestStructMiddlewareTest extends TestCase
                 3 => 'test3',
             ]
         );
-        $route   = new Route(path: '/', name: 'route', requestStruct: IndexedJsonRequestStructEnum::class);
+        $route   = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            requestStruct: IndexedJsonRequestStructEnum::class
+        );
         $handler = new RouteMatchedHandler();
 
         $middleware = new RequestStructMiddleware();

--- a/tests/Unit/Http/Routing/Middleware/ResponseStructMiddlewareTest.php
+++ b/tests/Unit/Http/Routing/Middleware/ResponseStructMiddlewareTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Routing\Middleware;
 
 use JsonException;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Message\Request\ServerRequest;
 use Valkyrja\Http\Message\Response\JsonResponse;
 use Valkyrja\Http\Message\Response\Response;
@@ -34,7 +35,11 @@ class ResponseStructMiddlewareTest extends TestCase
     {
         $request  = new ServerRequest();
         $response = new JsonResponse();
-        $route    = new Route(path: '/', name: 'route');
+        $route    = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $handler  = new RouteDispatchedHandler();
 
         $middleware = new ResponseStructMiddleware();
@@ -53,7 +58,12 @@ class ResponseStructMiddlewareTest extends TestCase
     {
         $request  = new ServerRequest();
         $response = new Response();
-        $route    = new Route(path: '/', name: 'route', responseStruct: IndexedResponseStructEnum::class);
+        $route    = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            responseStruct: IndexedResponseStructEnum::class
+        );
         $handler  = new RouteDispatchedHandler();
 
         $middleware = new ResponseStructMiddleware();
@@ -75,7 +85,12 @@ class ResponseStructMiddlewareTest extends TestCase
     {
         $request  = new ServerRequest();
         $response = new JsonResponse(data: ['first' => 'test', 'second' => 'test2', 'third' => 'test3']);
-        $route    = new Route(path: '/', name: 'route', responseStruct: IndexedResponseStructEnum::class);
+        $route    = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+            responseStruct: IndexedResponseStructEnum::class
+        );
         $handler  = new RouteDispatchedHandler();
 
         $middleware = new ResponseStructMiddleware();

--- a/tests/Unit/Http/Routing/Processor/ProcessorTest.php
+++ b/tests/Unit/Http/Routing/Processor/ProcessorTest.php
@@ -38,7 +38,8 @@ class ProcessorTest extends TestCase
 
         $route = new Route(
             path: '/',
-            name: 'route'
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
 
         $routeAfterProcessing = $processor->route($route);
@@ -53,7 +54,8 @@ class ProcessorTest extends TestCase
 
         $route = new Route(
             path: 'some/path',
-            name: 'route'
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
 
         $routeAfterProcessing = $processor->route($route);
@@ -69,6 +71,7 @@ class ProcessorTest extends TestCase
         $route = new Route(
             path: '/{value}',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             parameters: [
                 new Parameter(
                     name: 'value',
@@ -93,6 +96,7 @@ class ProcessorTest extends TestCase
         $route = new Route(
             path: '/{val}',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             parameters: [
                 new Parameter(
                     name: 'value',
@@ -111,6 +115,7 @@ class ProcessorTest extends TestCase
         $route = new Route(
             path: '/{value}',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             regex: Regex::ALPHA,
             parameters: [
                 new Parameter(
@@ -135,6 +140,7 @@ class ProcessorTest extends TestCase
         $route = new Route(
             path: '/{optional?}',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             parameters: [
                 new Parameter(
                     name: 'optional',
@@ -158,6 +164,7 @@ class ProcessorTest extends TestCase
         $route = new Route(
             path: '/{noncapture}',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             parameters: [
                 new Parameter(
                     name: 'noncapture',

--- a/tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
@@ -17,6 +17,7 @@ use Valkyrja\Application\Config;
 use Valkyrja\Attribute\Contract\Attributes as AttributesContract;
 use Valkyrja\Container\Constant\ConfigValue;
 use Valkyrja\Dispatcher\Contract\Dispatcher;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Message\Factory\Contract\ResponseFactory as HttpMessageResponseFactory;
 use Valkyrja\Http\Message\Request\Contract\ServerRequest;
 use Valkyrja\Http\Middleware\Handler\Contract\RouteDispatchedHandler as RouteDispatchedHandlerContract;
@@ -161,7 +162,11 @@ class ServiceProviderTest extends ServiceProviderTestCase
 
         self::assertFalse($container->has(CollectionContract::class));
 
-        $route = new Data\Route(path: '/', name: 'route');
+        $route = new Data\Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $collector->method('getRoutes')->willReturn([$route]);
 
         ServiceProvider::publishCollection($container);

--- a/tests/Unit/Http/Routing/RouterTest.php
+++ b/tests/Unit/Http/Routing/RouterTest.php
@@ -88,7 +88,11 @@ class RouterTest extends TestCase
             method: RequestMethod::POST
         );
 
-        $route = new Route(path: '/', name: 'route');
+        $route = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $collection->add($route);
 
         $response = $router->dispatch(request: $request);
@@ -111,7 +115,11 @@ class RouterTest extends TestCase
             method: RequestMethod::POST
         );
 
-        $route = new Route(path: '/', name: 'route');
+        $route = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $collection->add($route);
 
         $router->dispatch(request: $request);
@@ -134,7 +142,11 @@ class RouterTest extends TestCase
             method: RequestMethod::GET
         );
 
-        $route = new Route(path: '/', name: 'route');
+        $route = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
         $collection->add($route);
 
         $router->dispatch(request: $request);
@@ -157,6 +169,7 @@ class RouterTest extends TestCase
         $route = new Route(
             path: '/',
             name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             routeMatchedMiddleware: [RouteMatchedMiddlewareChangedClass::class]
         );
         $collection->add($route);

--- a/tests/Unit/Http/Routing/Url/UrlTest.php
+++ b/tests/Unit/Http/Routing/Url/UrlTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Http\Routing\Url;
 
 use Override;
+use Valkyrja\Dispatcher\Data\MethodDispatch;
 use Valkyrja\Http\Routing\Collection\Collection;
 use Valkyrja\Http\Routing\Constant\Regex;
 use Valkyrja\Http\Routing\Data\Parameter;
@@ -41,11 +42,13 @@ class UrlTest extends TestCase
 
         $route      = new Route(
             path: '/',
-            name: self::ROUTE_NAME
+            name: self::ROUTE_NAME,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
         $route2     = new Route(
             path: '/{value}',
             name: self::ROUTE2_NAME,
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
             parameters: [
                 new Parameter(
                     name: 'value',


### PR DESCRIPTION
# Description

Update data route object to require dispatch, but allow attribute to not require.

The attribute data object cannot require it because if it did it would not throw an exception when creating the attribute instance due to missing required parameter. We auto fill the dispatch based on the method the route attribute is attached to.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->