### PR TITLE
[CI] Add methods to override php_unit_test_case_static_method_calls

### DIFF
--- a/.github/ci/phpcsfixer/.php_cs.dist.php
+++ b/.github/ci/phpcsfixer/.php_cs.dist.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
  */
 
 $header = <<<EOF
-This file is part of the Valkyrja Framework package.
+    This file is part of the Valkyrja Framework package.
 
-(c) Melech Mizrachi <melechmizrachi@gmail.com>
+    (c) Melech Mizrachi <melechmizrachi@gmail.com>
 
-For the full copyright and license information, please view the LICENSE
-file that was distributed with this source code.
-EOF;
+    For the full copyright and license information, please view the LICENSE
+    file that was distributed with this source code.
+    EOF;
 
 $finder = PhpCsFixer\Finder::create()
                            ->exclude('.github')
@@ -201,7 +201,11 @@ return new PhpCsFixer\Config()
             ],
             'php_unit_test_case_static_method_calls'   => [
                 'call_type' => 'self',
-                'methods'   => [],
+                'methods'   => [
+                    'any'     => 'this',
+                    'equalTo' => 'this',
+                    'once'    => 'this',
+                ],
             ],
             'yoda_style'                               => [
                 'equal'            => false,

--- a/tests/Unit/Http/Client/Manager/GuzzleClientTest.php
+++ b/tests/Unit/Http/Client/Manager/GuzzleClientTest.php
@@ -73,11 +73,11 @@ class GuzzleClientTest extends TestCase
         //     'form_params' => $parsedBody,
         // ];
 
-        $psr7Response->expects(self::once())->method('getHeaders')->willReturn($headers);
-        $psr7Response->expects(self::once())->method('getStatusCode')->willReturn(200);
-        $psr7Response->expects(self::once())->method('getBody')->willReturn($psr7Body);
-        $psr7Body->expects(self::once())->method('getContents')->willReturn($contents);
-        $guzzle->expects(self::once())
+        $psr7Response->expects($this->once())->method('getHeaders')->willReturn($headers);
+        $psr7Response->expects($this->once())->method('getStatusCode')->willReturn(200);
+        $psr7Response->expects($this->once())->method('getBody')->willReturn($psr7Body);
+        $psr7Body->expects($this->once())->method('getContents')->willReturn($contents);
+        $guzzle->expects($this->once())
                ->method('request')
                ->with(
                    'GET',

--- a/tests/Unit/Http/Client/Manager/LogClientTest.php
+++ b/tests/Unit/Http/Client/Manager/LogClientTest.php
@@ -37,7 +37,7 @@ class LogClientTest extends TestCase
         $client  = new LogClient($logger);
         $request = new Request();
 
-        $logger->expects(self::once())->method('info');
+        $logger->expects($this->once())->method('info');
 
         $response = $client->sendRequest($request);
 


### PR DESCRIPTION
# Description

Add methods to override php_unit_test_case_static_method_calls phpcsfixer rule.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->