### PR TITLE
[Event] Removing need for __set_state in DataFileGenerator

### DIFF
--- a/src/Valkyrja/Event/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Event/Generator/DataFileGenerator.php
@@ -101,6 +101,7 @@ class DataFileGenerator extends FileGenerator implements DataFileGeneratorContra
     {
         $contract = ListenerContract::class;
         $content  = var_export($route, true);
+        $content  = preg_replace('/([.^\S]*)::__set_state\(/', 'new $1(...', $content);
 
         return <<<PHP
             static fn (): $contract => $content

--- a/tests/Unit/Event/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Event/Generator/DataFileGeneratorTest.php
@@ -104,11 +104,11 @@ class DataFileGeneratorTest extends TestCase
                 events: array (
             ),
                 listeners: [
-                'name' => static fn (): Valkyrja\Event\Data\Contract\ListenerContract => \Valkyrja\Event\Data\Listener::__set_state(array(
+                'name' => static fn (): Valkyrja\Event\Data\Contract\ListenerContract => new \Valkyrja\Event\Data\Listener(...array(
                'eventId' => 'eventId',
                'name' => 'name',
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,
@@ -146,11 +146,11 @@ class DataFileGeneratorTest extends TestCase
                 events: array (
             ),
                 listeners: [
-                'name' => static fn (): Valkyrja\Event\Data\Contract\ListenerContract => \Valkyrja\Event\Data\Listener::__set_state(array(
+                'name' => static fn (): Valkyrja\Event\Data\Contract\ListenerContract => new \Valkyrja\Event\Data\Listener(...array(
                'eventId' => 'eventId',
                'name' => 'name',
                'dispatch' => 
-              \Valkyrja\Dispatch\Data\MethodDispatch::__set_state(array(
+              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
                  'class' => 'class',
                  'arguments' => NULL,
                  'dependencies' => NULL,

--- a/tests/Unit/Event/Generator/DataFileGeneratorTest.php
+++ b/tests/Unit/Event/Generator/DataFileGeneratorTest.php
@@ -99,6 +99,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 events: array (
@@ -120,6 +121,7 @@ class DataFileGeneratorTest extends TestCase
             ],
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);
@@ -141,6 +143,7 @@ class DataFileGeneratorTest extends TestCase
 
         $dataNamespace = Data::class;
 
+        // phpcs:disable
         $expected = <<<PHP
             new $dataNamespace(
                 events: array (
@@ -162,6 +165,7 @@ class DataFileGeneratorTest extends TestCase
             ],
             )
             PHP;
+        // phpcs:enable
 
         self::assertNotEmpty($contents);
         self::assertSame($expected, $contents);


### PR DESCRIPTION
# Description

Removing need for __set_state in DataFileGenerator.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->