### PR TITLE
[CI] Fix the composer outdated dependencies check on release

### DIFF
--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -154,7 +154,18 @@ jobs:
           COMPOSER_NAME: ${{ matrix.paths.name }}
           COMPOSER_COMMAND: ${{ matrix.paths.command }}
         run: |
-          composer "$COMPOSER_COMMAND"
+          output=$(composer "$COMPOSER_COMMAND" 2>&1)
+          if [[ "$output" == *"All your direct dependencies are up to date"* ]]; then
+            echo "$output"
+            echo "Proceeding..."
+
+            exit 0
+          else
+            echo "Composer dependencies must be updated before releasing. People rely on us to be on latest"
+            echo "$output"
+
+            exit 1
+          fi
 
   release:
     needs: [ check-composer, check-version ]


### PR DESCRIPTION
# Description

Fix the composer outdated dependencies check on release.

- Fix composer validation check in release
    - Doesn't flag on outdated because the command itself always exits 0
    - check the output of the command for :
        - `All your direct dependencies are up to date`

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->