### PR TITLE
[Http] Removing need for __set_state in DataFileGenerator

### DIFF
--- a/src/Valkyrja/Http/Routing/Data/Parameter.php
+++ b/src/Valkyrja/Http/Routing/Data/Parameter.php
@@ -37,22 +37,6 @@ class Parameter implements ParameterContract
     }
 
     /**
-     * @param array{
-     *     name: non-empty-string,
-     *     regex: non-empty-string,
-     *     cast: Cast|null,
-     *     isOptional: bool,
-     *     shouldCapture: bool,
-     *     default: array<scalar|object>|scalar|object|null,
-     *     value: array<scalar|object>|scalar|object|null,
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Http/Routing/Data/Route.php
+++ b/src/Valkyrja/Http/Routing/Data/Route.php
@@ -62,28 +62,6 @@ class Route implements RouteContract
     }
 
     /**
-     * @param array{
-     *     path: non-empty-string,
-     *     name: non-empty-string,
-     *     dispatch: MethodDispatchContract,
-     *     requestMethods: RequestMethod[],
-     *     regex: non-empty-string|null,
-     *     parameters: ParameterContract[],
-     *     routeMatchedMiddleware: class-string<RouteMatchedMiddlewareContract>[],
-     *     routeDispatchedMiddleware: class-string<RouteDispatchedMiddlewareContract>[],
-     *     throwableCaughtMiddleware: class-string<ThrowableCaughtMiddlewareContract>[],
-     *     sendingResponseMiddleware: class-string<SendingResponseMiddlewareContract>[],
-     *     terminatedMiddleware: class-string<TerminatedMiddlewareContract>[],
-     *     requestStruct: class-string<RequestStructContract>|null,
-     *     responseStruct: class-string<ResponseStructContract>|null,
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Http/Routing/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Http/Routing/Generator/DataFileGenerator.php
@@ -102,11 +102,12 @@ class DataFileGenerator extends FileGenerator implements DataFileGeneratorContra
 
     protected function getRouteAsContent(RouteContract $route): string
     {
-        $routeContract = RouteContract::class;
-        $routeContent  = var_export($route, true);
+        $contract = RouteContract::class;
+        $content  = var_export($route, true);
+        $content  = preg_replace('/([.^\S]*)::__set_state\(/', 'new $1(...', $content);
 
         return <<<PHP
-            static fn (): $routeContract => $routeContent
+            static fn (): $contract => $content
             PHP;
     }
 }

--- a/tests/Unit/Http/Routing/Data/ParameterTest.php
+++ b/tests/Unit/Http/Routing/Data/ParameterTest.php
@@ -39,7 +39,7 @@ class ParameterTest extends TestCase
         self::assertNull($parameter->getDefault());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $name          = 'name';
         $regex         = 'regex';
@@ -49,7 +49,7 @@ class ParameterTest extends TestCase
         $default       = 'default';
         $value         = 'value';
 
-        $parameter = Parameter::__set_state([
+        $parameter = new Parameter(...[
             'name'          => $name,
             'regex'         => $regex,
             'cast'          => $cast,

--- a/tests/Unit/Http/Routing/Data/RouteTest.php
+++ b/tests/Unit/Http/Routing/Data/RouteTest.php
@@ -66,7 +66,7 @@ class RouteTest extends TestCase
         self::assertNull($route->getResponseStruct());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $path                      = '/';
         $name                      = 'route';
@@ -82,7 +82,7 @@ class RouteTest extends TestCase
         $requestStruct             = IndexedJsonRequestStructEnum::class;
         $responseStruct            = ResponseStructEnum::class;
 
-        $route = Route::__set_state([
+        $route = new Route(...[
             'path'                      => $path,
             'name'                      => $name,
             'dispatch'                  => $dispatch,

--- a/tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
@@ -97,6 +97,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
@@ -148,6 +149,7 @@ class DataFileGeneratorTest extends TestCase
             )
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);
@@ -165,6 +167,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
@@ -216,6 +219,7 @@ class DataFileGeneratorTest extends TestCase
             )
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);

--- a/tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
@@ -100,11 +100,11 @@ class DataFileGeneratorTest extends TestCase
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
-                'route' => static fn (): Valkyrja\Http\Routing\Data\Contract\RouteContract => \Valkyrja\Http\Routing\Data\Route::__set_state(array(
+                'route' => static fn (): Valkyrja\Http\Routing\Data\Contract\RouteContract => new \Valkyrja\Http\Routing\Data\Route(...array(
                'path' => '/',
                'name' => 'route',
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,
@@ -168,11 +168,11 @@ class DataFileGeneratorTest extends TestCase
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
-                'route' => static fn (): Valkyrja\Http\Routing\Data\Contract\RouteContract => \Valkyrja\Http\Routing\Data\Route::__set_state(array(
+                'route' => static fn (): Valkyrja\Http\Routing\Data\Contract\RouteContract => new \Valkyrja\Http\Routing\Data\Route(...array(
                'path' => '/',
                'name' => 'route',
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,


### PR DESCRIPTION
# Description

Removing need for __set_state in DataFileGenerator.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->