### PR TITLE
[Auth] Add allowed classes for session authenticator

### DIFF
--- a/src/Valkyrja/Application/Env/Env.php
+++ b/src/Valkyrja/Application/Env/Env.php
@@ -17,6 +17,7 @@ use Twig\Extension\ExtensionInterface;
 use Valkyrja\Application\Constant\ComponentClass;
 use Valkyrja\Application\Provider\Provider;
 use Valkyrja\Auth\Authenticator\Contract\AuthenticatorContract;
+use Valkyrja\Auth\Data\Contract\AuthenticatedUsersContract;
 use Valkyrja\Auth\Entity\Contract\UserContract;
 use Valkyrja\Auth\Store\Contract\StoreContract;
 use Valkyrja\Broadcast\Broadcaster\Contract\BroadcasterContract;
@@ -139,6 +140,8 @@ class Env
     public const string|null AUTH_DEFAULT_USER_ENTITY = null;
     /** @var non-empty-string|null */
     public const string|null AUTH_SESSION_ITEM_ID = null;
+    /** @var class-string<AuthenticatedUsersContract>[]|null */
+    public const array|null AUTH_SESSION_ALLOWED_CLASSES = null;
 
     /************************************************************
      *

--- a/src/Valkyrja/Auth/Authenticator/SessionAuthenticator.php
+++ b/src/Valkyrja/Auth/Authenticator/SessionAuthenticator.php
@@ -32,8 +32,9 @@ use function is_string;
 class SessionAuthenticator extends Authenticator
 {
     /**
-     * @param StoreContract<U> $store  The store
-     * @param class-string<U>  $entity The user entity
+     * @param StoreContract<U>                           $store          The store
+     * @param class-string<U>                            $entity         The user entity
+     * @param class-string<AuthenticatedUsersContract>[] $allowedClasses The allowed authenticated users classes
      */
     public function __construct(
         protected SessionContract $session,
@@ -42,6 +43,7 @@ class SessionAuthenticator extends Authenticator
         string $entity,
         AuthenticatedUsersContract|null $authenticatedUsers = null,
         protected string $sessionItemId = SessionItemId::AUTHENTICATED_USERS,
+        protected array $allowedClasses = [AuthenticatedUsers::class],
     ) {
         parent::__construct(
             store: $store,
@@ -68,7 +70,7 @@ class SessionAuthenticator extends Authenticator
         /** @var mixed $sessionUsers */
         $sessionUsers = unserialize(
             $sessionSerializedUsers,
-            ['allowed_classes' => true]
+            ['allowed_classes' => $this->allowedClasses]
         );
 
         if (! $sessionUsers instanceof AuthenticatedUsersContract) {

--- a/src/Valkyrja/Auth/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Auth/Provider/ServiceProvider.php
@@ -18,6 +18,8 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Auth\Authenticator\Contract\AuthenticatorContract;
 use Valkyrja\Auth\Authenticator\SessionAuthenticator;
 use Valkyrja\Auth\Constant\SessionItemId;
+use Valkyrja\Auth\Data\AuthenticatedUsers;
+use Valkyrja\Auth\Data\Contract\AuthenticatedUsersContract;
 use Valkyrja\Auth\Entity\Contract\UserContract;
 use Valkyrja\Auth\Entity\User;
 use Valkyrja\Auth\Hasher\Contract\PasswordHasherContract;
@@ -95,6 +97,9 @@ final class ServiceProvider extends Provider
         /** @var non-empty-string $sessionItemId */
         $sessionItemId = $env::AUTH_SESSION_ITEM_ID
             ?? SessionItemId::AUTHENTICATED_USERS;
+        /** @var class-string<AuthenticatedUsersContract>[] $allowedClasses */
+        $allowedClasses = $env::AUTH_SESSION_ALLOWED_CLASSES
+            ?? [AuthenticatedUsers::class];
 
         $container->setSingleton(
             SessionAuthenticator::class,
@@ -104,6 +109,7 @@ final class ServiceProvider extends Provider
                 hasher: $container->getSingleton(PasswordHasherContract::class),
                 entity: $entity,
                 sessionItemId: $sessionItemId,
+                allowedClasses: $allowedClasses
             ),
         );
     }


### PR DESCRIPTION
# Description

Add allowed classes for session authenticator.

Leaving allowed_classes as true allows any class to be created, which can allow for unintentional behavior if a serialized string contains an unexpected class with unexpected constructor behavior.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->