### PR TITLE
[Http] Move HeaderValue constant class to Http/Message from Auth

### DIFF
--- a/src/Valkyrja/Auth/Authenticator/JwtAuthenticator.php
+++ b/src/Valkyrja/Auth/Authenticator/JwtAuthenticator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Auth\Authenticator;
 
 use Valkyrja\Auth\Authenticator\Abstract\Authenticator;
-use Valkyrja\Auth\Constant\HeaderValue;
 use Valkyrja\Auth\Data\AuthenticatedUsers;
 use Valkyrja\Auth\Data\Contract\AuthenticatedUsersContract;
 use Valkyrja\Auth\Entity\Contract\UserContract;
@@ -22,6 +21,7 @@ use Valkyrja\Auth\Hasher\Contract\PasswordHasherContract;
 use Valkyrja\Auth\Store\Contract\StoreContract;
 use Valkyrja\Auth\Throwable\Exception\InvalidAuthenticationException;
 use Valkyrja\Http\Message\Constant\HeaderName;
+use Valkyrja\Http\Message\Constant\HeaderValue;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Jwt\Manager\Contract\JwtContract;
 

--- a/src/Valkyrja/Auth/Authenticator/TokenAuthenticator.php
+++ b/src/Valkyrja/Auth/Authenticator/TokenAuthenticator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Auth\Authenticator;
 
 use Valkyrja\Auth\Authenticator\Abstract\Authenticator;
-use Valkyrja\Auth\Constant\HeaderValue;
 use Valkyrja\Auth\Data\AuthenticatedUsers;
 use Valkyrja\Auth\Data\Contract\AuthenticatedUsersContract;
 use Valkyrja\Auth\Entity\Contract\UserContract;
@@ -22,6 +21,7 @@ use Valkyrja\Auth\Hasher\Contract\PasswordHasherContract;
 use Valkyrja\Auth\Store\Contract\StoreContract;
 use Valkyrja\Auth\Throwable\Exception\InvalidAuthenticationException;
 use Valkyrja\Http\Message\Constant\HeaderName;
+use Valkyrja\Http\Message\Constant\HeaderValue;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 
 /**

--- a/src/Valkyrja/Http/Message/Constant/HeaderValue.php
+++ b/src/Valkyrja/Http/Message/Constant/HeaderValue.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Auth\Constant;
+namespace Valkyrja\Http\Message\Constant;
 
 final class HeaderValue
 {

--- a/src/Valkyrja/Session/Manager/Jwt/JwtSession.php
+++ b/src/Valkyrja/Session/Manager/Jwt/JwtSession.php
@@ -14,9 +14,9 @@ declare(strict_types=1);
 namespace Valkyrja\Session\Manager\Jwt;
 
 use Override;
-use Valkyrja\Auth\Constant\HeaderValue;
 use Valkyrja\Auth\Throwable\Exception\InvalidAuthenticationException;
 use Valkyrja\Http\Message\Constant\HeaderName;
+use Valkyrja\Http\Message\Constant\HeaderValue;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Jwt\Manager\Contract\JwtContract;
 use Valkyrja\Session\Manager\Abstract\Session;

--- a/src/Valkyrja/Session/Manager/Token/TokenSession.php
+++ b/src/Valkyrja/Session/Manager/Token/TokenSession.php
@@ -15,9 +15,9 @@ namespace Valkyrja\Session\Manager\Token;
 
 use JsonException;
 use Override;
-use Valkyrja\Auth\Constant\HeaderValue;
 use Valkyrja\Auth\Throwable\Exception\InvalidAuthenticationException;
 use Valkyrja\Http\Message\Constant\HeaderName;
+use Valkyrja\Http\Message\Constant\HeaderValue;
 use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Session\Manager\Abstract\Session;
 use Valkyrja\Type\BuiltIn\Support\Arr;


### PR DESCRIPTION
# Description

Move HeaderValue constant class to Http/Message from Auth.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->