### PR TITLE
[Auth] Change SessionId to SessionItemId for better clarity

### DIFF
--- a/src/Valkyrja/Application/Env/Env.php
+++ b/src/Valkyrja/Application/Env/Env.php
@@ -20,7 +20,7 @@ use Valkyrja\Application\Provider\Provider;
 use Valkyrja\Auth\Authenticator\Contract\AuthenticatorContract;
 use Valkyrja\Auth\Authenticator\SessionAuthenticator;
 use Valkyrja\Auth\Constant\RouteName;
-use Valkyrja\Auth\Constant\SessionId;
+use Valkyrja\Auth\Constant\SessionItemId;
 use Valkyrja\Auth\Entity\Contract\UserContract;
 use Valkyrja\Auth\Entity\User;
 use Valkyrja\Auth\Store\Contract\StoreContract;
@@ -175,7 +175,7 @@ class Env
     /** @var class-string<UserContract> */
     public const string AUTH_DEFAULT_USER_ENTITY = User::class;
     /** @var non-empty-string */
-    public const string AUTH_SESSION_ITEM_ID = SessionId::AUTHENTICATED_USERS;
+    public const string AUTH_SESSION_ITEM_ID = SessionItemId::AUTHENTICATED_USERS;
     /** @var non-empty-string */
     public const string AUTH_DEFAULT_AUTHORIZATION_HEADER = HeaderName::AUTHORIZATION;
     /** @var non-empty-string */

--- a/src/Valkyrja/Auth/Authenticator/SessionAuthenticator.php
+++ b/src/Valkyrja/Auth/Authenticator/SessionAuthenticator.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Auth\Authenticator;
 
 use Valkyrja\Auth\Authenticator\Abstract\Authenticator;
-use Valkyrja\Auth\Constant\SessionId;
+use Valkyrja\Auth\Constant\SessionItemId;
 use Valkyrja\Auth\Data\AuthenticatedUsers;
 use Valkyrja\Auth\Data\Contract\AuthenticatedUsersContract;
 use Valkyrja\Auth\Entity\Contract\UserContract;
@@ -41,7 +41,7 @@ class SessionAuthenticator extends Authenticator
         PasswordHasherContract $hasher,
         string $entity,
         AuthenticatedUsersContract|null $authenticatedUsers = null,
-        protected string $sessionItemId = SessionId::AUTHENTICATED_USERS,
+        protected string $sessionItemId = SessionItemId::AUTHENTICATED_USERS,
     ) {
         parent::__construct(
             store: $store,

--- a/src/Valkyrja/Auth/Constant/SessionItemId.php
+++ b/src/Valkyrja/Auth/Constant/SessionItemId.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Valkyrja\Auth\Constant;
 
-final class SessionId
+final class SessionItemId
 {
-    public const string AUTHENTICATED_USERS          = 'authenticated.users';
+    public const string AUTHENTICATED_USERS          = 'auth.users';
     public const string PASSWORD_CONFIRMED_TIMESTAMP = 'auth.passwordConfirmedTimestamp';
 }


### PR DESCRIPTION
# Description

Change SessionId to SessionItemId for better clarity. Also changing authenticated users session item id to be better in line with route names and other session item ids.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->