### PR TITLE
[Http] Remove the http:list command from component provider.

### DIFF
--- a/src/Valkyrja/Http/Routing/Provider/ComponentProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/ComponentProvider.php
@@ -15,7 +15,6 @@ namespace Valkyrja\Http\Routing\Provider;
 
 use Override;
 use Valkyrja\Application\Provider\Provider;
-use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 
 class ComponentProvider extends Provider
 {
@@ -27,17 +26,6 @@ class ComponentProvider extends Provider
     {
         return [
             ServiceProvider::class,
-        ];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public static function getCliControllers(): array
-    {
-        return [
-            ListCommand::class,
         ];
     }
 }

--- a/tests/Unit/Application/Entry/Abstract/AppTest.php
+++ b/tests/Unit/Application/Entry/Abstract/AppTest.php
@@ -51,7 +51,6 @@ use Valkyrja\Http\Middleware\Handler\Contract\RouteNotMatchedHandlerContract as 
 use Valkyrja\Http\Middleware\Handler\Contract\SendingResponseHandlerContract;
 use Valkyrja\Http\Middleware\Handler\Contract\TerminatedHandlerContract;
 use Valkyrja\Http\Middleware\Handler\Contract\ThrowableCaughtHandlerContract as HttpThrowableCaughtHandler;
-use Valkyrja\Http\Routing\Cli\Command\ListCommand as HttpListCommand;
 use Valkyrja\Http\Routing\Collection\Contract\CollectionContract as HttpRoutingCollection;
 use Valkyrja\Http\Routing\Collector\Contract\CollectorContract;
 use Valkyrja\Http\Routing\Data\Data as HttpData;
@@ -223,7 +222,6 @@ class AppTest extends TestCase
         self::assertContains(ListBashCommand::class, $commands);
         self::assertContains(CliListCommand::class, $commands);
         self::assertContains(VersionCommand::class, $commands);
-        self::assertContains(HttpListCommand::class, $commands);
 
         self::assertEmpty($application->getEventListeners());
         self::assertEmpty($application->getHttpControllers());

--- a/tests/Unit/Http/Routing/Provider/ComponentProviderTest.php
+++ b/tests/Unit/Http/Routing/Provider/ComponentProviderTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Provider;
 
-use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 use Valkyrja\Http\Routing\Provider\ComponentProvider;
 use Valkyrja\Http\Routing\Provider\ServiceProvider;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -26,10 +25,5 @@ class ComponentProviderTest extends TestCase
     public function testGetContainerProvider(): void
     {
         self::assertContains(ServiceProvider::class, ComponentProvider::getContainerProviders());
-    }
-
-    public function testGetCliControllers(): void
-    {
-        self::assertContains(ListCommand::class, ComponentProvider::getCliControllers());
     }
 }


### PR DESCRIPTION
# Description

Remove the http:list command from component provider.

Not all applications will have an http component, or a cli component, etc. So let's not add the command if it's not actually needed.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->