### PR TITLE
[CI] Fix the rector RemoveNonConflictingAliasInUseStatementRector rule

### DIFF
--- a/.github/ci/rector/Rector/CodingStyle/Rector/Stmt/RemoveNonConflictingAliasInUseStatementRector.php
+++ b/.github/ci/rector/Rector/CodingStyle/Rector/Stmt/RemoveNonConflictingAliasInUseStatementRector.php
@@ -126,14 +126,15 @@ final class RemoveNonConflictingAliasInUseStatementRector extends AbstractRector
                 $use          = $compareStmt->uses[0]->name->toString();
                 $lastName     = Strings::after($use, '\\', -1) ?? $use;
                 $useAliasName = $stmt->uses[0]->alias instanceof Identifier ? $stmt->uses[0]->alias->toString() : null;
+                $useHasAlias  = $useAliasName !== null;
 
                 if (
                     // Ensure the alias is not the same as the class name of another use statement
                     strtolower($lastName) === strtolower($aliasName)
-                    // Ensure the alias's class name is not the same as the class name of another use statement
-                    || strtolower($lastName) === strtolower($aliasUseLastName)
-                    // Ensure the alias is not the same as the alias of another use statement
-                    || strtolower($useAliasName) === strtolower($aliasName)
+                    // Ensure the alias's class name is not the same as the class name of another use statement that has no alias
+                    || (! $useHasAlias && strtolower($lastName) === strtolower($aliasUseLastName))
+                    // Ensure the alias is not the same as the alias of another use statement that has an alias
+                    || ($useHasAlias && strtolower($useAliasName) === strtolower($aliasName))
                 ) {
                     // If it matched then this alias is required and we should move onto the next alias
                     continue 2;


### PR DESCRIPTION
# Description

Fix the rector RemoveNonConflictingAliasInUseStatementRector rule for when a use statement has an alias but the alias being checked conflicts with the use statement class name but not the alias.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->