### PR TITLE
[Application] Deprecate and remove Application setup method

### DIFF
--- a/src/Valkyrja/Application/Kernel/Contract/ApplicationContract.php
+++ b/src/Valkyrja/Application/Kernel/Contract/ApplicationContract.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Application\Kernel\Contract;
 
-use Valkyrja\Application\Data\Config;
-use Valkyrja\Application\Data\Data;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Provider\Provider;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -48,11 +46,6 @@ interface ApplicationContract
            \_/ \__,_|_|_|\_\\__, |_| _/ |\__,_|
                             |___/   |__/
         TEXT;
-
-    /**
-     * Setup the application.
-     */
-    public function setup(ContainerContract $container, Env $env, Config|Data $configData = new Config(), bool $force = false): void;
 
     /**
      * Add a component to the application.

--- a/src/Valkyrja/Application/Kernel/Valkyrja.php
+++ b/src/Valkyrja/Application/Kernel/Valkyrja.php
@@ -48,34 +48,8 @@ class Valkyrja implements ApplicationContract
      */
     protected ContainerContract $container;
 
-    /**
-     * Whether the application was setup.
-     */
-    protected bool $setup = false;
-
     public function __construct(ContainerContract $container, Env $env, Config|Data $configData = new Config())
     {
-        $this->setup(
-            container: $container,
-            env: $env,
-            configData: $configData
-        );
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function setup(ContainerContract $container, Env $env, Config|Data $configData = new Config(), bool $force = false): void
-    {
-        // If the application was already setup, no need to do it again
-        if ($this->setup && ! $force) {
-            return;
-        }
-
-        // Avoid re-setting up the app later
-        $this->setup = true;
-
         $this->setEnv(env: $env);
         $this->setContainer($container);
 

--- a/tests/Unit/Application/Kernel/ApplicationTest.php
+++ b/tests/Unit/Application/Kernel/ApplicationTest.php
@@ -106,43 +106,6 @@ class ApplicationTest extends TestCase
         self::assertSame($env, $container->getSingleton(Env::class));
         self::assertSame($config, $container->getSingleton(Config::class));
         self::assertSame($env::APP_TIMEZONE, date_default_timezone_get());
-
-        $env2       = new Env();
-        $config2    = new Config();
-        $container2 = new Container();
-
-        $application->setup(
-            container: $container2,
-            env: $env2,
-            configData: $config2
-        );
-
-        // Ensure setup isn't run twice
-        self::assertSame($container, $application->getContainer());
-        self::assertNotSame($container2, $application->getContainer());
-        self::assertTrue($container->has(Config::class));
-        self::assertSame($env, $application->getEnv());
-        self::assertSame($env, $container->getSingleton(Env::class));
-        self::assertSame($config, $container->getSingleton(Config::class));
-
-        $env3       = new Env();
-        $config3    = new Config();
-        $container3 = new Container();
-
-        $application->setup(
-            container: $container3,
-            env: $env3,
-            configData: $config3,
-            force: true,
-        );
-
-        // Ensure setup is run, and config and env are overridden when setup is forced
-        self::assertNotSame($container, $application->getContainer());
-        self::assertSame($container3, $application->getContainer());
-        self::assertTrue($container3->has(Config::class));
-        self::assertSame($env3, $application->getEnv());
-        self::assertSame($env3, $container3->getSingleton(Env::class));
-        self::assertSame($config3, $container3->getSingleton(Config::class));
     }
 
     /**
@@ -173,57 +136,6 @@ class ApplicationTest extends TestCase
         self::assertSame($data->cli, $container->getSingleton(CliData::class));
         self::assertSame($data->http, $container->getSingleton(HttpData::class));
         self::assertSame($env::APP_TIMEZONE, date_default_timezone_get());
-
-        $env2       = new Env();
-        $data2      = new Data();
-        $container2 = new Container();
-
-        $application->setup(
-            container: $container2,
-            env: $env2,
-            configData: $data2
-        );
-
-        // Ensure setup isn't run twice
-        self::assertSame($container, $application->getContainer());
-        self::assertNotSame($container2, $application->getContainer());
-        self::assertNotTrue($container2->has(Config::class));
-        self::assertTrue($container->has(ContainerData::class));
-        self::assertTrue($container->has(EventData::class));
-        self::assertTrue($container->has(CliData::class));
-        self::assertTrue($container->has(HttpData::class));
-        self::assertSame($env, $application->getEnv());
-        self::assertSame($env, $container->getSingleton(Env::class));
-        self::assertSame($data->container, $container->getSingleton(ContainerData::class));
-        self::assertSame($data->event, $container->getSingleton(EventData::class));
-        self::assertSame($data->cli, $container->getSingleton(CliData::class));
-        self::assertSame($data->http, $container->getSingleton(HttpData::class));
-
-        $env3       = new Env();
-        $data3      = new Data();
-        $container3 = new Container();
-
-        $application->setup(
-            container: $container3,
-            env: $env3,
-            configData: $data3,
-            force: true,
-        );
-
-        // Ensure setup is run, and data and env are overridden when setup is forced
-        self::assertNotSame($container, $application->getContainer());
-        self::assertSame($container3, $application->getContainer());
-        self::assertNotTrue($container3->has(Config::class));
-        self::assertTrue($container3->has(ContainerData::class));
-        self::assertTrue($container3->has(EventData::class));
-        self::assertTrue($container3->has(CliData::class));
-        self::assertTrue($container3->has(HttpData::class));
-        self::assertSame($env3, $application->getEnv());
-        self::assertSame($env3, $container3->getSingleton(Env::class));
-        self::assertSame($data3->container, $container3->getSingleton(ContainerData::class));
-        self::assertSame($data3->event, $container3->getSingleton(EventData::class));
-        self::assertSame($data3->cli, $container3->getSingleton(CliData::class));
-        self::assertSame($data3->http, $container3->getSingleton(HttpData::class));
     }
 
     /**


### PR DESCRIPTION
# Description

Deprecate and remove `Application->setup()` method.

This had served a purpose in the past, but it is a remnant of old code and no longer serves a purpose.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->