### PR TITLE
[Type] Explicitly casting to an int before sprintf format to avoid warning

### DIFF
--- a/src/Valkyrja/Type/Uuid/Support/UuidV1.php
+++ b/src/Valkyrja/Type/Uuid/Support/UuidV1.php
@@ -79,7 +79,7 @@ class UuidV1 extends Uuid
             }
 
             if (is_numeric($node)) {
-                $node = sprintf('%012x', $node);
+                $node = sprintf('%012x', (int) $node);
             }
 
             $len = strlen($node);


### PR DESCRIPTION
# Description

```
/src/Valkyrja/Type/Uuid/Support/UuidV1.php:82
The float-string "24320e2239321" is not representable as an int, cast occurred
```

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->