### PR TITLE
[Http] Do not cache 5xx status code responses

### DIFF
--- a/src/Valkyrja/Http/Middleware/Cache/CacheResponseMiddleware.php
+++ b/src/Valkyrja/Http/Middleware/Cache/CacheResponseMiddleware.php
@@ -105,6 +105,10 @@ class CacheResponseMiddleware implements RequestReceivedMiddlewareContract, Term
     #[Override]
     public function terminated(ServerRequestContract $request, ResponseContract $response, TerminatedHandlerContract $handler): void
     {
+        if ($response->getStatusCode()->value >= StatusCode::INTERNAL_SERVER_ERROR->value) {
+            return;
+        }
+
         $this->filesystem->write(
             $this->getCachePathForRequest($request),
             base64_encode(serialize($response))


### PR DESCRIPTION
# Description

Do not cache 5xx status code responses.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->