### PR TITLE
[CI] Update the CI workflows to get the latest ref version of the ci dir

### DIFF
--- a/.github/ci/phpcsfixer/.php_cs.dist.php
+++ b/.github/ci/phpcsfixer/.php_cs.dist.php
@@ -202,9 +202,10 @@ return new PhpCsFixer\Config()
             'php_unit_test_case_static_method_calls'   => [
                 'call_type' => 'self',
                 'methods'   => [
-                    'any'   => 'this',
-                    'once'  => 'this',
-                    'never' => 'this',
+                    'any'     => 'this',
+                    'equalTo' => 'this',
+                    'once'    => 'this',
+                    'never'   => 'this',
                 ],
             ],
             'yoda_style'                               => [

--- a/.github/ci/phpcsfixer/.php_cs.dist.php
+++ b/.github/ci/phpcsfixer/.php_cs.dist.php
@@ -202,10 +202,9 @@ return new PhpCsFixer\Config()
             'php_unit_test_case_static_method_calls'   => [
                 'call_type' => 'self',
                 'methods'   => [
-                    'any'     => 'this',
-                    'equalTo' => 'this',
-                    'once'    => 'this',
-                    'never'   => 'this',
+                    'any'   => 'this',
+                    'once'  => 'this',
+                    'never' => 'this',
                 ],
             ],
             'yoda_style'                               => [

--- a/.github/workflows/phparkitect.yml
+++ b/.github/workflows/phparkitect.yml
@@ -32,6 +32,9 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/phparkitect/**'
+              - '.github/workflows/phparkitect.yml'
             files:
               - '.github/ci/phparkitect/**'
               - '.github/workflows/phparkitect.yml'
@@ -40,6 +43,15 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/phparkitect
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -32,6 +32,9 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/phpcodesniffer/**'
+              - '.github/workflows/phpcodesniffer.yml'
             files:
               - '.github/ci/phpcodesniffer/**'
               - '.github/workflows/phpcodesniffer.yml'
@@ -40,6 +43,15 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/phpcodesniffer
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Get latest CI code from target
         if: steps.changes.outputs.ci == 'true'
         env:
-          REF: github.base_ref
+          REF: ${{ github.base_ref }}
         run: |
           echo "github.base_ref: $REF"
 

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -32,6 +32,9 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/phpcsfixer/**'
+              - '.github/workflows/phpcsfixer.yml'
             files:
               - '.github/ci/phpcsfixer/**'
               - '.github/workflows/phpcsfixer.yml'
@@ -40,6 +43,13 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci == 'true'
+        env:
+          REF: github.base_ref
+        run: |
+          echo "github.base_ref: $REF"
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -45,7 +45,7 @@ jobs:
               - 'composer.json'
 
       - name: Get latest CI code from target
-        if: steps.changes.outputs.ci == 'true' && github.base_ref
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
         env:
           REF: ${{ github.base_ref }}
         run: |

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -50,6 +50,7 @@ jobs:
           REF: ${{ github.base_ref }}
         run: |
           echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
           git checkout origin/"$REF" -- ./github/cli/phpcsfixer
 
       - name: Setup PHP

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -45,11 +45,12 @@ jobs:
               - 'composer.json'
 
       - name: Get latest CI code from target
-        if: steps.changes.outputs.ci == 'true'
+        if: steps.changes.outputs.ci == 'true' && github.base_ref
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "github.base_ref: $REF"
+          echo "Using CI code from `$REF`"
+          git checkout origin/"$REF" -- ./github/cli/phpcsfixer
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "Using CI code from `$REF`"
           git fetch origin "$REF"
-          git checkout origin/"$REF" -- .github/cli/phpcsfixer
+          git checkout origin/"$REF" -- .github/ci/phpcsfixer
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "Using CI code from `$REF`"
           git fetch origin "$REF"
-          git checkout origin/"$REF" -- ./github/cli/phpcsfixer
+          git checkout origin/"$REF" -- .github/cli/phpcsfixer
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -32,6 +32,10 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/phpstan/**'
+              - '.github/ci/root-and-suggested/**'
+              - '.github/workflows/phpstan.yml'
             files:
               - '.github/ci/phpstan/**'
               - '.github/ci/root-and-suggested/**'
@@ -41,6 +45,16 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/phpstan
+          git checkout origin/"$REF" -- .github/ci/root-and-suggested
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -35,6 +35,10 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/phpunit/**'
+              - '.github/ci/root-and-suggested/**'
+              - '.github/workflows/phpunit.yml'
             files:
               - '.github/ci/phpunit/**'
               - '.github/ci/root-and-suggested/**'
@@ -44,6 +48,16 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/phpunit
+          git checkout origin/"$REF" -- .github/ci/root-and-suggested
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -32,6 +32,10 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            ci:
+              - '.github/ci/psalm/**'
+              - '.github/ci/root-and-suggested/**'
+              - '.github/workflows/psalm.yml'
             files:
               - '.github/ci/psalm/**'
               - '.github/ci/root-and-suggested/**'
@@ -41,6 +45,16 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/psalm
+          git checkout origin/"$REF" -- .github/ci/root-and-suggested
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -32,6 +32,9 @@ jobs:
         id: changes
         with:
           filters: |
+            ci:
+              - '.github/ci/rector/**'
+              - '.github/workflows/rector.yml'
             files:
               - '.github/ci/rector/**'
               - '.github/workflows/rector.yml'
@@ -40,6 +43,15 @@ jobs:
               - 'src/**/*.php'
               - 'tests/**/*.php'
               - 'composer.json'
+
+      - name: Get latest CI code from target
+        if: steps.changes.outputs.ci != 'true' && github.base_ref
+        env:
+          REF: ${{ github.base_ref }}
+        run: |
+          echo "Using CI code from `$REF`"
+          git fetch origin "$REF"
+          git checkout origin/"$REF" -- .github/ci/rector
 
       - name: Setup PHP
         if: steps.changes.outputs.files == 'true'


### PR DESCRIPTION
# Description

Update the CI workflows to get the latest ref version of the ci directory. This way branches with outdated code won't run on older versions of the CI code on their local branch which may pass, or fail, but the worst scenario is they pass in the PR and break the target after being merged in and a follow up PR has to be made to fix those issues.

Should have passed as a negative test: https://github.com/valkyrjaio/valkyrja/actions/runs/20807755846/job/59765298111
And it did.

Should have failed after the logic was fixed: https://github.com/valkyrjaio/valkyrja/actions/runs/20807781131/job/59765369125
And it did.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->