### PR TITLE
[CI] Fix echo statement in workflows

### DIFF
--- a/.github/workflows/phparkitect.yml
+++ b/.github/workflows/phparkitect.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/phparkitect
 

--- a/.github/workflows/phpcodesniffer.yml
+++ b/.github/workflows/phpcodesniffer.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/phpcodesniffer
 

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/phpcsfixer
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/phpstan
           git checkout origin/"$REF" -- .github/ci/root-and-suggested

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/phpunit
           git checkout origin/"$REF" -- .github/ci/root-and-suggested

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/psalm
           git checkout origin/"$REF" -- .github/ci/root-and-suggested

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           REF: ${{ github.base_ref }}
         run: |
-          echo "Using CI code from `$REF`"
+          echo "Using CI code from $REF"
           git fetch origin "$REF"
           git checkout origin/"$REF" -- .github/ci/rector
 


### PR DESCRIPTION
# Description

Fix echo statement in workflows. It was trying to run the command since backticks were used to style the target name instead of quotes.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->