### PR TITLE
[Orm] Deprecate Helpers class in favor of DateFactory

### DIFF
--- a/src/Valkyrja/Container/Manager/Trait/ProvidersAwareTrait.php
+++ b/src/Valkyrja/Container/Manager/Trait/ProvidersAwareTrait.php
@@ -77,7 +77,7 @@ trait ProvidersAwareTrait
 
         $this->providers[] = $provider;
 
-        // Helpers::validateClass($provider, Provides::class);
+        // DateFactory::validateClass($provider, Provides::class);
 
         /** @var class-string<ProviderContract> $providerClass */
         $providerClass = $provider;

--- a/src/Valkyrja/Orm/Entity/Trait/Dateable.php
+++ b/src/Valkyrja/Orm/Entity/Trait/Dateable.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Orm\Entity\Trait;
 
 use Valkyrja\Orm\Constant\DateFormat;
-use Valkyrja\Orm\Support\Helpers;
+use Valkyrja\Orm\Factory\DateFactory;
 
 trait Dateable
 {
@@ -31,7 +31,7 @@ trait Dateable
      */
     public static function getFormattedDate(): string
     {
-        return Helpers::getFormattedDate(static::getDateFormat());
+        return DateFactory::getFormattedDate(static::getDateFormat());
     }
 
     /**

--- a/src/Valkyrja/Orm/Entity/Trait/SoftDeletable.php
+++ b/src/Valkyrja/Orm/Entity/Trait/SoftDeletable.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Orm\Entity\Trait;
 
 use Valkyrja\Orm\Constant\DateFormat;
-use Valkyrja\Orm\Support\Helpers;
+use Valkyrja\Orm\Factory\DateFactory;
 
 trait SoftDeletable
 {
@@ -31,7 +31,7 @@ trait SoftDeletable
      */
     public static function getFormattedDeletedDate(): string
     {
-        return Helpers::getFormattedDate(static::getDeletedDateFormat());
+        return DateFactory::getFormattedDate(static::getDeletedDateFormat());
     }
 
     /**

--- a/src/Valkyrja/Orm/Factory/DateFactory.php
+++ b/src/Valkyrja/Orm/Factory/DateFactory.php
@@ -11,36 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Orm\Support;
+namespace Valkyrja\Orm\Factory;
 
 use DateTime;
 use Valkyrja\Orm\Constant\DateFormat;
 use Valkyrja\Orm\Throwable\Exception\RuntimeException;
 
 use function microtime;
-use function str_replace;
 
-class Helpers
+class DateFactory
 {
-    /**
-     * Get a column for a value bind.
-     *
-     * @param string $column The column
-     */
-    public static function getColumnForValueBind(string $column): string
-    {
-        return ':'
-            . str_replace(
-                [
-                    '.',
-                    ':',
-                    '-',
-                ],
-                '',
-                $column
-            );
-    }
-
     /**
      * Get the formatted date.
      *

--- a/tests/Classes/Orm/Support/DateFactoryWithFailingDateTimeClass.php
+++ b/tests/Classes/Orm/Support/DateFactoryWithFailingDateTimeClass.php
@@ -15,12 +15,12 @@ namespace Valkyrja\Tests\Classes\Orm\Support;
 
 use DateTime;
 use Override;
-use Valkyrja\Orm\Support\Helpers;
+use Valkyrja\Orm\Factory\DateFactory;
 
 /**
  * Test helper class that simulates DateTime creation failure.
  */
-class HelpersWithFailingDateTimeClass extends Helpers
+class DateFactoryWithFailingDateTimeClass extends DateFactory
 {
     /**
      * @inheritDoc

--- a/tests/Unit/Http/Routing/Support/HelpersTest.php
+++ b/tests/Unit/Http/Routing/Support/HelpersTest.php
@@ -17,7 +17,7 @@ use Valkyrja\Http\Routing\Support\Helpers;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 /**
- * Class HelpersTest.
+ * Class DateFactoryTest.
  */
 class HelpersTest extends TestCase
 {

--- a/tests/Unit/Orm/Factory/DateFactoryTest.php
+++ b/tests/Unit/Orm/Factory/DateFactoryTest.php
@@ -11,54 +11,19 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Tests\Unit\Orm\Support;
+namespace Valkyrja\Tests\Unit\Orm\Factory;
 
 use Valkyrja\Orm\Constant\DateFormat;
-use Valkyrja\Orm\Support\Helpers;
+use Valkyrja\Orm\Factory\DateFactory;
 use Valkyrja\Orm\Throwable\Exception\RuntimeException;
-use Valkyrja\Tests\Classes\Orm\Support\HelpersWithFailingDateTimeClass;
+use Valkyrja\Tests\Classes\Orm\Support\DateFactoryWithFailingDateTimeClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
-class HelpersTest extends TestCase
+class DateFactoryTest extends TestCase
 {
-    public function testGetColumnForValueBindSimpleColumn(): void
-    {
-        $result = Helpers::getColumnForValueBind('column');
-
-        self::assertSame(':column', $result);
-    }
-
-    public function testGetColumnForValueBindRemovesDots(): void
-    {
-        $result = Helpers::getColumnForValueBind('table.column');
-
-        self::assertSame(':tablecolumn', $result);
-    }
-
-    public function testGetColumnForValueBindRemovesColons(): void
-    {
-        $result = Helpers::getColumnForValueBind(':column');
-
-        self::assertSame(':column', $result);
-    }
-
-    public function testGetColumnForValueBindRemovesDashes(): void
-    {
-        $result = Helpers::getColumnForValueBind('some-column');
-
-        self::assertSame(':somecolumn', $result);
-    }
-
-    public function testGetColumnForValueBindRemovesMultipleSpecialChars(): void
-    {
-        $result = Helpers::getColumnForValueBind('table.some-column:value');
-
-        self::assertSame(':tablesomecolumnvalue', $result);
-    }
-
     public function testGetFormattedDateReturnsString(): void
     {
-        $result = Helpers::getFormattedDate();
+        $result = DateFactory::getFormattedDate();
 
         self::assertIsString($result);
         self::assertNotEmpty($result);
@@ -66,7 +31,7 @@ class HelpersTest extends TestCase
 
     public function testGetFormattedDateWithDefaultFormat(): void
     {
-        $result = Helpers::getFormattedDate();
+        $result = DateFactory::getFormattedDate();
 
         // Default format: 'm-d-Y H:i:s T'
         // Should match pattern like: 01-26-2026 12:30:45 UTC
@@ -75,7 +40,7 @@ class HelpersTest extends TestCase
 
     public function testGetFormattedDateWithMillisecondFormat(): void
     {
-        $result = Helpers::getFormattedDate(DateFormat::MILLISECOND);
+        $result = DateFactory::getFormattedDate(DateFormat::MILLISECOND);
 
         // Millisecond format: 'm-d-Y H:i:s.v T'
         // Should contain milliseconds
@@ -84,7 +49,7 @@ class HelpersTest extends TestCase
 
     public function testGetFormattedDateWithMicrosecondFormat(): void
     {
-        $result = Helpers::getFormattedDate(DateFormat::MICROSECOND);
+        $result = DateFactory::getFormattedDate(DateFormat::MICROSECOND);
 
         // Microsecond format: 'm-d-Y H:i:s.u T'
         // Should contain microseconds
@@ -93,7 +58,7 @@ class HelpersTest extends TestCase
 
     public function testGetFormattedDateWithCustomFormat(): void
     {
-        $result = Helpers::getFormattedDate('Y-m-d');
+        $result = DateFactory::getFormattedDate('Y-m-d');
 
         // Should match YYYY-MM-DD format
         self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $result);
@@ -104,6 +69,6 @@ class HelpersTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Failure occurred when creating a new DateTime object for current microtime.');
 
-        HelpersWithFailingDateTimeClass::getFormattedDate();
+        DateFactoryWithFailingDateTimeClass::getFormattedDate();
     }
 }


### PR DESCRIPTION
# Description

Deprecate Helpers class in favor of DateFactory.
Also removing unused method `getColumnForValueBind`  from Helpers class.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->