### PR TITLE
[Cli] Require dispatch in cli route data object

### DIFF
--- a/src/Valkyrja/Cli/Routing/Attribute/Route.php
+++ b/src/Valkyrja/Cli/Routing/Attribute/Route.php
@@ -14,7 +14,15 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Routing\Attribute;
 
 use Attribute;
+use Valkyrja\Cli\Interaction\Message\Contract\Message;
+use Valkyrja\Cli\Middleware\Contract\CommandDispatchedMiddleware;
+use Valkyrja\Cli\Middleware\Contract\CommandMatchedMiddleware;
+use Valkyrja\Cli\Middleware\Contract\ExitedMiddleware;
+use Valkyrja\Cli\Middleware\Contract\ThrowableCaughtMiddleware;
+use Valkyrja\Cli\Routing\Data\Contract\Parameter;
 use Valkyrja\Cli\Routing\Data\Route as Model;
+use Valkyrja\Dispatcher\Data\Contract\MethodDispatch;
+use Valkyrja\Dispatcher\Data\MethodDispatch as DefaultDispatch;
 
 /**
  * Attribute Route.
@@ -24,4 +32,37 @@ use Valkyrja\Cli\Routing\Data\Route as Model;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class Route extends Model
 {
+    /**
+     * @param non-empty-string                            $name                        The name
+     * @param non-empty-string                            $description                 The description
+     * @param Message                                     $helpText                    The help text
+     * @param class-string<CommandMatchedMiddleware>[]    $commandMatchedMiddleware    The command matched middleware
+     * @param class-string<CommandDispatchedMiddleware>[] $commandDispatchedMiddleware The command dispatched middleware
+     * @param class-string<ThrowableCaughtMiddleware>[]   $throwableCaughtMiddleware   The throwable caught middleware
+     * @param class-string<ExitedMiddleware>[]            $exitedMiddleware            The exited middleware
+     * @param Parameter[]                                 $parameters                  The parameters
+     */
+    public function __construct(
+        protected string $name,
+        protected string $description,
+        protected Message $helpText,
+        protected MethodDispatch $dispatch = new DefaultDispatch(self::class, '__construct'),
+        protected array $commandMatchedMiddleware = [],
+        protected array $commandDispatchedMiddleware = [],
+        protected array $throwableCaughtMiddleware = [],
+        protected array $exitedMiddleware = [],
+        array $parameters = [],
+    ) {
+        parent::__construct(
+            name: $name,
+            description: $description,
+            helpText: $helpText,
+            dispatch: $dispatch,
+            commandMatchedMiddleware: $commandMatchedMiddleware,
+            commandDispatchedMiddleware: $commandDispatchedMiddleware,
+            throwableCaughtMiddleware: $throwableCaughtMiddleware,
+            exitedMiddleware: $exitedMiddleware,
+            parameters: $parameters,
+        );
+    }
 }

--- a/src/Valkyrja/Cli/Routing/Data/Route.php
+++ b/src/Valkyrja/Cli/Routing/Data/Route.php
@@ -24,7 +24,6 @@ use Valkyrja\Cli\Routing\Data\Contract\OptionParameter;
 use Valkyrja\Cli\Routing\Data\Contract\Parameter;
 use Valkyrja\Cli\Routing\Data\Contract\Route as Contract;
 use Valkyrja\Dispatcher\Data\Contract\MethodDispatch;
-use Valkyrja\Dispatcher\Data\MethodDispatch as DefaultDispatch;
 
 /**
  * Class Route.
@@ -53,7 +52,7 @@ class Route implements Contract
         protected string $name,
         protected string $description,
         protected Message $helpText,
-        protected MethodDispatch $dispatch = new DefaultDispatch(self::class, '__construct'),
+        protected MethodDispatch $dispatch,
         protected array $commandMatchedMiddleware = [],
         protected array $commandDispatchedMiddleware = [],
         protected array $throwableCaughtMiddleware = [],

--- a/tests/Unit/Cli/Middleware/Handler/HandlerTestCase.php
+++ b/tests/Unit/Cli/Middleware/Handler/HandlerTestCase.php
@@ -18,6 +18,7 @@ use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Output\Output;
 use Valkyrja\Cli\Routing\Data\Route;
 use Valkyrja\Container\Container;
+use Valkyrja\Dispatcher\Data\MethodDispatch as DefaultDispatch;
 use Valkyrja\Tests\Unit\TestCase;
 
 /**
@@ -46,6 +47,11 @@ class HandlerTestCase extends TestCase
 
         $this->input   = new Input();
         $this->output  = new Output();
-        $this->command = new Route(name: 'test', description: 'Test Command', helpText: new Message('text'));
+        $this->command = new Route(
+            name: 'test',
+            description: 'Test Command',
+            helpText: new Message('text'),
+            dispatch: new DefaultDispatch(self::class, 'dispatch')
+        );
     }
 }

--- a/tests/Unit/Cli/Routing/Data/CommandTest.php
+++ b/tests/Unit/Cli/Routing/Data/CommandTest.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Tests\Unit\Cli\Routing\Data;
 
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Routing\Data\Route;
+use Valkyrja\Dispatcher\Data\MethodDispatch as DefaultDispatch;
 use Valkyrja\Tests\Unit\TestCase;
 
 /**
@@ -29,7 +30,8 @@ class CommandTest extends TestCase
         $command = new Route(
             name: 'test-command',
             description: 'Test Command',
-            helpText: new Message('Help text')
+            helpText: new Message('Help text'),
+            dispatch: new DefaultDispatch(self::class, 'dispatch')
         );
 
         self::assertSame('test-command', $command->getName());

--- a/tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
@@ -32,6 +32,7 @@ use Valkyrja\Cli\Routing\Data;
 use Valkyrja\Cli\Routing\Provider\ServiceProvider;
 use Valkyrja\Cli\Routing\Router;
 use Valkyrja\Dispatcher\Contract\Dispatcher;
+use Valkyrja\Dispatcher\Data\MethodDispatch as DefaultDispatch;
 use Valkyrja\Reflection\Contract\Reflection;
 use Valkyrja\Tests\Unit\Container\Provider\ServiceProviderTestCase;
 
@@ -94,7 +95,12 @@ class ServiceProviderTest extends ServiceProviderTestCase
         $this->container->setSingleton(Config::class, new Config());
         $this->container->setSingleton(Collector::class, $collector = self::createStub(Collector::class));
 
-        $command = new Data\Route(name: 'test', description: 'test', helpText: new Message('test'));
+        $command = new Data\Route(
+            name: 'test',
+            description: 'test',
+            helpText: new Message('test'),
+            dispatch: new DefaultDispatch(self::class, 'dispatch')
+        );
         $collector->method('getCommands')->willReturn([$command]);
 
         ServiceProvider::publishCollection($this->container);


### PR DESCRIPTION
# Description

Update data route object to require dispatch, but allow attribute to not require.

The attribute data object cannot require it because if it did it would not throw an exception when creating the attribute instance due to missing required parameter. We auto fill the dispatch based on the method the route attribute is attached to.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->