### PR TITLE
[Type] Rename Enum classes as enum is a reserved keyword

### DIFF
--- a/src/Valkyrja/Type/BuiltIn/Enum/Support/Enumerable.php
+++ b/src/Valkyrja/Type/BuiltIn/Enum/Support/Enumerable.php
@@ -19,7 +19,7 @@ use UnitEnum;
 use function assert;
 use function in_array;
 
-class Enum
+class Enumerable
 {
     /**
      * A cache of enum class names and their names, or values.

--- a/src/Valkyrja/Type/BuiltIn/Enum/Trait/Arrayable.php
+++ b/src/Valkyrja/Type/BuiltIn/Enum/Trait/Arrayable.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Type\BuiltIn\Enum\Trait;
 
-use Valkyrja\Type\BuiltIn\Enum\Support\Enum;
+use Valkyrja\Type\BuiltIn\Enum\Support\Enumerable;
 
 trait Arrayable
 {
@@ -24,7 +24,7 @@ trait Arrayable
      */
     public static function names(): array
     {
-        return Enum::names(static::class);
+        return Enumerable::names(static::class);
     }
 
     /**
@@ -34,7 +34,7 @@ trait Arrayable
      */
     public static function values(): array
     {
-        return Enum::values(static::class);
+        return Enumerable::values(static::class);
     }
 
     /**
@@ -44,7 +44,7 @@ trait Arrayable
      */
     public static function asArray(): array
     {
-        return Enum::asArray(static::class);
+        return Enumerable::asArray(static::class);
     }
 
     /**
@@ -54,6 +54,6 @@ trait Arrayable
      */
     public static function asReverseArray(): array
     {
-        return Enum::asReverseArray(static::class);
+        return Enumerable::asReverseArray(static::class);
     }
 }

--- a/src/Valkyrja/Type/BuiltIn/Enum/Trait/Enumerable.php
+++ b/src/Valkyrja/Type/BuiltIn/Enum/Trait/Enumerable.php
@@ -21,7 +21,7 @@ use Valkyrja\Type\Throwable\Exception\RuntimeException;
 use function is_int;
 use function is_string;
 
-trait Enum
+trait Enumerable
 {
     /**
      * Get a new Type given a value.

--- a/tests/Classes/Enum/EnumClass.php
+++ b/tests/Classes/Enum/EnumClass.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Classes\Enum;
 
 use Valkyrja\Type\BuiltIn\Enum\Contract\EnumContract as Contract;
-use Valkyrja\Type\BuiltIn\Enum\Trait\Enum as EnumTrait;
+use Valkyrja\Type\BuiltIn\Enum\Trait\Enumerable;
 
 /**
  * Enum class to use to test enums.
  */
-enum Enum implements Contract
+enum EnumClass implements Contract
 {
-    use EnumTrait;
+    use Enumerable;
 
     case spade;
     case heart;

--- a/tests/Classes/Enum/IntEnum.php
+++ b/tests/Classes/Enum/IntEnum.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Classes\Enum;
 
 use Valkyrja\Type\BuiltIn\Enum\Contract\EnumContract as Contract;
-use Valkyrja\Type\BuiltIn\Enum\Trait\Enum;
+use Valkyrja\Type\BuiltIn\Enum\Trait\Enumerable;
 
 /**
  * Model class to use to test int BackedEnum.
  */
 enum IntEnum: int implements Contract
 {
-    use Enum;
+    use Enumerable;
 
     case first  = 1;
     case second = 2;

--- a/tests/Classes/Enum/StringEnum.php
+++ b/tests/Classes/Enum/StringEnum.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Classes\Enum;
 
 use Valkyrja\Type\BuiltIn\Enum\Contract\EnumContract as Contract;
-use Valkyrja\Type\BuiltIn\Enum\Trait\Enum;
+use Valkyrja\Type\BuiltIn\Enum\Trait\Enumerable;
 
 /**
  * Model class to use to test string BackedEnum.
  */
 enum StringEnum: string implements Contract
 {
-    use Enum;
+    use Enumerable;
 
     case foo = 'bar';
 }

--- a/tests/Classes/Model/CastableModelClass.php
+++ b/tests/Classes/Model/CastableModelClass.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Classes\Model;
 
-use Valkyrja\Tests\Classes\Enum\Enum;
+use Valkyrja\Tests\Classes\Enum\EnumClass;
 use Valkyrja\Tests\Classes\Enum\IntEnum;
 use Valkyrja\Tests\Classes\Enum\StringEnum;
 use Valkyrja\Type\Data\ArrayCast;
@@ -122,8 +122,8 @@ class CastableModelClass extends AbstractModel
     /** @var ModelClass[] */
     public array $modelArray;
 
-    public Enum $enum;
-    /** @var Enum[] */
+    public EnumClass $enum;
+    /** @var EnumClass[] */
     public array $enumArray;
 
     public StringEnum $stringEnum;
@@ -170,8 +170,8 @@ class CastableModelClass extends AbstractModel
             self::NULL_ARRAY_PROPERTY              => new ArrayCast(CastType::null),
             self::MODEL_PROPERTY                   => new OriginalCast(ModelClass::class),
             self::MODEL_ARRAY_PROPERTY             => new OriginalArrayCast(ModelClass::class),
-            self::ENUM_PROPERTY                    => new OriginalCast(Enum::class),
-            self::ENUM_ARRAY_PROPERTY              => new OriginalArrayCast(Enum::class),
+            self::ENUM_PROPERTY                    => new OriginalCast(EnumClass::class),
+            self::ENUM_ARRAY_PROPERTY              => new OriginalArrayCast(EnumClass::class),
             self::STRING_ENUM_PROPERTY             => new OriginalCast(StringEnum::class),
             self::STRING_ENUM_ARRAY_PROPERTY       => new OriginalArrayCast(StringEnum::class),
             self::INT_ENUM_PROPERTY                => new OriginalCast(IntEnum::class),

--- a/tests/Unit/Http/Message/Enum/StatusCodeTest.php
+++ b/tests/Unit/Http/Message/Enum/StatusCodeTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Valkyrja\Http\Message\Constant\StatusText;
 use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Tests\Unit\TestCase;
-use Valkyrja\Type\BuiltIn\Enum\Support\Enum;
+use Valkyrja\Type\BuiltIn\Enum\Support\Enumerable;
 
 use function constant;
 
@@ -30,7 +30,7 @@ class StatusCodeTest extends TestCase
     {
         $codes = [];
 
-        foreach (Enum::values(StatusCode::class) as $code) {
+        foreach (Enumerable::values(StatusCode::class) as $code) {
             $codes[] = [$code];
         }
 

--- a/tests/Unit/Type/BuiltIn/Enum/EnumTest.php
+++ b/tests/Unit/Type/BuiltIn/Enum/EnumTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Type\BuiltIn\Enum;
 
 use JsonException;
-use Valkyrja\Tests\Classes\Enum\Enum as EnumClass;
+use Valkyrja\Tests\Classes\Enum\EnumClass;
 use Valkyrja\Tests\Classes\Enum\IntEnum;
 use Valkyrja\Tests\Classes\Enum\StringEnum;
 use Valkyrja\Tests\Unit\TestCase;

--- a/tests/Unit/Type/BuiltIn/Enum/Support/EnumTest.php
+++ b/tests/Unit/Type/BuiltIn/Enum/Support/EnumTest.php
@@ -16,9 +16,9 @@ namespace Valkyrja\Tests\Unit\Type\BuiltIn\Enum\Support;
 use Valkyrja\Tests\Classes\Enum\ArrayableEnum;
 use Valkyrja\Tests\Classes\Enum\ArrayableIntEnum;
 use Valkyrja\Tests\Classes\Enum\ArrayableStringEnum;
-use Valkyrja\Tests\Classes\Enum\Enum as TestEnum;
+use Valkyrja\Tests\Classes\Enum\EnumClass as TestEnum;
 use Valkyrja\Tests\Unit\TestCase;
-use Valkyrja\Type\BuiltIn\Enum\Support\Enum;
+use Valkyrja\Type\BuiltIn\Enum\Support\Enumerable;
 
 class EnumTest extends TestCase
 {
@@ -28,17 +28,17 @@ class EnumTest extends TestCase
     {
         self::assertSame(
             ['spade', 'heart', 'diamond', 'club'],
-            Enum::names(ArrayableEnum::class)
+            Enumerable::names(ArrayableEnum::class)
         );
 
         self::assertSame(
             ['foo', 'lorem'],
-            Enum::names(ArrayableStringEnum::class)
+            Enumerable::names(ArrayableStringEnum::class)
         );
 
         self::assertSame(
             ['first', 'second'],
-            Enum::names(ArrayableIntEnum::class)
+            Enumerable::names(ArrayableIntEnum::class)
         );
     }
 
@@ -46,17 +46,17 @@ class EnumTest extends TestCase
     {
         self::assertSame(
             ['spade', 'heart', 'diamond', 'club'],
-            Enum::values(ArrayableEnum::class)
+            Enumerable::values(ArrayableEnum::class)
         );
 
         self::assertSame(
             ['bar', 'ipsum'],
-            Enum::values(ArrayableStringEnum::class)
+            Enumerable::values(ArrayableStringEnum::class)
         );
 
         self::assertSame(
             [1, 2],
-            Enum::values(ArrayableIntEnum::class)
+            Enumerable::values(ArrayableIntEnum::class)
         );
     }
 
@@ -64,17 +64,17 @@ class EnumTest extends TestCase
     {
         self::assertSame(
             ['spade' => 'spade', 'heart' => 'heart', 'diamond' => 'diamond', 'club' => 'club'],
-            Enum::asArray(ArrayableEnum::class)
+            Enumerable::asArray(ArrayableEnum::class)
         );
 
         self::assertSame(
             ['foo' => 'bar', 'lorem' => 'ipsum'],
-            Enum::asArray(ArrayableStringEnum::class)
+            Enumerable::asArray(ArrayableStringEnum::class)
         );
 
         self::assertSame(
             ['first' => 1, 'second' => 2],
-            Enum::asArray(ArrayableIntEnum::class)
+            Enumerable::asArray(ArrayableIntEnum::class)
         );
     }
 
@@ -82,38 +82,38 @@ class EnumTest extends TestCase
     {
         self::assertSame(
             ['spade' => 'spade', 'heart' => 'heart', 'diamond' => 'diamond', 'club' => 'club'],
-            Enum::asReverseArray(ArrayableEnum::class)
+            Enumerable::asReverseArray(ArrayableEnum::class)
         );
 
         self::assertSame(
             ['bar' => 'foo', 'ipsum' => 'lorem'],
-            Enum::asReverseArray(ArrayableStringEnum::class)
+            Enumerable::asReverseArray(ArrayableStringEnum::class)
         );
 
         self::assertSame(
             [1 => 'first', 2 => 'second'],
-            Enum::asReverseArray(ArrayableIntEnum::class)
+            Enumerable::asReverseArray(ArrayableIntEnum::class)
         );
     }
 
     public function testIsValidName(): void
     {
-        self::assertTrue(Enum::isValidName(ArrayableEnum::class, 'spade'));
-        self::assertFalse(Enum::isValidName(ArrayableEnum::class, 'card'));
+        self::assertTrue(Enumerable::isValidName(ArrayableEnum::class, 'spade'));
+        self::assertFalse(Enumerable::isValidName(ArrayableEnum::class, 'card'));
 
-        self::assertTrue(Enum::isValidName(ArrayableStringEnum::class, 'foo'));
-        self::assertFalse(Enum::isValidName(ArrayableStringEnum::class, 'too'));
+        self::assertTrue(Enumerable::isValidName(ArrayableStringEnum::class, 'foo'));
+        self::assertFalse(Enumerable::isValidName(ArrayableStringEnum::class, 'too'));
 
-        self::assertTrue(Enum::isValidName(ArrayableIntEnum::class, 'second'));
-        self::assertFalse(Enum::isValidName(ArrayableIntEnum::class, 'third'));
+        self::assertTrue(Enumerable::isValidName(ArrayableIntEnum::class, 'second'));
+        self::assertFalse(Enumerable::isValidName(ArrayableIntEnum::class, 'third'));
     }
 
     public function testIsValidValue(): void
     {
-        self::assertTrue(Enum::isValidValue(ArrayableStringEnum::class, 'bar'));
-        self::assertFalse(Enum::isValidValue(ArrayableStringEnum::class, 'too'));
+        self::assertTrue(Enumerable::isValidValue(ArrayableStringEnum::class, 'bar'));
+        self::assertFalse(Enumerable::isValidValue(ArrayableStringEnum::class, 'too'));
 
-        self::assertTrue(Enum::isValidValue(ArrayableIntEnum::class, 2));
-        self::assertFalse(Enum::isValidValue(ArrayableIntEnum::class, 3));
+        self::assertTrue(Enumerable::isValidValue(ArrayableIntEnum::class, 2));
+        self::assertFalse(Enumerable::isValidValue(ArrayableIntEnum::class, 3));
     }
 }

--- a/tests/Unit/Type/BuiltIn/Support/ArrayOfTest.php
+++ b/tests/Unit/Type/BuiltIn/Support/ArrayOfTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Type\BuiltIn\Support;
 
 use Throwable;
-use Valkyrja\Tests\Classes\Enum\Enum;
+use Valkyrja\Tests\Classes\Enum\EnumClass;
 use Valkyrja\Tests\Classes\Enum\IntEnum;
 use Valkyrja\Tests\Classes\Enum\StringEnum;
 use Valkyrja\Tests\Unit\TestCase;
@@ -309,9 +309,9 @@ class ArrayOfTest extends TestCase
     protected function getArrayOfEnums(): array
     {
         return [
-            Enum::heart,
-            Enum::club,
-            Enum::diamond,
+            EnumClass::heart,
+            EnumClass::club,
+            EnumClass::diamond,
         ];
     }
 

--- a/tests/Unit/Type/Model/CastableModelTest.php
+++ b/tests/Unit/Type/Model/CastableModelTest.php
@@ -15,7 +15,7 @@ namespace Valkyrja\Tests\Unit\Type\Model;
 
 use JsonException;
 use RuntimeException;
-use Valkyrja\Tests\Classes\Enum\Enum;
+use Valkyrja\Tests\Classes\Enum\EnumClass;
 use Valkyrja\Tests\Classes\Enum\IntEnum;
 use Valkyrja\Tests\Classes\Enum\StringEnum;
 use Valkyrja\Tests\Classes\Model\CastableModelClass;
@@ -533,7 +533,7 @@ class CastableModelTest extends TestCase
      */
     public function testEnumCast(): void
     {
-        $value   = Enum::club;
+        $value   = EnumClass::club;
         $decoded = json_decode(json_encode($value, JSON_THROW_ON_ERROR), false, 512, JSON_THROW_ON_ERROR);
 
         // Test an Enum


### PR DESCRIPTION
# Description

Rename Enum classes as enum is a reserved keyword.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->