### PR TITLE
[Cli] Move command name constants from commands to new Constant class

### DIFF
--- a/src/Valkyrja/Application/Entry/Cli.php
+++ b/src/Valkyrja/Application/Entry/Cli.php
@@ -18,7 +18,7 @@ use Valkyrja\Application\Entry\Abstract\App;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Factory\InputFactory;
 use Valkyrja\Cli\Interaction\Input\Contract\InputContract;
-use Valkyrja\Cli\Server\Command\ListCommand;
+use Valkyrja\Cli\Server\Constant\CommandName;
 use Valkyrja\Cli\Server\Handler\Contract\InputHandlerContract;
 
 class Cli extends App
@@ -50,7 +50,7 @@ class Cli extends App
     {
         /** @var non-empty-string $commandName */
         $commandName = $env::APP_CLI_DEFAULT_COMMAND_NAME
-            ?? ListCommand::NAME;
+            ?? CommandName::LIST;
 
         $input = InputFactory::fromGlobals(
             commandName: $commandName

--- a/src/Valkyrja/Cli/Server/Command/HelpCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/HelpCommand.php
@@ -40,13 +40,12 @@ use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
 use Valkyrja\Cli\Routing\Enum\OptionMode;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
+use Valkyrja\Cli\Server\Constant\CommandName;
 
 use function is_string;
 
 class HelpCommand
 {
-    public const string NAME = 'help';
-
     protected RouteContract $helpRoute;
 
     public function __construct(
@@ -58,7 +57,7 @@ class HelpCommand
     }
 
     #[Route(
-        name: self::NAME,
+        name: CommandName::HELP,
         description: 'Help for a command',
         helpText: new Message('A command to get help for a specific command.'),
         parameters: [

--- a/src/Valkyrja/Cli/Server/Command/ListBashCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/ListBashCommand.php
@@ -20,13 +20,12 @@ use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Cli\Routing\Data\ArgumentParameter;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+use Valkyrja\Cli\Server\Constant\CommandName;
 
 use function is_string;
 
 class ListBashCommand
 {
-    public const string NAME = 'list:bash';
-
     public function __construct(
         protected RouteContract $route,
         protected CollectionContract $collection,
@@ -35,7 +34,7 @@ class ListBashCommand
     }
 
     #[Route(
-        name: self::NAME,
+        name: CommandName::LIST_BASH,
         description: 'List all commands for bash completion',
         helpText: new Message('A command to list all the commands present within the Cli component for bash completion.'),
         parameters: [

--- a/src/Valkyrja/Cli/Server/Command/ListCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/ListCommand.php
@@ -28,13 +28,12 @@ use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
+use Valkyrja\Cli\Server\Constant\CommandName;
 
 use function is_string;
 
 class ListCommand
 {
-    public const string NAME = 'list';
-
     public function __construct(
         protected VersionCommand $version,
         protected RouteContract $route,
@@ -44,7 +43,7 @@ class ListCommand
     }
 
     #[Route(
-        name: self::NAME,
+        name: CommandName::LIST,
         description: 'List all commands',
         helpText: new Message('A command to list all the commands present within the Cli component.'),
         parameters: [

--- a/src/Valkyrja/Cli/Server/Command/VersionCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/VersionCommand.php
@@ -22,20 +22,19 @@ use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
+use Valkyrja\Cli\Server\Constant\CommandName;
 
 use const PHP_VERSION;
 
 class VersionCommand
 {
-    public const string NAME = 'version';
-
     public function __construct(
         protected OutputFactoryContract $outputFactory
     ) {
     }
 
     #[Route(
-        name: self::NAME,
+        name: CommandName::VERSION,
         description: 'Get the application version',
         helpText: new Message('A command to show the application version and info'),
     )]

--- a/src/Valkyrja/Cli/Server/Constant/CommandName.php
+++ b/src/Valkyrja/Cli/Server/Constant/CommandName.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Cli\Server\Constant;
+
+final class CommandName
+{
+    /** @var non-empty-string */
+    public const string HELP = 'help';
+    /** @var non-empty-string */
+    public const string LIST = 'list';
+    /** @var non-empty-string */
+    public const string LIST_BASH = 'list:bash';
+    /** @var non-empty-string */
+    public const string VERSION = 'version';
+}

--- a/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
@@ -29,6 +29,7 @@ use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
 use Valkyrja\Cli\Server\Command\VersionCommand;
+use Valkyrja\Cli\Server\Constant\CommandName;
 use Valkyrja\Cli\Server\Handler\Contract\InputHandlerContract;
 use Valkyrja\Cli\Server\Handler\InputHandler;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
@@ -195,7 +196,7 @@ final class ServiceProvider extends Provider
 
         /** @var non-empty-string $commandName */
         $commandName = $env::CLI_HELP_COMMAND_NAME
-            ?? HelpCommand::NAME;
+            ?? CommandName::HELP;
         /** @var non-empty-string $name */
         $name = $env::CLI_HELP_OPTION_NAME
             ?? OptionName::HELP;
@@ -222,7 +223,7 @@ final class ServiceProvider extends Provider
 
         /** @var non-empty-string $commandName */
         $commandName = $env::CLI_VERSION_COMMAND_NAME
-            ?? VersionCommand::NAME;
+            ?? CommandName::VERSION;
         /** @var non-empty-string $name */
         $name = $env::CLI_VERSION_OPTION_NAME
             ?? OptionName::VERSION;

--- a/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForHelpOptionsMiddlewareTest.php
@@ -18,7 +18,7 @@ use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 use Valkyrja\Cli\Routing\Constant\OptionName;
 use Valkyrja\Cli\Routing\Constant\OptionShortName;
-use Valkyrja\Cli\Server\Command\HelpCommand;
+use Valkyrja\Cli\Server\Constant\CommandName;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -35,7 +35,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->willReturn($input);
 
         $middleware = new CheckForHelpOptionsMiddleware(
-            commandName: HelpCommand::NAME,
+            commandName: CommandName::HELP,
             optionName: OptionName::HELP,
             optionShortName: OptionShortName::HELP,
         );
@@ -55,7 +55,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->willReturnArgument(0);
 
         $middleware = new CheckForHelpOptionsMiddleware(
-            commandName: HelpCommand::NAME,
+            commandName: CommandName::HELP,
             optionName: OptionName::HELP,
             optionShortName: OptionShortName::HELP,
         );
@@ -63,7 +63,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame(HelpCommand::NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(CommandName::HELP, $inputAfterMiddleware->getCommandName());
         self::assertNotEmpty($inputAfterMiddleware->getOptions());
         self::assertSame('command', $inputAfterMiddleware->getOptions()[0]->getName());
         self::assertSame($input->getCommandName(), $inputAfterMiddleware->getOptions()[0]->getValue());
@@ -79,7 +79,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
             ->willReturnArgument(0);
 
         $middleware = new CheckForHelpOptionsMiddleware(
-            commandName: HelpCommand::NAME,
+            commandName: CommandName::HELP,
             optionName: OptionName::HELP,
             optionShortName: OptionShortName::HELP,
         );
@@ -87,7 +87,7 @@ class CheckForHelpOptionsMiddlewareTest extends TestCase
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame(HelpCommand::NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(CommandName::HELP, $inputAfterMiddleware->getCommandName());
         self::assertNotEmpty($inputAfterMiddleware->getOptions());
         self::assertSame('command', $inputAfterMiddleware->getOptions()[0]->getName());
         self::assertSame($input->getCommandName(), $inputAfterMiddleware->getOptions()[0]->getValue());

--- a/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
+++ b/tests/Unit/Cli/Server/Middleware/InputReceived/CheckForVersionOptionsMiddlewareTest.php
@@ -18,7 +18,7 @@ use Valkyrja\Cli\Interaction\Option\Option;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
 use Valkyrja\Cli\Routing\Constant\OptionName;
 use Valkyrja\Cli\Routing\Constant\OptionShortName;
-use Valkyrja\Cli\Server\Command\VersionCommand;
+use Valkyrja\Cli\Server\Constant\CommandName;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForVersionOptionsMiddleware;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -35,7 +35,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->willReturn($input);
 
         $middleware = new CheckForVersionOptionsMiddleware(
-            commandName: VersionCommand::NAME,
+            commandName: CommandName::VERSION,
             optionName: OptionName::VERSION,
             optionShortName: OptionShortName::VERSION,
         );
@@ -55,7 +55,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->willReturnArgument(0);
 
         $middleware = new CheckForVersionOptionsMiddleware(
-            commandName: VersionCommand::NAME,
+            commandName: CommandName::VERSION,
             optionName: OptionName::VERSION,
             optionShortName: OptionShortName::VERSION,
         );
@@ -63,7 +63,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame(VersionCommand::NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(CommandName::VERSION, $inputAfterMiddleware->getCommandName());
         self::assertEmpty($inputAfterMiddleware->getOptions());
     }
 
@@ -77,7 +77,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
             ->willReturnArgument(0);
 
         $middleware = new CheckForVersionOptionsMiddleware(
-            commandName: VersionCommand::NAME,
+            commandName: CommandName::VERSION,
             optionName: OptionName::VERSION,
             optionShortName: OptionShortName::VERSION,
         );
@@ -85,7 +85,7 @@ class CheckForVersionOptionsMiddlewareTest extends TestCase
         $inputAfterMiddleware = $middleware->inputReceived($input, $handler);
 
         self::assertNotSame($input, $inputAfterMiddleware);
-        self::assertSame(VersionCommand::NAME, $inputAfterMiddleware->getCommandName());
+        self::assertSame(CommandName::VERSION, $inputAfterMiddleware->getCommandName());
         self::assertEmpty($inputAfterMiddleware->getOptions());
     }
 }


### PR DESCRIPTION
# Description

Move command name constants from commands to new Constant class.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->