### PR TITLE
[Cli] Update the CheckForHelpOptionsMiddleware to not rely on Env

### DIFF
--- a/src/Valkyrja/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddleware.php
+++ b/src/Valkyrja/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddleware.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Middleware\InputReceived;
 
 use Override;
-use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
@@ -23,8 +22,15 @@ use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 
 class CheckForHelpOptionsMiddleware implements InputReceivedMiddlewareContract
 {
+    /**
+     * @param string $commandName     The command name to route to
+     * @param string $optionName      The option name to check for
+     * @param string $optionShortName The option short name to check for
+     */
     public function __construct(
-        protected Env $env,
+        protected string $commandName,
+        protected string $optionName,
+        protected string $optionShortName,
     ) {
     }
 
@@ -34,22 +40,13 @@ class CheckForHelpOptionsMiddleware implements InputReceivedMiddlewareContract
     #[Override]
     public function inputReceived(InputContract $input, InputReceivedHandlerContract $handler): InputContract|OutputContract
     {
-        $env = $this->env;
-        /** @var non-empty-string $name */
-        $name = $env::CLI_HELP_OPTION_NAME;
-        /** @var non-empty-string $shortName */
-        $shortName = $env::CLI_HELP_OPTION_SHORT_NAME;
-
         // Check if the options are set for help
         if (
-            $input->hasOption($shortName)
-            || $input->hasOption($name)
+            $input->hasOption($this->optionShortName)
+            || $input->hasOption($this->optionName)
         ) {
-            /** @var non-empty-string $commandName */
-            $commandName = $env::CLI_HELP_COMMAND_NAME;
-
             $input = $input
-                ->withCommandName($commandName)
+                ->withCommandName($this->commandName)
                 ->withOptions(
                     new Option('command', $input->getCommandName()),
                 );

--- a/src/Valkyrja/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddleware.php
+++ b/src/Valkyrja/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddleware.php
@@ -23,9 +23,9 @@ use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 class CheckForHelpOptionsMiddleware implements InputReceivedMiddlewareContract
 {
     /**
-     * @param string $commandName     The command name to route to
-     * @param string $optionName      The option name to check for
-     * @param string $optionShortName The option short name to check for
+     * @param non-empty-string $commandName     The command name to route to
+     * @param non-empty-string $optionName      The option name to check for
+     * @param non-empty-string $optionShortName The option short name to check for
      */
     public function __construct(
         protected string $commandName,

--- a/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
@@ -199,10 +199,21 @@ final class ServiceProvider extends Provider
      */
     public static function publishCheckForHelpOptionsMiddleware(ContainerContract $container): void
     {
+        $env = $container->getSingleton(Env::class);
+
+        /** @var non-empty-string $commandName */
+        $commandName = $env::CLI_HELP_COMMAND_NAME;
+        /** @var non-empty-string $name */
+        $name = $env::CLI_HELP_OPTION_NAME;
+        /** @var non-empty-string $shortName */
+        $shortName = $env::CLI_HELP_OPTION_SHORT_NAME;
+
         $container->setSingleton(
             CheckForHelpOptionsMiddleware::class,
             new CheckForHelpOptionsMiddleware(
-                env: $container->getSingleton(Env::class)
+                commandName: $commandName,
+                optionName: $name,
+                optionShortName: $shortName
             )
         );
     }

--- a/tests/Unit/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
@@ -13,19 +13,18 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Cli\Middleware\InputReceived;
 
+use Valkyrja\Cli\Command\HelpCommand;
 use Valkyrja\Cli\Interaction\Input\Input;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 use Valkyrja\Cli\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
 use Valkyrja\Cli\Routing\Data\Option\HelpOptionParameter;
-use Valkyrja\Tests\EnvClass;
 use Valkyrja\Tests\Unit\TestCase;
 
 class CheckForHelpOptionsMiddlewareTest extends TestCase
 {
     public function testWithoutHelpOptions(): void
     {
-        $env     = new EnvClass();
         $input   = new Input();
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -34,7 +33,11 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckForHelpOptionsMiddleware(env: $env);
+        $middleware = new CheckForHelpOptionsMiddleware(
+            commandName: HelpCommand::NAME,
+            optionName: HelpOptionParameter::NAME,
+            optionShortName: HelpOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -43,7 +46,6 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
     public function testWithHelpOption(): void
     {
-        $env     = new EnvClass();
         $input   = new Input()->withOptions(new Option(name: HelpOptionParameter::NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -51,12 +53,16 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->method('inputReceived')
             ->willReturnArgument(0);
 
-        $middleware = new CheckForHelpOptionsMiddleware(env: $env);
+        $middleware = new CheckForHelpOptionsMiddleware(
+            commandName: HelpCommand::NAME,
+            optionName: HelpOptionParameter::NAME,
+            optionShortName: HelpOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame($env::CLI_HELP_COMMAND_NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(HelpCommand::NAME, $inputAfterMiddleware->getCommandName());
         self::assertNotEmpty($inputAfterMiddleware->getOptions());
         self::assertSame('command', $inputAfterMiddleware->getOptions()[0]->getName());
         self::assertSame($input->getCommandName(), $inputAfterMiddleware->getOptions()[0]->getValue());
@@ -64,7 +70,6 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
     public function testWithHelpShortOption(): void
     {
-        $env     = new EnvClass();
         $input   = new Input()->withOptions(new Option(name: HelpOptionParameter::SHORT_NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -72,12 +77,16 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->method('inputReceived')
             ->willReturnArgument(0);
 
-        $middleware = new CheckForHelpOptionsMiddleware(env: $env);
+        $middleware = new CheckForHelpOptionsMiddleware(
+            commandName: HelpCommand::NAME,
+            optionName: HelpOptionParameter::NAME,
+            optionShortName: HelpOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame($env::CLI_HELP_COMMAND_NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(HelpCommand::NAME, $inputAfterMiddleware->getCommandName());
         self::assertNotEmpty($inputAfterMiddleware->getOptions());
         self::assertSame('command', $inputAfterMiddleware->getOptions()[0]->getName());
         self::assertSame($input->getCommandName(), $inputAfterMiddleware->getOptions()[0]->getValue());


### PR DESCRIPTION
# Description

Update the CheckForHelpOptionsMiddleware to not rely on the Env class.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->