### PR TITLE
[Cli] Use OptionName instead of other constants

### DIFF
--- a/src/Valkyrja/Application/Env/Env.php
+++ b/src/Valkyrja/Application/Env/Env.php
@@ -35,8 +35,8 @@ use Valkyrja\Cli\Middleware\Contract\RouteDispatchedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\RouteMatchedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\RouteNotMatchedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\ThrowableCaughtMiddlewareContract;
-use Valkyrja\Cli\Routing\Data\Option\HelpOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\VersionOptionParameter;
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Middleware\RouteNotMatched\CheckCommandForTypoMiddleware;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
@@ -241,15 +241,15 @@ class Env
     /** @var non-empty-string */
     public const string CLI_HELP_COMMAND_NAME = HelpCommand::NAME;
     /** @var non-empty-string */
-    public const string CLI_HELP_OPTION_NAME = HelpOptionParameter::NAME;
+    public const string CLI_HELP_OPTION_NAME = OptionName::HELP;
     /** @var non-empty-string */
-    public const string CLI_HELP_OPTION_SHORT_NAME = HelpOptionParameter::SHORT_NAME;
+    public const string CLI_HELP_OPTION_SHORT_NAME = OptionShortName::HELP;
     /** @var non-empty-string */
     public const string CLI_VERSION_COMMAND_NAME = VersionCommand::NAME;
     /** @var non-empty-string */
-    public const string CLI_VERSION_OPTION_NAME = VersionOptionParameter::NAME;
+    public const string CLI_VERSION_OPTION_NAME = OptionName::VERSION;
     /** @var non-empty-string */
-    public const string CLI_VERSION_OPTION_SHORT_NAME = VersionOptionParameter::SHORT_NAME;
+    public const string CLI_VERSION_OPTION_SHORT_NAME = OptionShortName::VERSION;
 
     /************************************************************
      *

--- a/src/Valkyrja/Cli/Routing/Constant/OptionShortName.php
+++ b/src/Valkyrja/Cli/Routing/Constant/OptionShortName.php
@@ -13,18 +13,18 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Constant;
 
-final class OptionName
+final class OptionShortName
 {
     /** @var non-empty-string */
-    public const string HELP = 'help';
+    public const string HELP = 'h';
     /** @var non-empty-string */
-    public const string VERSION = 'version';
+    public const string VERSION = 'v';
     /** @var non-empty-string */
-    public const string QUIET = 'quiet';
+    public const string QUIET = 'q';
     /** @var non-empty-string */
-    public const string SILENT = 'silent';
+    public const string SILENT = 's';
     /** @var non-empty-string */
-    public const string NO_INTERACTION = 'no-interaction';
+    public const string NO_INTERACTION = 'N';
     /** @var non-empty-string */
-    public const string TOKEN = 'token';
+    public const string TOKEN = 't';
 }

--- a/src/Valkyrja/Cli/Routing/Data/Option/HelpOptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/Option/HelpOptionParameter.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Data\Option;
 
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 
 class HelpOptionParameter extends OptionParameter
 {
-    public const string NAME       = 'help';
-    public const string SHORT_NAME = 'h';
-
     public function __construct()
     {
         parent::__construct(
-            name: self::NAME,
+            name: OptionName::HELP,
             description: 'Help with this command',
-            shortNames: [self::SHORT_NAME],
+            shortNames: [OptionShortName::HELP],
             valueMode: OptionValueMode::NONE
         );
     }

--- a/src/Valkyrja/Cli/Routing/Data/Option/NoInteractionOptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/Option/NoInteractionOptionParameter.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Data\Option;
 
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 
 class NoInteractionOptionParameter extends OptionParameter
 {
-    public const string NAME       = 'no-interaction';
-    public const string SHORT_NAME = 'N';
-
     public function __construct()
     {
         parent::__construct(
-            name: self::NAME,
+            name: OptionName::NO_INTERACTION,
             description: 'No interactive questions are asked.',
-            shortNames: [self::SHORT_NAME],
+            shortNames: [OptionShortName::NO_INTERACTION],
             valueMode: OptionValueMode::NONE
         );
     }

--- a/src/Valkyrja/Cli/Routing/Data/Option/QuietOptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/Option/QuietOptionParameter.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Data\Option;
 
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 
 class QuietOptionParameter extends OptionParameter
 {
-    public const string NAME       = 'quiet';
-    public const string SHORT_NAME = 'q';
-
     public function __construct()
     {
         parent::__construct(
-            name: self::NAME,
+            name: OptionName::QUIET,
             description: 'Output is suppressed, except for errors.',
-            shortNames: [self::SHORT_NAME],
+            shortNames: [OptionShortName::QUIET],
             valueMode: OptionValueMode::NONE
         );
     }

--- a/src/Valkyrja/Cli/Routing/Data/Option/SilentOptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/Option/SilentOptionParameter.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Data\Option;
 
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 
 class SilentOptionParameter extends OptionParameter
 {
-    public const string NAME       = 'silent';
-    public const string SHORT_NAME = 's';
-
     public function __construct()
     {
         parent::__construct(
-            name: self::NAME,
+            name: OptionName::SILENT,
             description: 'All output is suppressed',
-            shortNames: [self::SHORT_NAME],
+            shortNames: [OptionShortName::SILENT],
             valueMode: OptionValueMode::NONE
         );
     }

--- a/src/Valkyrja/Cli/Routing/Data/Option/VersionOptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/Option/VersionOptionParameter.php
@@ -13,20 +13,19 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Routing\Data\Option;
 
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 
 class VersionOptionParameter extends OptionParameter
 {
-    public const string NAME       = 'version';
-    public const string SHORT_NAME = 'v';
-
     public function __construct()
     {
         parent::__construct(
-            name: self::NAME,
+            name: OptionName::VERSION,
             description: 'Application version',
-            shortNames: [self::SHORT_NAME],
+            shortNames: [OptionShortName::VERSION],
             valueMode: OptionValueMode::NONE
         );
     }

--- a/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
@@ -21,10 +21,9 @@ use Valkyrja\Cli\Middleware\Handler\Contract\ExitedHandlerContract;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 use Valkyrja\Cli\Middleware\Handler\Contract\ThrowableCaughtHandlerContract;
 use Valkyrja\Cli\Routing\Collection\Collection;
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
-use Valkyrja\Cli\Routing\Data\Option\NoInteractionOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\QuietOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\SilentOptionParameter;
 use Valkyrja\Cli\Routing\Dispatcher\Contract\RouterContract;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
@@ -244,12 +243,12 @@ final class ServiceProvider extends Provider
             CheckGlobalInteractionOptionsMiddleware::class,
             new CheckGlobalInteractionOptionsMiddleware(
                 config: $container->getSingleton(Config::class),
-                noInteractionOptionName: NoInteractionOptionParameter::NAME,
-                noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-                quietOptionName: QuietOptionParameter::NAME,
-                quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-                silentOptionName: SilentOptionParameter::NAME,
-                silentOptionShortName: SilentOptionParameter::SHORT_NAME
+                noInteractionOptionName: OptionName::NO_INTERACTION,
+                noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+                quietOptionName: OptionName::QUIET,
+                quietOptionShortName: OptionShortName::QUIET,
+                silentOptionName: OptionName::SILENT,
+                silentOptionShortName: OptionShortName::SILENT
             )
         );
     }

--- a/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
@@ -16,7 +16,8 @@ namespace Valkyrja\Tests\Unit\Cli\Server\Middleware\InputReceived;
 use Valkyrja\Cli\Interaction\Input\Input;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
-use Valkyrja\Cli\Routing\Data\Option\HelpOptionParameter;
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -35,8 +36,8 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForHelpOptionsMiddleware(
             commandName: HelpCommand::NAME,
-            optionName: HelpOptionParameter::NAME,
-            optionShortName: HelpOptionParameter::SHORT_NAME,
+            optionName: OptionName::HELP,
+            optionShortName: OptionShortName::HELP,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -46,7 +47,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
     public function testWithHelpOption(): void
     {
-        $input   = new Input()->withOptions(new Option(name: HelpOptionParameter::NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionName::HELP));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -55,8 +56,8 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForHelpOptionsMiddleware(
             commandName: HelpCommand::NAME,
-            optionName: HelpOptionParameter::NAME,
-            optionShortName: HelpOptionParameter::SHORT_NAME,
+            optionName: OptionName::HELP,
+            optionShortName: OptionShortName::HELP,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -70,7 +71,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
     public function testWithHelpShortOption(): void
     {
-        $input   = new Input()->withOptions(new Option(name: HelpOptionParameter::SHORT_NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionShortName::HELP));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -79,8 +80,8 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForHelpOptionsMiddleware(
             commandName: HelpCommand::NAME,
-            optionName: HelpOptionParameter::NAME,
-            optionShortName: HelpOptionParameter::SHORT_NAME,
+            optionName: OptionName::HELP,
+            optionShortName: OptionShortName::HELP,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);

--- a/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
@@ -16,7 +16,8 @@ namespace Valkyrja\Tests\Unit\Cli\Server\Middleware\InputReceived;
 use Valkyrja\Cli\Interaction\Input\Input;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
-use Valkyrja\Cli\Routing\Data\Option\VersionOptionParameter;
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForVersionOptionsMiddleware;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -35,8 +36,8 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForVersionOptionsMiddleware(
             commandName: VersionCommand::NAME,
-            optionName: VersionOptionParameter::NAME,
-            optionShortName: VersionOptionParameter::SHORT_NAME,
+            optionName: OptionName::VERSION,
+            optionShortName: OptionShortName::VERSION,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -46,7 +47,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
     public function testWithVersionOption(): void
     {
-        $input   = new Input()->withOptions(new Option(name: VersionOptionParameter::NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionName::VERSION));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -55,8 +56,8 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForVersionOptionsMiddleware(
             commandName: VersionCommand::NAME,
-            optionName: VersionOptionParameter::NAME,
-            optionShortName: VersionOptionParameter::SHORT_NAME,
+            optionName: OptionName::VERSION,
+            optionShortName: OptionShortName::VERSION,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -68,7 +69,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
     public function testWithVersionShortOption(): void
     {
-        $input   = new Input()->withOptions(new Option(name: VersionOptionParameter::SHORT_NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionShortName::VERSION));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -77,8 +78,8 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckForVersionOptionsMiddleware(
             commandName: VersionCommand::NAME,
-            optionName: VersionOptionParameter::NAME,
-            optionShortName: VersionOptionParameter::SHORT_NAME,
+            optionName: OptionName::VERSION,
+            optionShortName: OptionShortName::VERSION,
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);

--- a/tests/Unit/Cli/Server/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/InputReceived/CheckGlobalInteractionOptionsMiddlewareTest.php
@@ -17,9 +17,8 @@ use Valkyrja\Cli\Interaction\Data\Config;
 use Valkyrja\Cli\Interaction\Input\Input;
 use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
-use Valkyrja\Cli\Routing\Data\Option\NoInteractionOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\QuietOptionParameter;
-use Valkyrja\Cli\Routing\Data\Option\SilentOptionParameter;
+use Valkyrja\Cli\Routing\Constant\OptionName;
+use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckGlobalInteractionOptionsMiddleware;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -38,12 +37,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -57,7 +56,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithNoInteractionOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: NoInteractionOptionParameter::NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionName::NO_INTERACTION));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -67,12 +66,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -86,7 +85,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithNoInteractionShortOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: NoInteractionOptionParameter::SHORT_NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionShortName::NO_INTERACTION));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -96,12 +95,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -115,7 +114,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithQuietOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: QuietOptionParameter::NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionName::QUIET));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -125,12 +124,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -144,7 +143,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithQuietShortOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: QuietOptionParameter::SHORT_NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionShortName::QUIET));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -154,12 +153,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -173,7 +172,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithSilentOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: SilentOptionParameter::NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionName::SILENT));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -183,12 +182,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -202,7 +201,7 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     public function testWithSilentShortOption(): void
     {
         $config  = new Config();
-        $input   = new Input()->withOptions(new Option(name: SilentOptionParameter::SHORT_NAME));
+        $input   = new Input()->withOptions(new Option(name: OptionShortName::SILENT));
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
             ->expects($this->once())
@@ -212,12 +211,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -232,9 +231,9 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     {
         $config  = new Config();
         $input   = new Input()->withOptions(
-            new Option(name: NoInteractionOptionParameter::NAME),
-            new Option(name: QuietOptionParameter::NAME),
-            new Option(name: SilentOptionParameter::NAME),
+            new Option(name: OptionName::NO_INTERACTION),
+            new Option(name: OptionName::QUIET),
+            new Option(name: OptionName::SILENT),
         );
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -245,12 +244,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
@@ -265,9 +264,9 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
     {
         $config  = new Config();
         $input   = new Input()->withOptions(
-            new Option(name: NoInteractionOptionParameter::SHORT_NAME),
-            new Option(name: QuietOptionParameter::SHORT_NAME),
-            new Option(name: SilentOptionParameter::SHORT_NAME),
+            new Option(name: OptionShortName::NO_INTERACTION),
+            new Option(name: OptionShortName::QUIET),
+            new Option(name: OptionShortName::SILENT),
         );
         $handler = $this->createMock(InputReceivedHandlerContract::class);
         $handler
@@ -278,12 +277,12 @@ class CheckGlobalInteractionOptionsMiddlewareTest extends TestCase
 
         $middleware = new CheckGlobalInteractionOptionsMiddleware(
             config: $config,
-            noInteractionOptionName: NoInteractionOptionParameter::NAME,
-            noInteractionOptionShortName: NoInteractionOptionParameter::SHORT_NAME,
-            quietOptionName: QuietOptionParameter::NAME,
-            quietOptionShortName: QuietOptionParameter::SHORT_NAME,
-            silentOptionName: SilentOptionParameter::NAME,
-            silentOptionShortName: SilentOptionParameter::SHORT_NAME
+            noInteractionOptionName: OptionName::NO_INTERACTION,
+            noInteractionOptionShortName: OptionShortName::NO_INTERACTION,
+            quietOptionName: OptionName::QUIET,
+            quietOptionShortName: OptionShortName::QUIET,
+            silentOptionName: OptionName::SILENT,
+            silentOptionShortName: OptionShortName::SILENT
         );
 
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);


### PR DESCRIPTION
# Description

Use OptionName instead of other constants. Add OptionShortName constant.

Gets rid of other constants, so breaking change.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->