### PR TITLE
[CI] Add method_chaining_indentation rule to phpcsfixer

### DIFF
--- a/.github/ci/phpcsfixer/.php_cs.dist.php
+++ b/.github/ci/phpcsfixer/.php_cs.dist.php
@@ -21,10 +21,10 @@ $header = <<<EOF
     EOF;
 
 $finder = PhpCsFixer\Finder::create()
-                           ->exclude('.github')
-                           ->exclude('docs')
-                           ->exclude('vendor')
-                           ->in(__DIR__ . '/../../../');
+    ->exclude('.github')
+    ->exclude('docs')
+    ->exclude('vendor')
+    ->in(__DIR__ . '/../../../');
 
 return new PhpCsFixer\Config()
     ->setParallelConfig(
@@ -55,6 +55,7 @@ return new PhpCsFixer\Config()
             'combine_consecutive_unsets'               => true,
             'comment_to_phpdoc'                        => true,
             // 'explicit_string_variable'                 => true,
+            'method_chaining_indentation'              => true,
             'modernize_types_casting'                  => true,
             'no_unreachable_default_argument_value'    => true,
             'no_superfluous_elseif'                    => true,

--- a/tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
+++ b/tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
@@ -64,9 +64,9 @@ class RouterTest extends TestCase
         $input   = new Input(commandName: 'non-existing-command');
         $handler = $this->createMock(RouteNotMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeNotMatched')
-                ->with($input, self::anything())
-                ->willReturnArgument(1);
+            ->method('routeNotMatched')
+            ->with($input, self::anything())
+            ->willReturnArgument(1);
 
         $router = new Router(routeNotMatchedHandler: $handler);
 
@@ -99,9 +99,9 @@ class RouterTest extends TestCase
 
         $handler = $this->createMock(RouteMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeMatched')
-                ->with($input, self::anything())
-                ->willReturnArgument(1);
+            ->method('routeMatched')
+            ->with($input, self::anything())
+            ->willReturnArgument(1);
 
         $command = new Route(
             name: 'test-command',
@@ -126,9 +126,9 @@ class RouterTest extends TestCase
 
         $handler = $this->createMock(RouteMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeMatched')
-                ->with($input, self::anything())
-                ->willReturn($output);
+            ->method('routeMatched')
+            ->with($input, self::anything())
+            ->willReturn($output);
 
         $command = new Route(
             name: 'test-command',
@@ -154,9 +154,9 @@ class RouterTest extends TestCase
 
         $handler = $this->createMock(RouteDispatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeDispatched')
-                ->with($input, self::anything(), self::anything())
-                ->willReturnArgument(1);
+            ->method('routeDispatched')
+            ->with($input, self::anything(), self::anything())
+            ->willReturnArgument(1);
 
         $command = new Route(
             name: 'test-command',

--- a/tests/Unit/Cli/Routing/Middleware/RouteNotMatched/CheckCommandForTypoMiddlewareTest.php
+++ b/tests/Unit/Cli/Routing/Middleware/RouteNotMatched/CheckCommandForTypoMiddlewareTest.php
@@ -33,14 +33,14 @@ class CheckCommandForTypoMiddlewareTest extends TestCase
         $output2 = new Output(isInteractive: false);
         $handler = $this->createMock(RouteNotMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeNotMatched')
-                ->withAnyParameters()
-                ->willReturnArgument(1);
+            ->method('routeNotMatched')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
         $router = $this->createMock(RouterContract::class);
         $router->expects($this->never())
-               ->method('dispatch')
-               ->withAnyParameters()
-               ->willReturn($output2);
+            ->method('dispatch')
+            ->withAnyParameters()
+            ->willReturn($output2);
         $collection = new Collection();
         $collection->add(
             new Route(
@@ -79,14 +79,14 @@ class CheckCommandForTypoMiddlewareTest extends TestCase
         $output2 = new Output(isInteractive: false);
         $handler = $this->createMock(RouteNotMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeNotMatched')
-                ->withAnyParameters()
-                ->willReturnArgument(1);
+            ->method('routeNotMatched')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
         $router = $this->createMock(RouterContract::class);
         $router->expects($this->once())
-               ->method('dispatch')
-               ->withAnyParameters()
-               ->willReturn($output2);
+            ->method('dispatch')
+            ->withAnyParameters()
+            ->willReturn($output2);
         $collection = new Collection();
         $collection->add(
             new Route(
@@ -126,14 +126,14 @@ class CheckCommandForTypoMiddlewareTest extends TestCase
         $output2 = new Output(isInteractive: false);
         $handler = $this->createMock(RouteNotMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeNotMatched')
-                ->withAnyParameters()
-                ->willReturnArgument(1);
+            ->method('routeNotMatched')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
         $router = $this->createMock(RouterContract::class);
         $router->expects($this->never())
-               ->method('dispatch')
-               ->withAnyParameters()
-               ->willReturn($output2);
+            ->method('dispatch')
+            ->withAnyParameters()
+            ->willReturn($output2);
         $collection = new Collection();
         $collection->add(
             new Route(
@@ -173,14 +173,14 @@ class CheckCommandForTypoMiddlewareTest extends TestCase
         $output2 = new Output(isInteractive: false);
         $handler = $this->createMock(RouteNotMatchedHandlerContract::class);
         $handler->expects($this->once())
-                ->method('routeNotMatched')
-                ->withAnyParameters()
-                ->willReturnArgument(1);
+            ->method('routeNotMatched')
+            ->withAnyParameters()
+            ->willReturnArgument(1);
         $router = $this->createMock(RouterContract::class);
         $router->expects($this->never())
-               ->method('dispatch')
-               ->withAnyParameters()
-               ->willReturn($output2);
+            ->method('dispatch')
+            ->withAnyParameters()
+            ->willReturn($output2);
         $collection = new Collection();
         $collection->add(
             new Route(

--- a/tests/Unit/Cli/Server/Command/HelpCommandTest.php
+++ b/tests/Unit/Cli/Server/Command/HelpCommandTest.php
@@ -38,19 +38,19 @@ class HelpCommandTest extends TestCase
         $output = new Output();
         $route  = $this->createMock(RouteContract::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->with('command')
-              ->willReturn(null);
+            ->method('getOption')
+            ->with('command')
+            ->willReturn(null);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->never())
-                   ->method('get');
+            ->method('get');
         $version = $this->createMock(VersionCommand::class);
         $version->expects($this->never())
-                ->method('run');
+            ->method('run');
         $outputFactory = $this->createMock(OutputFactoryContract::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
 
         $helpCommand   = new HelpCommand(
             version: $version,
@@ -75,25 +75,25 @@ class HelpCommandTest extends TestCase
         $output = new Output();
         $option = $this->createMock(OptionParameterContract::class);
         $option->expects($this->once())
-               ->method('getFirstValue')
-               ->willReturn($commandName);
+            ->method('getFirstValue')
+            ->willReturn($commandName);
         $route = $this->createMock(RouteContract::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->with('command')
-              ->willReturn($option);
+            ->method('getOption')
+            ->with('command')
+            ->willReturn($option);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('get')
-                   ->with($commandName)
-                   ->willReturn(null);
+            ->method('get')
+            ->with($commandName)
+            ->willReturn(null);
         $version = $this->createMock(VersionCommand::class);
         $version->expects($this->never())
-                ->method('run');
+            ->method('run');
         $outputFactory = $this->createMock(OutputFactoryContract::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
 
         $helpCommand   = new HelpCommand(
             version: $version,
@@ -161,25 +161,25 @@ class HelpCommandTest extends TestCase
         $output = new Output();
         $option = $this->createMock(OptionParameterContract::class);
         $option->expects($this->once())
-               ->method('getFirstValue')
-               ->willReturn($commandName);
+            ->method('getFirstValue')
+            ->willReturn($commandName);
         $route = $this->createMock(RouteContract::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->with('command')
-              ->willReturn($option);
+            ->method('getOption')
+            ->with('command')
+            ->willReturn($option);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('get')
-                   ->with($commandName)
-                   ->willReturn($helpRoute);
+            ->method('get')
+            ->with($commandName)
+            ->willReturn($helpRoute);
         $version = $this->createMock(VersionCommand::class);
         $version->expects($this->once())
-                ->method('run')
-                ->willReturn($output->withMessages(new Message($versionText)));
+            ->method('run')
+            ->willReturn($output->withMessages(new Message($versionText)));
         $outputFactory = $this->createMock(OutputFactoryContract::class);
         $outputFactory->expects($this->never())
-                      ->method('createOutput');
+            ->method('createOutput');
 
         $helpCommand   = new HelpCommand(
             version: $version,

--- a/tests/Unit/Cli/Server/Command/ListBashCommandTest.php
+++ b/tests/Unit/Cli/Server/Command/ListBashCommandTest.php
@@ -28,16 +28,16 @@ class ListBashCommandTest extends TestCase
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([]);
+            ->method('all')
+            ->willReturn([]);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getArgument')
-              ->willReturn(null);
+            ->method('getArgument')
+            ->willReturn(null);
 
         $command = new ListBashCommand(
             route: $route,
@@ -55,28 +55,28 @@ class ListBashCommandTest extends TestCase
         $listRouteName = 'Route1name';
         $listRoute     = $this->createMock(Route::class);
         $listRoute->expects($this->once())
-                  ->method('getName')
-                  ->willReturn($listRouteName);
+            ->method('getName')
+            ->willReturn($listRouteName);
 
         $listRoute2Name = 'Route2name';
         $listRoute2     = $this->createMock(Route::class);
         $listRoute2->expects($this->once())
-                   ->method('getName')
-                   ->willReturn($listRoute2Name);
+            ->method('getName')
+            ->willReturn($listRoute2Name);
 
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([$listRoute, $listRoute2]);
+            ->method('all')
+            ->willReturn([$listRoute, $listRoute2]);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getArgument')
-              ->willReturn(null);
+            ->method('getArgument')
+            ->willReturn(null);
 
         $command = new ListBashCommand(
             route: $route,
@@ -96,38 +96,38 @@ class ListBashCommandTest extends TestCase
         $listRouteName = "$namespace:Route1name";
         $listRoute     = $this->createMock(Route::class);
         $listRoute->expects($this->exactly(2))
-                  ->method('getName')
-                  ->willReturn($listRouteName);
+            ->method('getName')
+            ->willReturn($listRouteName);
 
         $listRoute2Name = "$namespace:Route2name";
         $listRoute2     = $this->createMock(Route::class);
         $listRoute2->expects($this->exactly(2))
-                   ->method('getName')
-                   ->willReturn($listRoute2Name);
+            ->method('getName')
+            ->willReturn($listRoute2Name);
 
         $listRoute3Name = 'Route3name';
         $listRoute3     = $this->createMock(Route::class);
         $listRoute3->expects($this->once())
-                   ->method('getName')
-                   ->willReturn($listRoute3Name);
+            ->method('getName')
+            ->willReturn($listRoute3Name);
 
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([$listRoute, $listRoute2, $listRoute3]);
+            ->method('all')
+            ->willReturn([$listRoute, $listRoute2, $listRoute3]);
         $argument = $this->createMock(ArgumentParameter::class);
         $argument->expects($this->once())
-                 ->method('getFirstValue')
-                 ->willReturn($namespace);
+            ->method('getFirstValue')
+            ->willReturn($namespace);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getArgument')
-              ->willReturn($argument);
+            ->method('getArgument')
+            ->willReturn($argument);
 
         $command = new ListBashCommand(
             route: $route,
@@ -147,38 +147,38 @@ class ListBashCommandTest extends TestCase
         $listRouteName = 'Route1name';
         $listRoute     = $this->createMock(Route::class);
         $listRoute->expects($this->exactly(2))
-                  ->method('getName')
-                  ->willReturn($namespace . $listRouteName);
+            ->method('getName')
+            ->willReturn($namespace . $listRouteName);
 
         $listRoute2Name = 'Route2name';
         $listRoute2     = $this->createMock(Route::class);
         $listRoute2->expects($this->exactly(2))
-                   ->method('getName')
-                   ->willReturn($namespace . $listRoute2Name);
+            ->method('getName')
+            ->willReturn($namespace . $listRoute2Name);
 
         $listRoute3Name = 'Route3name';
         $listRoute3     = $this->createMock(Route::class);
         $listRoute3->expects($this->once())
-                   ->method('getName')
-                   ->willReturn($listRoute3Name);
+            ->method('getName')
+            ->willReturn($listRoute3Name);
 
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([$listRoute, $listRoute2, $listRoute3]);
+            ->method('all')
+            ->willReturn([$listRoute, $listRoute2, $listRoute3]);
         $argument = $this->createMock(ArgumentParameter::class);
         $argument->expects($this->once())
-                 ->method('getFirstValue')
-                 ->willReturn($namespace);
+            ->method('getFirstValue')
+            ->willReturn($namespace);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getArgument')
-              ->willReturn($argument);
+            ->method('getArgument')
+            ->willReturn($argument);
 
         $command = new ListBashCommand(
             route: $route,

--- a/tests/Unit/Cli/Server/Command/ListCommandTest.php
+++ b/tests/Unit/Cli/Server/Command/ListCommandTest.php
@@ -33,19 +33,19 @@ class ListCommandTest extends TestCase
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $versionCommand = $this->createMock(VersionCommand::class);
         $versionCommand->expects($this->never())
-                       ->method('run');
+            ->method('run');
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([]);
+            ->method('all')
+            ->willReturn([]);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->willReturn(null);
+            ->method('getOption')
+            ->willReturn(null);
 
         $command = new ListCommand(
             version: $versionCommand,
@@ -68,23 +68,23 @@ class ListCommandTest extends TestCase
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->once())
-                      ->method('createOutput')
-                      ->willReturn($output);
+            ->method('createOutput')
+            ->willReturn($output);
         $versionCommand = $this->createMock(VersionCommand::class);
         $versionCommand->expects($this->never())
-                       ->method('run');
+            ->method('run');
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([]);
+            ->method('all')
+            ->willReturn([]);
         $option = $this->createMock(OptionParameter::class);
         $option->expects($this->once())
-               ->method('getFirstValue')
-               ->willReturn('non-existent namespace');
+            ->method('getFirstValue')
+            ->willReturn('non-existent namespace');
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->willReturn($option);
+            ->method('getOption')
+            ->willReturn($option);
 
         $command = new ListCommand(
             version: $versionCommand,
@@ -108,39 +108,39 @@ class ListCommandTest extends TestCase
         $listRouteDescription = 'Route 1 description';
         $listRoute            = $this->createMock(Route::class);
         $listRoute->expects($this->exactly(2))
-                  ->method('getName')
-                  ->willReturn($listRouteName);
+            ->method('getName')
+            ->willReturn($listRouteName);
         $listRoute->expects($this->once())
-                  ->method('getDescription')
-                  ->willReturn($listRouteDescription);
+            ->method('getDescription')
+            ->willReturn($listRouteDescription);
 
         $listRoute2Name        = 'Route2name';
         $listRoute2Description = 'Route 2 description';
         $listRoute2            = $this->createMock(Route::class);
         $listRoute2->expects($this->exactly(2))
-                   ->method('getName')
-                   ->willReturn($listRoute2Name);
+            ->method('getName')
+            ->willReturn($listRoute2Name);
         $listRoute2->expects($this->once())
-                   ->method('getDescription')
-                   ->willReturn($listRoute2Description);
+            ->method('getDescription')
+            ->willReturn($listRoute2Description);
 
         $versionText   = 'Version Command Output';
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->never())
-                      ->method('createOutput');
+            ->method('createOutput');
         $versionCommand = $this->createMock(VersionCommand::class);
         $versionCommand->expects($this->once())
-                       ->method('run')
-                       ->willReturn($output->withMessages(new Message($versionText)));
+            ->method('run')
+            ->willReturn($output->withMessages(new Message($versionText)));
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([$listRoute, $listRoute2]);
+            ->method('all')
+            ->willReturn([$listRoute, $listRoute2]);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->willReturn(null);
+            ->method('getOption')
+            ->willReturn(null);
 
         $command = new ListCommand(
             version: $versionCommand,
@@ -171,51 +171,51 @@ class ListCommandTest extends TestCase
         $listRouteDescription = 'Route 1 description';
         $listRoute            = $this->createMock(Route::class);
         $listRoute->expects($this->exactly(3))
-                  ->method('getName')
-                  ->willReturn($listRouteName);
+            ->method('getName')
+            ->willReturn($listRouteName);
         $listRoute->expects($this->once())
-                  ->method('getDescription')
-                  ->willReturn($listRouteDescription);
+            ->method('getDescription')
+            ->willReturn($listRouteDescription);
 
         $listRoute2Name        = "$namespace:Route2name";
         $listRoute2Description = 'Route 2 description';
         $listRoute2            = $this->createMock(Route::class);
         $listRoute2->expects($this->exactly(3))
-                   ->method('getName')
-                   ->willReturn($listRoute2Name);
+            ->method('getName')
+            ->willReturn($listRoute2Name);
         $listRoute2->expects($this->once())
-                   ->method('getDescription')
-                   ->willReturn($listRoute2Description);
+            ->method('getDescription')
+            ->willReturn($listRoute2Description);
 
         $listRoute3Name = 'Route3name';
         $listRoute3     = $this->createMock(Route::class);
         $listRoute3->expects($this->once())
-                   ->method('getName')
-                   ->willReturn($listRoute3Name);
+            ->method('getName')
+            ->willReturn($listRoute3Name);
         $listRoute3->expects($this->never())
-                   ->method('getDescription');
+            ->method('getDescription');
 
         $versionText   = 'Version Command Output';
         $output        = new Output();
         $outputFactory = $this->createMock(OutputFactory::class);
         $outputFactory->expects($this->never())
-                      ->method('createOutput');
+            ->method('createOutput');
         $versionCommand = $this->createMock(VersionCommand::class);
         $versionCommand->expects($this->once())
-                       ->method('run')
-                       ->willReturn($output->withMessages(new Message($versionText)));
+            ->method('run')
+            ->willReturn($output->withMessages(new Message($versionText)));
         $collection = $this->createMock(CollectionContract::class);
         $collection->expects($this->once())
-                   ->method('all')
-                   ->willReturn([$listRoute, $listRoute2, $listRoute3]);
+            ->method('all')
+            ->willReturn([$listRoute, $listRoute2, $listRoute3]);
         $option = $this->createMock(OptionParameter::class);
         $option->expects($this->once())
-               ->method('getFirstValue')
-               ->willReturn($namespace);
+            ->method('getFirstValue')
+            ->willReturn($namespace);
         $route = $this->createMock(Route::class);
         $route->expects($this->once())
-              ->method('getOption')
-              ->willReturn($option);
+            ->method('getOption')
+            ->willReturn($option);
 
         $command = new ListCommand(
             version: $versionCommand,

--- a/tests/Unit/Cli/Server/Middleware/ThrowableCaught/LogThrowableCaughtMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/ThrowableCaught/LogThrowableCaughtMiddlewareTest.php
@@ -32,21 +32,21 @@ class LogThrowableCaughtMiddlewareTest extends TestCase
 
         $logger = $this->createMock(LoggerContract::class);
         $logger->expects($this->once())
-               ->method('throwable')
-               ->with(
-                   self::equalTo($exception),
-                   self::equalTo("Cli Server Error\nUrl: $commandName"),
-               );
+            ->method('throwable')
+            ->with(
+                self::equalTo($exception),
+                self::equalTo("Cli Server Error\nUrl: $commandName"),
+            );
 
         $handler = $this->createMock(ThrowableCaughtHandler::class);
         $handler->expects($this->once())
-                ->method('throwableCaught')
-                ->with(
-                    self::equalTo($input),
-                    self::equalTo($output),
-                    self::equalTo($exception),
-                )
-                ->willReturn($output);
+            ->method('throwableCaught')
+            ->with(
+                self::equalTo($input),
+                self::equalTo($output),
+                self::equalTo($exception),
+            )
+            ->willReturn($output);
 
         $middleware = new LogThrowableCaughtMiddleware(logger: $logger);
 

--- a/tests/Unit/Cli/Server/Middleware/ThrowableCaught/OutputThrowableCaughtMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/ThrowableCaught/OutputThrowableCaughtMiddlewareTest.php
@@ -33,13 +33,13 @@ class OutputThrowableCaughtMiddlewareTest extends TestCase
 
         $handler = $this->createMock(ThrowableCaughtHandler::class);
         $handler->expects($this->once())
-                ->method('throwableCaught')
-                ->with(
-                    self::equalTo($input),
-                    self::anything(),
-                    self::equalTo($exception),
-                )
-                ->willReturnArgument(1);
+            ->method('throwableCaught')
+            ->with(
+                self::equalTo($input),
+                self::anything(),
+                self::equalTo($exception),
+            )
+            ->willReturnArgument(1);
 
         $middleware = new OutputThrowableCaughtMiddleware();
 

--- a/tests/Unit/Http/Client/Manager/GuzzleClientTest.php
+++ b/tests/Unit/Http/Client/Manager/GuzzleClientTest.php
@@ -78,18 +78,18 @@ class GuzzleClientTest extends TestCase
         $psr7Response->expects($this->once())->method('getBody')->willReturn($psr7Body);
         $psr7Body->expects($this->once())->method('getContents')->willReturn($contents);
         $guzzle->expects($this->once())
-               ->method('request')
-               ->with(
-                   'GET',
-                   $stringUri,
-                   self::logicalAnd(
-                       self::arrayHasKey('headers'),
-                       self::arrayHasKey('body'),
-                       self::arrayHasKey('cookies'),
-                       self::arrayHasKey('form_params'),
-                   )
-               )
-               ->willReturn($psr7Response);
+            ->method('request')
+            ->with(
+                'GET',
+                $stringUri,
+                self::logicalAnd(
+                    self::arrayHasKey('headers'),
+                    self::arrayHasKey('body'),
+                    self::arrayHasKey('cookies'),
+                    self::arrayHasKey('form_params'),
+                )
+            )
+            ->willReturn($psr7Response);
 
         $response = $client->sendRequest($request);
 

--- a/tests/Unit/Http/Routing/Middleware/ViewRouteNotMatchedMiddlewareTest.php
+++ b/tests/Unit/Http/Routing/Middleware/ViewRouteNotMatchedMiddlewareTest.php
@@ -46,8 +46,8 @@ class ViewRouteNotMatchedMiddlewareTest extends TestCase
 
         $view = self::createStub(RendererContract::class);
         $view->method('render')
-             ->with('errors/404', $args)
-             ->willReturn($templateText);
+            ->with('errors/404', $args)
+            ->willReturn($templateText);
 
         $middleware = new ViewRouteNotMatchedMiddleware(renderer: $view);
 

--- a/tests/Unit/Http/Server/Middleware/LogExceptionMiddlewareTest.php
+++ b/tests/Unit/Http/Server/Middleware/LogExceptionMiddlewareTest.php
@@ -37,21 +37,21 @@ class LogExceptionMiddlewareTest extends TestCase
 
         $logger = $this->createMock(LoggerContract::class);
         $logger->expects($this->once())
-               ->method('throwable')
-               ->with(
-                   self::equalTo($exception),
-                   self::equalTo("Http Server Error\nUrl: $url"),
-               );
+            ->method('throwable')
+            ->with(
+                self::equalTo($exception),
+                self::equalTo("Http Server Error\nUrl: $url"),
+            );
 
         $handler = $this->createMock(ThrowableCaughtHandler::class);
         $handler->expects($this->once())
-                ->method('throwableCaught')
-                ->with(
-                    self::equalTo($request),
-                    self::equalTo($response),
-                    self::equalTo($exception),
-                )
-                ->willReturn($response);
+            ->method('throwableCaught')
+            ->with(
+                self::equalTo($request),
+                self::equalTo($response),
+                self::equalTo($exception),
+            )
+            ->willReturn($response);
 
         $middleware = new LogThrowableCaughtMiddleware(logger: $logger);
 

--- a/tests/Unit/Http/Server/Middleware/ViewExceptionMiddlewareTest.php
+++ b/tests/Unit/Http/Server/Middleware/ViewExceptionMiddlewareTest.php
@@ -46,22 +46,22 @@ class ViewExceptionMiddlewareTest extends TestCase
 
         $view = $this->createMock(ResponseFactory::class);
         $view->expects($this->once())
-             ->method('createResponseFromView')
-             ->with(
-                 self::equalTo('errors/500'),
-                 self::equalTo($args)
-             )
-             ->willReturn($viewResponse);
+            ->method('createResponseFromView')
+            ->with(
+                self::equalTo('errors/500'),
+                self::equalTo($args)
+            )
+            ->willReturn($viewResponse);
 
         $handler = $this->createMock(ThrowableCaughtHandler::class);
         $handler->expects($this->once())
-                ->method('throwableCaught')
-                ->with(
-                    self::equalTo($request),
-                    self::equalTo($viewResponse),
-                    self::equalTo($exception),
-                )
-                ->willReturn($viewResponse);
+            ->method('throwableCaught')
+            ->with(
+                self::equalTo($request),
+                self::equalTo($viewResponse),
+                self::equalTo($exception),
+            )
+            ->willReturn($viewResponse);
 
         $middleware = new ViewThrowableCaughtMiddleware(viewResponseFactory: $view);
 

--- a/tests/Unit/View/Factory/ResponseFactoryTest.php
+++ b/tests/Unit/View/Factory/ResponseFactoryTest.php
@@ -48,22 +48,22 @@ class ResponseFactoryTest extends TestCase
 
         $template = $this->createMock(TemplateContract::class);
         $template->expects($this->once())
-                 ->method('render')
-                 ->willReturn($templateContent);
+            ->method('render')
+            ->willReturn($templateContent);
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('createTemplate')
-                 ->with($templateName, [])
-                 ->willReturn($template);
+            ->method('createTemplate')
+            ->with($templateName, [])
+            ->willReturn($template);
 
         $response = self::createStub(ResponseContract::class);
 
         $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
-                            ->method('createResponse')
-                            ->with($templateContent, null, null)
-                            ->willReturn($response);
+            ->method('createResponse')
+            ->with($templateContent, null, null)
+            ->willReturn($response);
 
         $factory = new ResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName);
@@ -82,22 +82,22 @@ class ResponseFactoryTest extends TestCase
 
         $template = $this->createMock(TemplateContract::class);
         $template->expects($this->once())
-                 ->method('render')
-                 ->willReturn($templateContent);
+            ->method('render')
+            ->willReturn($templateContent);
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('createTemplate')
-                 ->with($templateName, $data)
-                 ->willReturn($template);
+            ->method('createTemplate')
+            ->with($templateName, $data)
+            ->willReturn($template);
 
         $response = self::createStub(ResponseContract::class);
 
         $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
-                            ->method('createResponse')
-                            ->with($templateContent, null, null)
-                            ->willReturn($response);
+            ->method('createResponse')
+            ->with($templateContent, null, null)
+            ->willReturn($response);
 
         $factory = new ResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, $data);
@@ -116,22 +116,22 @@ class ResponseFactoryTest extends TestCase
 
         $template = $this->createMock(TemplateContract::class);
         $template->expects($this->once())
-                 ->method('render')
-                 ->willReturn($templateContent);
+            ->method('render')
+            ->willReturn($templateContent);
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('createTemplate')
-                 ->with($templateName, [])
-                 ->willReturn($template);
+            ->method('createTemplate')
+            ->with($templateName, [])
+            ->willReturn($template);
 
         $response = self::createStub(ResponseContract::class);
 
         $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
-                            ->method('createResponse')
-                            ->with($templateContent, $statusCode, null)
-                            ->willReturn($response);
+            ->method('createResponse')
+            ->with($templateContent, $statusCode, null)
+            ->willReturn($response);
 
         $factory = new ResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, null, $statusCode);
@@ -150,22 +150,22 @@ class ResponseFactoryTest extends TestCase
 
         $template = $this->createMock(TemplateContract::class);
         $template->expects($this->once())
-                 ->method('render')
-                 ->willReturn($templateContent);
+            ->method('render')
+            ->willReturn($templateContent);
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('createTemplate')
-                 ->with($templateName, [])
-                 ->willReturn($template);
+            ->method('createTemplate')
+            ->with($templateName, [])
+            ->willReturn($template);
 
         $response = self::createStub(ResponseContract::class);
 
         $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
-                            ->method('createResponse')
-                            ->with($templateContent, null, $headers)
-                            ->willReturn($response);
+            ->method('createResponse')
+            ->with($templateContent, null, $headers)
+            ->willReturn($response);
 
         $factory = new ResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, null, null, $headers);
@@ -186,22 +186,22 @@ class ResponseFactoryTest extends TestCase
 
         $template = $this->createMock(TemplateContract::class);
         $template->expects($this->once())
-                 ->method('render')
-                 ->willReturn($templateContent);
+            ->method('render')
+            ->willReturn($templateContent);
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('createTemplate')
-                 ->with($templateName, $data)
-                 ->willReturn($template);
+            ->method('createTemplate')
+            ->with($templateName, $data)
+            ->willReturn($template);
 
         $response = self::createStub(ResponseContract::class);
 
         $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
-                            ->method('createResponse')
-                            ->with($templateContent, $statusCode, $headers)
-                            ->willReturn($response);
+            ->method('createResponse')
+            ->with($templateContent, $statusCode, $headers)
+            ->willReturn($response);
 
         $factory = new ResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, $data, $statusCode, $headers);

--- a/tests/Unit/View/Renderer/TwigRendererTest.php
+++ b/tests/Unit/View/Renderer/TwigRendererTest.php
@@ -77,9 +77,9 @@ class TwigRendererTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->once())
-             ->method('render')
-             ->with($templateName, $variables)
-             ->willReturn($renderedContent);
+            ->method('render')
+            ->with($templateName, $variables)
+            ->willReturn($renderedContent);
 
         $renderer = new TwigRenderer($twig);
 
@@ -99,9 +99,9 @@ class TwigRendererTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->once())
-             ->method('render')
-             ->with($templateName, [])
-             ->willReturn($renderedContent);
+            ->method('render')
+            ->with($templateName, [])
+            ->willReturn($renderedContent);
 
         $renderer = new TwigRenderer($twig);
 
@@ -156,9 +156,9 @@ class TwigRendererTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->once())
-             ->method('render')
-             ->with($templateName, $variables)
-             ->willReturn($renderedContent);
+            ->method('render')
+            ->with($templateName, $variables)
+            ->willReturn($renderedContent);
 
         $renderer = new TwigRenderer($twig);
 
@@ -178,9 +178,9 @@ class TwigRendererTest extends TestCase
 
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->once())
-             ->method('render')
-             ->with($templateName, [])
-             ->willReturn($renderedContent);
+            ->method('render')
+            ->with($templateName, [])
+            ->willReturn($renderedContent);
 
         $renderer = new TwigRenderer($twig);
 

--- a/tests/Unit/View/Template/TemplateTest.php
+++ b/tests/Unit/View/Template/TemplateTest.php
@@ -205,8 +205,8 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->willReturn($templateContent);
+            ->method('renderFile')
+            ->willReturn($templateContent);
 
         $template = new Template($renderer, 'test');
         $template->setLayout('layouts/main');
@@ -226,8 +226,8 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->willReturn($templateContent);
+            ->method('renderFile')
+            ->willReturn($templateContent);
 
         $template = new Template($renderer, 'test');
         $template->setLayout('layouts/main');
@@ -248,8 +248,8 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->exactly(2))
-                 ->method('renderFile')
-                 ->willReturnOnConsecutiveCalls($templateContent, $layoutContent);
+            ->method('renderFile')
+            ->willReturnOnConsecutiveCalls($templateContent, $layoutContent);
 
         $template = new Template($renderer, 'test');
 
@@ -290,10 +290,10 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('startRender');
+            ->method('startRender');
         $renderer->expects($this->once())
-                 ->method('endRender')
-                 ->willReturn($blockContent);
+            ->method('endRender')
+            ->willReturn($blockContent);
 
         $template = new Template($renderer, 'test');
 
@@ -314,10 +314,10 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->exactly(2))
-                 ->method('startRender');
+            ->method('startRender');
         $renderer->expects($this->exactly(2))
-                 ->method('endRender')
-                 ->willReturnOnConsecutiveCalls($innerContent, $outerContent);
+            ->method('endRender')
+            ->willReturnOnConsecutiveCalls($innerContent, $outerContent);
 
         $template = new Template($renderer, 'test');
 
@@ -341,12 +341,12 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->with(
-                     'partials/header',
-                     self::callback(static fn ($variables) => isset($variables['template']) && $variables['template'] instanceof Template)
-                 )
-                 ->willReturn($partialContent);
+            ->method('renderFile')
+            ->with(
+                'partials/header',
+                self::callback(static fn ($variables) => isset($variables['template']) && $variables['template'] instanceof Template)
+            )
+            ->willReturn($partialContent);
 
         $template = new Template($renderer, 'test');
 
@@ -362,12 +362,12 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->with(
-                     'partials/greeting',
-                     self::callback(static fn ($variables) => $variables['name'] === 'John' && isset($variables['template']))
-                 )
-                 ->willReturn($partialContent);
+            ->method('renderFile')
+            ->with(
+                'partials/greeting',
+                self::callback(static fn ($variables) => $variables['name'] === 'John' && isset($variables['template']))
+            )
+            ->willReturn($partialContent);
 
         $template = new Template($renderer, 'test');
 
@@ -383,12 +383,12 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->with(
-                     'home',
-                     self::callback(static fn ($variables) => isset($variables['template']) && $variables['template'] instanceof Template)
-                 )
-                 ->willReturn($renderedContent);
+            ->method('renderFile')
+            ->with(
+                'home',
+                self::callback(static fn ($variables) => isset($variables['template']) && $variables['template'] instanceof Template)
+            )
+            ->willReturn($renderedContent);
 
         $template = new Template($renderer, 'home');
 
@@ -404,12 +404,12 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->with(
-                     'greeting',
-                     self::callback(static fn ($variables) => $variables['name'] === 'World' && isset($variables['template']))
-                 )
-                 ->willReturn($renderedContent);
+            ->method('renderFile')
+            ->with(
+                'greeting',
+                self::callback(static fn ($variables) => $variables['name'] === 'World' && isset($variables['template']))
+            )
+            ->willReturn($renderedContent);
 
         $template = new Template($renderer, 'greeting');
 
@@ -426,8 +426,8 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->exactly(2))
-                 ->method('renderFile')
-                 ->willReturnOnConsecutiveCalls($templateContent, $layoutContent);
+            ->method('renderFile')
+            ->willReturnOnConsecutiveCalls($templateContent, $layoutContent);
 
         $template = new Template($renderer, 'page');
         $template->setLayout('layouts/main');
@@ -444,8 +444,8 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->once())
-                 ->method('renderFile')
-                 ->willReturn($renderedContent);
+            ->method('renderFile')
+            ->willReturn($renderedContent);
 
         $template = new Template($renderer, 'test');
 
@@ -465,27 +465,27 @@ class TemplateTest extends TestCase
 
         $renderer = $this->createMock(RendererContract::class);
         $renderer->expects($this->exactly(3))
-                 ->method('renderFile')
-                 ->willReturnCallback(
-                     static function (string $path) use (
-                         &$template,
-                         $templateContent,
-                         $firstLayoutContent,
-                         $finalLayoutContent
-                     ): string {
-                         if ($path === 'page') {
-                             return $templateContent;
-                         }
+            ->method('renderFile')
+            ->willReturnCallback(
+                static function (string $path) use (
+                    &$template,
+                    $templateContent,
+                    $firstLayoutContent,
+                    $finalLayoutContent
+                ): string {
+                    if ($path === 'page') {
+                        return $templateContent;
+                    }
 
-                         if ($path === 'layouts/first') {
-                             $template->setLayout('layouts/final');
+                    if ($path === 'layouts/first') {
+                        $template->setLayout('layouts/final');
 
-                             return $firstLayoutContent;
-                         }
+                        return $firstLayoutContent;
+                    }
 
-                         return $finalLayoutContent;
-                     }
-                 );
+                    return $finalLayoutContent;
+                }
+            );
 
         $template = new Template($renderer, 'page');
         $template->setLayout('layouts/first');


### PR DESCRIPTION
# Description

Add `method_chaining_indentation` rule to phpcsfixer.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->