### PR TITLE
[Application] Remove application component from required

### DIFF
--- a/src/Valkyrja/Application/Env/Env.php
+++ b/src/Valkyrja/Application/Env/Env.php
@@ -76,7 +76,6 @@ class Env
     public const string APP_KEY = 'some_secret_app_key';
     /** @var class-string<Provider>[] */
     public const array APP_REQUIRED_COMPONENTS = [
-        ComponentClass::APPLICATION,
         ComponentClass::ATTRIBUTE,
         ComponentClass::CONTAINER,
         ComponentClass::DISPATCHER,

--- a/tests/Unit/Application/Entry/Abstract/AppTest.php
+++ b/tests/Unit/Application/Entry/Abstract/AppTest.php
@@ -14,8 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Application\Entry\Abstract;
 
 use Override;
-use Valkyrja\Application\Cli\Command\CacheCommand;
-use Valkyrja\Application\Cli\Command\ClearCacheCommand;
 use Valkyrja\Application\Entry\Abstract\App;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
@@ -221,8 +219,6 @@ class AppTest extends TestCase
 
         $commands = $application->getCliControllers();
 
-        self::assertContains(CacheCommand::class, $commands);
-        self::assertContains(ClearCacheCommand::class, $commands);
         self::assertContains(HelpCommand::class, $commands);
         self::assertContains(ListBashCommand::class, $commands);
         self::assertContains(CliListCommand::class, $commands);


### PR DESCRIPTION
# Description

Remove application component from required.

After all the main components' caches have been reworked the config:cache commands do nothing. They also shouldn't be in an application by default in any case, and should be added only if the dev needs them.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->