### PR TITLE
[Cli] Removing need for __set_state in DataFileGenerator

### DIFF
--- a/src/Valkyrja/Cli/Interaction/Format/BackgroundColorFormat.php
+++ b/src/Valkyrja/Cli/Interaction/Format/BackgroundColorFormat.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Interaction\Format;
 
-use Override;
 use Valkyrja\Cli\Interaction\Enum\BackgroundColor;
 
 class BackgroundColorFormat extends Format
@@ -24,19 +23,5 @@ class BackgroundColorFormat extends Format
             (string) $backgroundColor->value,
             (string) BackgroundColor::DEFAULT
         );
-    }
-
-    /**
-     * @param array{
-     *     setCode: non-empty-string,
-     *     unsetCode: non-empty-string,
-     * } $array The array
-     */
-    #[Override]
-    public static function __set_state(array $array): static
-    {
-        return new static(BackgroundColor::WHITE)
-            ->withSetCode($array['setCode'])
-            ->withUnsetCode($array['unsetCode']);
     }
 }

--- a/src/Valkyrja/Cli/Interaction/Format/Format.php
+++ b/src/Valkyrja/Cli/Interaction/Format/Format.php
@@ -29,17 +29,6 @@ class Format implements FormatContract
     }
 
     /**
-     * @param array{
-     *     setCode: non-empty-string,
-     *     unsetCode: non-empty-string,
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Cli/Interaction/Format/StyleFormat.php
+++ b/src/Valkyrja/Cli/Interaction/Format/StyleFormat.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Interaction\Format;
 
-use Override;
 use Valkyrja\Cli\Interaction\Enum\Style;
 
 class StyleFormat extends Format
@@ -24,19 +23,5 @@ class StyleFormat extends Format
             (string) $style->value,
             (string) Style::DEFAULTS[$style->value]
         );
-    }
-
-    /**
-     * @param array{
-     *     setCode: non-empty-string,
-     *     unsetCode: non-empty-string,
-     * } $array The array
-     */
-    #[Override]
-    public static function __set_state(array $array): static
-    {
-        return new static(Style::BOLD)
-            ->withSetCode($array['setCode'])
-            ->withUnsetCode($array['unsetCode']);
     }
 }

--- a/src/Valkyrja/Cli/Interaction/Format/TextColorFormat.php
+++ b/src/Valkyrja/Cli/Interaction/Format/TextColorFormat.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Interaction\Format;
 
-use Override;
 use Valkyrja\Cli\Interaction\Enum\TextColor;
 
 class TextColorFormat extends Format
@@ -24,19 +23,5 @@ class TextColorFormat extends Format
             (string) $textColor->value,
             (string) TextColor::DEFAULT
         );
-    }
-
-    /**
-     * @param array{
-     *     setCode: non-empty-string,
-     *     unsetCode: non-empty-string,
-     * } $array The array
-     */
-    #[Override]
-    public static function __set_state(array $array): static
-    {
-        return new static(TextColor::WHITE)
-            ->withSetCode($array['setCode'])
-            ->withUnsetCode($array['unsetCode']);
     }
 }

--- a/src/Valkyrja/Cli/Interaction/Formatter/Formatter.php
+++ b/src/Valkyrja/Cli/Interaction/Formatter/Formatter.php
@@ -33,18 +33,6 @@ class Formatter implements FormatterContract
     }
 
     /**
-     * @param array{
-     *     formats: FormatContract[],
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        $formats = $array['formats'];
-
-        return new static(...$formats);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Cli/Interaction/Message/Message.php
+++ b/src/Valkyrja/Cli/Interaction/Message/Message.php
@@ -29,17 +29,6 @@ class Message implements MessageContract
     }
 
     /**
-     * @param array{
-     *     text: non-empty-string,
-     *     formatter: FormatterContract|null,
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      *
      * @return non-empty-string

--- a/src/Valkyrja/Cli/Routing/Data/ArgumentParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/ArgumentParameter.php
@@ -47,21 +47,6 @@ class ArgumentParameter extends Parameter implements ArgumentParameterContract
     }
 
     /**
-     * @param array{
-     *     name: non-empty-string,
-     *     description: non-empty-string,
-     *     cast: Cast|null,
-     *     mode: ArgumentMode,
-     *     valueMode: ArgumentValueMode,
-     *     arguments: ArgumentContract[],
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Cli/Routing/Data/OptionParameter.php
+++ b/src/Valkyrja/Cli/Routing/Data/OptionParameter.php
@@ -56,25 +56,6 @@ class OptionParameter extends Parameter implements OptionParameterContract
     }
 
     /**
-     * @param array{
-     *     name: non-empty-string,
-     *     description: non-empty-string,
-     *     cast: Cast|null,
-     *     valueDisplayName: non-empty-string|null,
-     *     defaultValue: non-empty-string|null,
-     *     shortNames: non-empty-string[],
-     *     validValues: non-empty-string[],
-     *     options: OptionContract[],
-     *     mode: OptionMode,
-     *     valueMode: OptionValueMode,
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Cli/Routing/Data/Route.php
+++ b/src/Valkyrja/Cli/Routing/Data/Route.php
@@ -52,25 +52,6 @@ class Route implements RouteContract
     }
 
     /**
-     * @param array{
-     *     name: non-empty-string,
-     *     description: non-empty-string,
-     *     helpText: MessageContract,
-     *     dispatch: MethodDispatchContract,
-     *     routeMatchedMiddleware: class-string<RouteMatchedMiddlewareContract>[],
-     *     routeDispatchedMiddleware: class-string<RouteDispatchedMiddlewareContract>[],
-     *     throwableCaughtMiddleware: class-string<ThrowableCaughtMiddlewareContract>[],
-     *     exitedMiddleware: class-string<ExitedMiddlewareContract>[],
-     *     arguments: ArgumentParameterContract[],
-     *     options: OptionParameterContract[],
-     * } $array The array
-     */
-    public static function __set_state(array $array): static
-    {
-        return new static(...$array);
-    }
-
-    /**
      * @inheritDoc
      */
     #[Override]

--- a/src/Valkyrja/Cli/Routing/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Cli/Routing/Generator/DataFileGenerator.php
@@ -97,11 +97,12 @@ class DataFileGenerator extends FileGenerator implements DataFileGeneratorContra
 
     protected function getRouteAsContent(RouteContract $route): string
     {
-        $routeContract = RouteContract::class;
-        $routeContent  = var_export($route, true);
+        $contract = RouteContract::class;
+        $content  = var_export($route, true);
+        $content  = preg_replace('/([.^\S]*)::__set_state\(/', 'new $1(...', $content);
 
         return <<<PHP
-            static fn (): $routeContract => $routeContent
+            static fn (): $contract => $content
             PHP;
     }
 }

--- a/tests/Unit/Cli/Interaction/Format/BackgroundColorFormatTest.php
+++ b/tests/Unit/Cli/Interaction/Format/BackgroundColorFormatTest.php
@@ -38,20 +38,6 @@ class BackgroundColorFormatTest extends TestCase
         self::assertInstanceOf(Format::class, $format);
     }
 
-    public function testSetState(): void
-    {
-        $setCode   = (string) BackgroundColor::WHITE->value;
-        $unsetCode = (string) BackgroundColor::DEFAULT;
-
-        $format = BackgroundColorFormat::__set_state([
-            'setCode'   => $setCode,
-            'unsetCode' => $unsetCode,
-        ]);
-
-        self::assertSame($setCode, $format->getSetCode());
-        self::assertSame($unsetCode, $format->getUnsetCode());
-    }
-
     public function testGetSetCode(): void
     {
         $format = new BackgroundColorFormat(BackgroundColor::RED);

--- a/tests/Unit/Cli/Interaction/Format/FormatTest.php
+++ b/tests/Unit/Cli/Interaction/Format/FormatTest.php
@@ -29,12 +29,12 @@ class FormatTest extends TestCase
         self::assertInstanceOf(FormatContract::class, $format);
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $setCode   = '1';
         $unsetCode = '22';
 
-        $format  = Format::__set_state([
+        $format  = new Format(...[
             'setCode'   => $setCode,
             'unsetCode' => $unsetCode,
         ]);

--- a/tests/Unit/Cli/Interaction/Format/StyleFormatTest.php
+++ b/tests/Unit/Cli/Interaction/Format/StyleFormatTest.php
@@ -38,20 +38,6 @@ class StyleFormatTest extends TestCase
         self::assertInstanceOf(Format::class, $format);
     }
 
-    public function testSetState(): void
-    {
-        $setCode   = (string) Style::BOLD->value;
-        $unsetCode = (string) Style::DEFAULTS[Style::BOLD->value];
-
-        $format = StyleFormat::__set_state([
-            'setCode'   => $setCode,
-            'unsetCode' => $unsetCode,
-        ]);
-
-        self::assertSame($setCode, $format->getSetCode());
-        self::assertSame($unsetCode, $format->getUnsetCode());
-    }
-
     public function testGetSetCode(): void
     {
         $format = new StyleFormat(Style::BOLD);

--- a/tests/Unit/Cli/Interaction/Format/TextColorFormatTest.php
+++ b/tests/Unit/Cli/Interaction/Format/TextColorFormatTest.php
@@ -38,20 +38,6 @@ class TextColorFormatTest extends TestCase
         self::assertInstanceOf(Format::class, $format);
     }
 
-    public function testSetState(): void
-    {
-        $setCode   = (string) TextColor::WHITE->value;
-        $unsetCode = (string) TextColor::DEFAULT;
-
-        $format = TextColorFormat::__set_state([
-            'setCode'   => $setCode,
-            'unsetCode' => $unsetCode,
-        ]);
-
-        self::assertSame($setCode, $format->getSetCode());
-        self::assertSame($unsetCode, $format->getUnsetCode());
-    }
-
     public function testGetSetCode(): void
     {
         $format = new TextColorFormat(TextColor::RED);

--- a/tests/Unit/Cli/Interaction/Formatter/FormatterTest.php
+++ b/tests/Unit/Cli/Interaction/Formatter/FormatterTest.php
@@ -38,19 +38,6 @@ class FormatterTest extends TestCase
         self::assertSame($text, $formatter->formatText($text));
     }
 
-    public function testSetState(): void
-    {
-        $format = new StyleFormat(Style::BOLD);
-
-        $formatter = Formatter::__set_state([
-            'formats' => [
-                $format,
-            ],
-        ]);
-
-        self::assertSame([$format], $formatter->getFormats());
-    }
-
     public function testStyle(): void
     {
         $text     = 'text';

--- a/tests/Unit/Cli/Interaction/Message/MessageTest.php
+++ b/tests/Unit/Cli/Interaction/Message/MessageTest.php
@@ -34,12 +34,12 @@ class MessageTest extends TestCase
         self::assertNull($message->getFormatter());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $text      = 'text';
         $formatter = new HighlightedTextFormatter();
 
-        $message = Message::__set_state([
+        $message = new Message(...[
             'text'      => $text,
             'formatter' => $formatter,
         ]);

--- a/tests/Unit/Cli/Routing/Data/ArgumentParameterTest.php
+++ b/tests/Unit/Cli/Routing/Data/ArgumentParameterTest.php
@@ -54,7 +54,7 @@ class ArgumentParameterTest extends TestCase
         self::assertTrue($parameter->areValuesValid());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $name        = self::NAME;
         $description = self::DESCRIPTION;
@@ -63,7 +63,7 @@ class ArgumentParameterTest extends TestCase
         $valueMode   = ArgumentValueMode::ARRAY;
         $arguments   = [new Argument('test')];
 
-        $parameter = ArgumentParameter::__set_state([
+        $parameter = new ArgumentParameter(...[
             'name'        => $name,
             'description' => $description,
             'cast'        => $cast,

--- a/tests/Unit/Cli/Routing/Data/OptionParameterTest.php
+++ b/tests/Unit/Cli/Routing/Data/OptionParameterTest.php
@@ -58,7 +58,7 @@ class OptionParameterTest extends TestCase
         self::assertTrue($parameter->areValuesValid());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $name             = self::NAME;
         $description      = self::DESCRIPTION;
@@ -74,17 +74,17 @@ class OptionParameterTest extends TestCase
         $defaultValue     = 'b';
         $valueDisplayName = 'test';
 
-        $parameter = OptionParameter::__set_state([
+        $parameter = new OptionParameter(...[
             'name'             => $name,
             'description'      => $description,
+            'valueDisplayName' => $valueDisplayName,
             'cast'             => $cast,
+            'defaultValue'     => $defaultValue,
             'shortNames'       => $shortNames,
-            'mode'             => $mode,
-            'valueMode'        => $valueMode,
             'validValues'      => $validValues,
             'options'          => $options,
-            'defaultValue'     => $defaultValue,
-            'valueDisplayName' => $valueDisplayName,
+            'mode'             => $mode,
+            'valueMode'        => $valueMode,
         ]);
 
         self::assertSame($name, $parameter->getName());

--- a/tests/Unit/Cli/Routing/Data/RouteTest.php
+++ b/tests/Unit/Cli/Routing/Data/RouteTest.php
@@ -64,7 +64,7 @@ class RouteTest extends TestCase
         self::assertEmpty($route->getExitedMiddleware());
     }
 
-    public function testSetState(): void
+    public function testConstructor(): void
     {
         $name                      = self::NAME;
         $description               = self::DESCRIPTION;
@@ -77,17 +77,17 @@ class RouteTest extends TestCase
         $throwableCaughtMiddleware = [ThrowableCaughtMiddlewareClass::class];
         $exitedMiddleware          = [ExitedMiddlewareClass::class];
 
-        $route = Route::__set_state([
+        $route = new Route(...[
             'name'                      => $name,
             'description'               => $description,
             'helpText'                  => $helpText,
             'dispatch'                  => $dispatch,
-            'arguments'                 => $arguments,
-            'options'                   => $options,
             'routeMatchedMiddleware'    => $routeMatchedMiddleware,
             'routeDispatchedMiddleware' => $routeDispatchedMiddleware,
             'throwableCaughtMiddleware' => $throwableCaughtMiddleware,
             'exitedMiddleware'          => $exitedMiddleware,
+            'arguments'                 => $arguments,
+            'options'                   => $options,
         ]);
 
         self::assertSame($name, $route->getName());

--- a/tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
@@ -99,6 +99,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
@@ -141,6 +142,7 @@ class DataFileGeneratorTest extends TestCase
             ],
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);
@@ -163,6 +165,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
@@ -205,6 +208,7 @@ class DataFileGeneratorTest extends TestCase
             ],
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);

--- a/tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
@@ -102,16 +102,16 @@ class DataFileGeneratorTest extends TestCase
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
-                'route' => static fn (): Valkyrja\Cli\Routing\Data\Contract\RouteContract => \Valkyrja\Cli\Routing\Data\Route::__set_state(array(
+                'route' => static fn (): Valkyrja\Cli\Routing\Data\Contract\RouteContract => new \Valkyrja\Cli\Routing\Data\Route(...array(
                'name' => 'test',
                'description' => 'description',
                'helpText' => 
-              \Valkyrja\Cli\Interaction\Message\Message::__set_state(array(
+              new \Valkyrja\Cli\Interaction\Message\Message(...array(
                  'text' => 'help text',
                  'formatter' => NULL,
               )),
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,
@@ -166,16 +166,16 @@ class DataFileGeneratorTest extends TestCase
         $expected = <<<PHP
             new $dataNamespace(
                 routes: [
-                'route' => static fn (): Valkyrja\Cli\Routing\Data\Contract\RouteContract => \Valkyrja\Cli\Routing\Data\Route::__set_state(array(
+                'route' => static fn (): Valkyrja\Cli\Routing\Data\Contract\RouteContract => new \Valkyrja\Cli\Routing\Data\Route(...array(
                'name' => 'test',
                'description' => 'description',
                'helpText' => 
-              \Valkyrja\Cli\Interaction\Message\Message::__set_state(array(
+              new \Valkyrja\Cli\Interaction\Message\Message(...array(
                  'text' => 'help text',
                  'formatter' => NULL,
               )),
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,


### PR DESCRIPTION
# Description

Removing need for __set_state in DataFileGenerator.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->