### PR TITLE
[Cli] Update the CheckGlobalInteractionOptionsMiddleware to not rely on Env

### DIFF
--- a/src/Valkyrja/Cli/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddleware.php
+++ b/src/Valkyrja/Cli/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddleware.php
@@ -14,21 +14,30 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Middleware\InputReceived;
 
 use Override;
-use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Data\Config;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Middleware\Contract\InputReceivedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
-use Valkyrja\Cli\Routing\Data\Option\NoInteractionOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\QuietOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\SilentOptionParameter;
 
 class CheckGlobalInteractionOptionsMiddleware implements InputReceivedMiddlewareContract
 {
+    /**
+     * @param non-empty-string $noInteractionOptionName      The no interaction option name
+     * @param non-empty-string $noInteractionOptionShortName The no interaction option short name
+     * @param non-empty-string $quietOptionName              The quiet option name
+     * @param non-empty-string $quietOptionShortName         The quiet option short name
+     * @param non-empty-string $silentOptionName             The silent option name
+     * @param non-empty-string $silentOptionShortName        The silent option short name
+     */
     public function __construct(
         protected Config $config,
-        protected Env $env,
+        protected string $noInteractionOptionName,
+        protected string $noInteractionOptionShortName,
+        protected string $quietOptionName,
+        protected string $quietOptionShortName,
+        protected string $silentOptionName,
+        protected string $silentOptionShortName,
     ) {
     }
 
@@ -53,8 +62,8 @@ class CheckGlobalInteractionOptionsMiddleware implements InputReceivedMiddleware
     protected function setIsInteractive(InputContract $input): void
     {
         if (
-            $input->hasOption(NoInteractionOptionParameter::SHORT_NAME)
-            || $input->hasOption(NoInteractionOptionParameter::NAME)
+            $input->hasOption($this->noInteractionOptionShortName)
+            || $input->hasOption($this->noInteractionOptionName)
         ) {
             $this->config->isInteractive = false;
         }
@@ -68,8 +77,8 @@ class CheckGlobalInteractionOptionsMiddleware implements InputReceivedMiddleware
     protected function setIsQuiet(InputContract $input): void
     {
         if (
-            $input->hasOption(QuietOptionParameter::SHORT_NAME)
-            || $input->hasOption(QuietOptionParameter::NAME)
+            $input->hasOption($this->quietOptionShortName)
+            || $input->hasOption($this->quietOptionName)
         ) {
             $this->config->isQuiet = true;
         }
@@ -83,8 +92,8 @@ class CheckGlobalInteractionOptionsMiddleware implements InputReceivedMiddleware
     protected function setIsSilent(InputContract $input): void
     {
         if (
-            $input->hasOption(SilentOptionParameter::SHORT_NAME)
-            || $input->hasOption(SilentOptionParameter::NAME)
+            $input->hasOption($this->silentOptionShortName)
+            || $input->hasOption($this->silentOptionName)
         ) {
             $this->config->isSilent = true;
         }

--- a/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
@@ -37,6 +37,9 @@ use Valkyrja\Cli\Middleware\Handler\ThrowableCaughtHandler;
 use Valkyrja\Cli\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
 use Valkyrja\Cli\Middleware\InputReceived\CheckForVersionOptionsMiddleware;
 use Valkyrja\Cli\Middleware\InputReceived\CheckGlobalInteractionOptionsMiddleware;
+use Valkyrja\Cli\Routing\Data\Option\NoInteractionOptionParameter;
+use Valkyrja\Cli\Routing\Data\Option\QuietOptionParameter;
+use Valkyrja\Cli\Routing\Data\Option\SilentOptionParameter;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Provider;
 
@@ -251,7 +254,12 @@ final class ServiceProvider extends Provider
             CheckGlobalInteractionOptionsMiddleware::class,
             new CheckGlobalInteractionOptionsMiddleware(
                 config: $container->getSingleton(Config::class),
-                env: $container->getSingleton(Env::class)
+                noInteractionOptionName: NoInteractionOptionParameter::NAME,
+                noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+                quietOptionName: QuietOptionParameter::NAME,
+                quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+                silentOptionName: SilentOptionParameter::NAME,
+                silentOptionShortName: SilentOptionParameter::SHORT_NAME
             )
         );
     }

--- a/tests/Unit/Cli/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddlewareTest.php
@@ -21,14 +21,12 @@ use Valkyrja\Cli\Middleware\InputReceived\CheckGlobalInteractionOptionsMiddlewar
 use Valkyrja\Cli\Routing\Data\Option\NoInteractionOptionParameter;
 use Valkyrja\Cli\Routing\Data\Option\QuietOptionParameter;
 use Valkyrja\Cli\Routing\Data\Option\SilentOptionParameter;
-use Valkyrja\Tests\EnvClass;
 use Valkyrja\Tests\Unit\TestCase;
 
 class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 {
     public function testWithoutHelpOptions(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input();
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -38,7 +36,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -50,7 +56,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithNoInteractionOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: NoInteractionOptionParameter::NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -60,7 +65,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -72,7 +85,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithNoInteractionShortOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: NoInteractionOptionParameter::SHORT_NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -82,7 +94,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -94,7 +114,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithQuietOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: QuietOptionParameter::NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -104,7 +123,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -116,7 +143,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithQuietShortOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: QuietOptionParameter::SHORT_NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -126,7 +152,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -138,7 +172,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithSilentOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: SilentOptionParameter::NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -148,7 +181,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -160,7 +201,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithSilentShortOption(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(new Option(name: SilentOptionParameter::SHORT_NAME));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
@@ -170,7 +210,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -182,7 +230,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithAllOptions(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(
             new Option(name: NoInteractionOptionParameter::NAME),
@@ -196,7 +243,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
@@ -208,7 +263,6 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
     public function testWithAllShortOptions(): void
     {
-        $env     = new EnvClass();
         $config  = new Config();
         $input   = new Input()->withOptions(
             new Option(name: NoInteractionOptionParameter::SHORT_NAME),
@@ -222,7 +276,15 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
             ->with($input)
             ->willReturn($input);
 
-        $middleware = new CheckGlobalInteractionOptionsMiddleware(config: $config, env: $env);
+        $middleware = new CheckGlobalInteractionOptionsMiddleware(
+            config: $config,
+            noInteractionOptionName: NoInteractionOptionParameter::NAME,
+            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
+            quietOptionName: QuietOptionParameter::NAME,
+            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
+            silentOptionName: SilentOptionParameter::NAME,
+            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+        );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 


### PR DESCRIPTION
# Description

Update the CheckGlobalInteractionOptionsMiddleware to not rely on the Env class.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->