### PR TITLE
[Reflection] Move ReflectionProperty to Attribute component

### DIFF
--- a/src/Valkyrja/Attribute/Trait/ReflectionAwareAttributeTrait.php
+++ b/src/Valkyrja/Attribute/Trait/ReflectionAwareAttributeTrait.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Reflection\Trait;
+namespace Valkyrja\Attribute\Trait;
 
 use Reflector;
 
 /**
- * Trait ReflectionProperty.
+ * Trait ReflectionAwareAttributeTrait.
  *
  * @author Melech Mizrachi
  */
-trait ReflectionProperty
+trait ReflectionAwareAttributeTrait
 {
     protected Reflector|null $reflection = null;
 

--- a/tests/Classes/Attribute/AttributeClass.php
+++ b/tests/Classes/Attribute/AttributeClass.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Classes\Attribute;
 
 use Attribute;
-use Valkyrja\Reflection\Trait\ReflectionProperty;
+use Valkyrja\Attribute\Trait\ReflectionAwareAttributeTrait;
 
 /**
  * Attribute class used for unit testing.
@@ -24,7 +24,7 @@ use Valkyrja\Reflection\Trait\ReflectionProperty;
 #[Attribute(Attribute::TARGET_ALL | Attribute::IS_REPEATABLE)]
 class AttributeClass
 {
-    use ReflectionProperty;
+    use ReflectionAwareAttributeTrait;
 
     public function __construct(
         public int $counter


### PR DESCRIPTION
# Description

Move ReflectionProperty to Attribute component and change name to make more sense.

This class was only used in the Attribute Collector anyway. It made no sense to be in the Reflection component.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->