### PR TITLE
[Cli] Update the CheckForVersionOptionsMiddleware to not rely on Env

### DIFF
--- a/src/Valkyrja/Cli/Middleware/InputReceived/CheckForVersionOptionsMiddleware.php
+++ b/src/Valkyrja/Cli/Middleware/InputReceived/CheckForVersionOptionsMiddleware.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Middleware\InputReceived;
 
 use Override;
-use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Middleware\Contract\InputReceivedMiddlewareContract;
@@ -22,8 +21,15 @@ use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 
 class CheckForVersionOptionsMiddleware implements InputReceivedMiddlewareContract
 {
+    /**
+     * @param non-empty-string $commandName     The command name to route to
+     * @param non-empty-string $optionName      The option name to check for
+     * @param non-empty-string $optionShortName The option short name to check for
+     */
     public function __construct(
-        protected Env $env,
+        protected string $commandName,
+        protected string $optionName,
+        protected string $optionShortName,
     ) {
     }
 
@@ -33,22 +39,13 @@ class CheckForVersionOptionsMiddleware implements InputReceivedMiddlewareContrac
     #[Override]
     public function inputReceived(InputContract $input, InputReceivedHandlerContract $handler): InputContract|OutputContract
     {
-        $env = $this->env;
-        /** @var non-empty-string $name */
-        $name = $env::CLI_VERSION_OPTION_NAME;
-        /** @var non-empty-string $shortName */
-        $shortName = $env::CLI_VERSION_OPTION_SHORT_NAME;
-
         // Check if the options are set for the version
         if (
-            $input->hasOption($shortName)
-            || $input->hasOption($name)
+            $input->hasOption($this->optionShortName)
+            || $input->hasOption($this->optionName)
         ) {
-            /** @var non-empty-string $commandName */
-            $commandName = $env::CLI_VERSION_COMMAND_NAME;
-
             $input = $input
-                ->withCommandName($commandName)
+                ->withCommandName($this->commandName)
                 ->withOptions();
         }
 

--- a/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
@@ -223,10 +223,21 @@ final class ServiceProvider extends Provider
      */
     public static function publishCheckForVersionOptionsMiddleware(ContainerContract $container): void
     {
+        $env = $container->getSingleton(Env::class);
+
+        /** @var non-empty-string $commandName */
+        $commandName = $env::CLI_VERSION_COMMAND_NAME;
+        /** @var non-empty-string $name */
+        $name = $env::CLI_VERSION_OPTION_NAME;
+        /** @var non-empty-string $shortName */
+        $shortName = $env::CLI_VERSION_OPTION_SHORT_NAME;
+
         $container->setSingleton(
             CheckForVersionOptionsMiddleware::class,
             new CheckForVersionOptionsMiddleware(
-                env: $container->getSingleton(Env::class)
+                commandName: $commandName,
+                optionName: $name,
+                optionShortName: $shortName
             )
         );
     }

--- a/tests/Unit/Cli/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
@@ -13,19 +13,18 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Cli\Middleware\InputReceived;
 
+use Valkyrja\Cli\Command\VersionCommand;
 use Valkyrja\Cli\Interaction\Input\Input;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 use Valkyrja\Cli\Middleware\InputReceived\CheckForVersionOptionsMiddleware;
 use Valkyrja\Cli\Routing\Data\Option\VersionOptionParameter;
-use Valkyrja\Tests\EnvClass;
 use Valkyrja\Tests\Unit\TestCase;
 
 class CheckForVersionOptionsMiddlewareTest extends TestCase
 {
     public function testWithoutVersionOptions(): void
     {
-        $env     = new EnvClass();
         $input   = new Input();
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -34,7 +33,11 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckForVersionOptionsMiddleware(env: $env);
+        $middleware = new CheckForVersionOptionsMiddleware(
+            commandName: VersionCommand::NAME,
+            optionName: VersionOptionParameter::NAME,
+            optionShortName: VersionOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -43,7 +46,6 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
     public function testWithVersionOption(): void
     {
-        $env     = new EnvClass();
         $input   = new Input()->withOptions(new Option(name: VersionOptionParameter::NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -51,18 +53,21 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->method('inputReceived')
             ->willReturnArgument(0);
 
-        $middleware = new CheckForVersionOptionsMiddleware(env: $env);
+        $middleware = new CheckForVersionOptionsMiddleware(
+            commandName: VersionCommand::NAME,
+            optionName: VersionOptionParameter::NAME,
+            optionShortName: VersionOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame($env::CLI_VERSION_COMMAND_NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(VersionCommand::NAME, $inputAfterMiddleware->getCommandName());
         self::assertEmpty($inputAfterMiddleware->getOptions());
     }
 
     public function testWithVersionShortOption(): void
     {
-        $env     = new EnvClass();
         $input   = new Input()->withOptions(new Option(name: VersionOptionParameter::SHORT_NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -70,12 +75,16 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->method('inputReceived')
             ->willReturnArgument(0);
 
-        $middleware = new CheckForVersionOptionsMiddleware(env: $env);
+        $middleware = new CheckForVersionOptionsMiddleware(
+            commandName: VersionCommand::NAME,
+            optionName: VersionOptionParameter::NAME,
+            optionShortName: VersionOptionParameter::SHORT_NAME,
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame($env::CLI_VERSION_COMMAND_NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(VersionCommand::NAME, $inputAfterMiddleware->getCommandName());
         self::assertEmpty($inputAfterMiddleware->getOptions());
     }
 }


### PR DESCRIPTION
# Description

Update the CheckForVersionOptionsMiddleware to not rely on the Env class.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->