### PR TITLE
[CI] Fix bug in RemoveNonConflictingAliasInUseStatementRector

### DIFF
--- a/.github/ci/rector/Rector/CodingStyle/Rector/Stmt/RemoveNonConflictingAliasInUseStatementRector.php
+++ b/.github/ci/rector/Rector/CodingStyle/Rector/Stmt/RemoveNonConflictingAliasInUseStatementRector.php
@@ -125,7 +125,7 @@ final class RemoveNonConflictingAliasInUseStatementRector extends AbstractRector
 
                 $use          = $compareStmt->uses[0]->name->toString();
                 $lastName     = Strings::after($use, '\\', -1) ?? $use;
-                $useAliasName = $stmt->uses[0]->alias instanceof Identifier ? $stmt->uses[0]->alias->toString() : null;
+                $useAliasName = $compareStmt->uses[0]->alias instanceof Identifier ? $compareStmt->uses[0]->alias->toString() : null;
                 $useHasAlias  = $useAliasName !== null;
 
                 if (

--- a/src/Valkyrja/Application/Constant/ComponentClass.php
+++ b/src/Valkyrja/Application/Constant/ComponentClass.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Application\Constant;
 
-use Valkyrja\Api\Provider\ComponentProvider as ApiComponentProvider;
+use Valkyrja\Api\Provider\ComponentProvider;
 use Valkyrja\Application\Provider\ComponentProvider as ApplicationComponentProvider;
 use Valkyrja\Attribute\Provider\ComponentProvider as AttributeComponentProvider;
 use Valkyrja\Auth\Provider\ComponentProvider as AuthComponentProvider;
@@ -45,7 +45,7 @@ use Valkyrja\View\Provider\ComponentProvider as ViewComponentProvider;
 final class ComponentClass
 {
     public const string APPLICATION     = ApplicationComponentProvider::class;
-    public const string API             = ApiComponentProvider::class;
+    public const string API             = ComponentProvider::class;
     public const string ATTRIBUTE       = AttributeComponentProvider::class;
     public const string AUTH            = AuthComponentProvider::class;
     public const string BROADCAST       = BroadcastComponentProvider::class;

--- a/src/Valkyrja/Application/Entry/Abstract/App.php
+++ b/src/Valkyrja/Application/Entry/Abstract/App.php
@@ -19,7 +19,7 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Application\Kernel\Valkyrja;
 use Valkyrja\Application\Provider\Provider;
-use Valkyrja\Container\Data\Data as ContainerData;
+use Valkyrja\Container\Data\Data;
 use Valkyrja\Container\Manager\Container;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\ServiceProvider;
@@ -131,7 +131,7 @@ abstract class App
     protected static function loadContainerData(ContainerContract $container): void
     {
         ServiceProvider::publishData(container: $container);
-        $containerData = $container->getSingleton(ContainerData::class);
+        $containerData = $container->getSingleton(Data::class);
 
         $container->setFromData($containerData);
     }

--- a/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Middleware/Provider/ServiceProvider.php
@@ -37,7 +37,7 @@ use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForHelpOptionsMiddleware;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckForVersionOptionsMiddleware;
 use Valkyrja\Cli\Server\Middleware\InputReceived\CheckGlobalInteractionOptionsMiddleware;
 use Valkyrja\Cli\Server\Middleware\RouteNotMatched\CheckCommandForTypoMiddleware;
-use Valkyrja\Cli\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware as CliLogThrowableCaughtMiddleware;
+use Valkyrja\Cli\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware;
 use Valkyrja\Cli\Server\Middleware\ThrowableCaught\OutputThrowableCaughtMiddleware;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Provider;
@@ -131,7 +131,7 @@ final class ServiceProvider extends Provider
         /** @var class-string<ThrowableCaughtMiddlewareContract>[] $middleware */
         $middleware = $env::CLI_MIDDLEWARE_THROWABLE_CAUGHT
             ?? [
-                CliLogThrowableCaughtMiddleware::class,
+                LogThrowableCaughtMiddleware::class,
                 OutputThrowableCaughtMiddleware::class,
             ];
 

--- a/src/Valkyrja/Cli/Routing/Collector/AttributeCollector.php
+++ b/src/Valkyrja/Cli/Routing/Collector/AttributeCollector.php
@@ -16,7 +16,7 @@ namespace Valkyrja\Cli\Routing\Collector;
 use Override;
 use ReflectionException;
 use ReflectionMethod;
-use Valkyrja\Attribute\Collector\Contract\CollectorContract;
+use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
 use Valkyrja\Cli\Middleware\Contract\ExitedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\RouteDispatchedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\RouteMatchedMiddlewareContract;
@@ -26,7 +26,7 @@ use Valkyrja\Cli\Routing\Attribute\OptionParameter as OptionAttribute;
 use Valkyrja\Cli\Routing\Attribute\Route as Attribute;
 use Valkyrja\Cli\Routing\Attribute\Route\Middleware;
 use Valkyrja\Cli\Routing\Attribute\Route\Name;
-use Valkyrja\Cli\Routing\Collector\Contract\CollectorContract as Contract;
+use Valkyrja\Cli\Routing\Collector\Contract\CollectorContract;
 use Valkyrja\Cli\Routing\Data\ArgumentParameter;
 use Valkyrja\Cli\Routing\Data\Contract\ArgumentParameterContract;
 use Valkyrja\Cli\Routing\Data\Contract\OptionParameterContract;
@@ -38,10 +38,10 @@ use Valkyrja\Reflection\Reflector\Contract\ReflectorContract;
 use function array_column;
 use function is_a;
 
-class AttributeCollector implements Contract
+class AttributeCollector implements CollectorContract
 {
     public function __construct(
-        protected CollectorContract $attributes,
+        protected AttributeCollectorContract $attributes,
         protected ReflectorContract $reflection,
     ) {
     }

--- a/src/Valkyrja/Event/Collector/AttributeCollector.php
+++ b/src/Valkyrja/Event/Collector/AttributeCollector.php
@@ -16,20 +16,20 @@ namespace Valkyrja\Event\Collector;
 use Override;
 use ReflectionException;
 use ReflectionMethod;
-use Valkyrja\Attribute\Collector\Contract\CollectorContract;
+use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
 use Valkyrja\Dispatch\Data\ClassDispatch;
 use Valkyrja\Dispatch\Data\Contract\MethodDispatchContract;
 use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Event\Attribute\Listener as Attribute;
-use Valkyrja\Event\Collector\Contract\CollectorContract as Contract;
+use Valkyrja\Event\Collector\Contract\CollectorContract;
 use Valkyrja\Event\Data\Contract\ListenerContract;
 use Valkyrja\Event\Data\Listener;
 use Valkyrja\Reflection\Reflector\Contract\ReflectorContract;
 
-class AttributeCollector implements Contract
+class AttributeCollector implements CollectorContract
 {
     public function __construct(
-        protected CollectorContract $attributes,
+        protected AttributeCollectorContract $attributes,
         protected ReflectorContract $reflection,
     ) {
     }

--- a/src/Valkyrja/Event/Dispatcher/Dispatcher.php
+++ b/src/Valkyrja/Event/Dispatcher/Dispatcher.php
@@ -21,9 +21,9 @@ use Valkyrja\Event\Collection\Collection;
 use Valkyrja\Event\Collection\Contract\CollectionContract;
 use Valkyrja\Event\Contract\DispatchCollectableEventContract;
 use Valkyrja\Event\Data\Contract\ListenerContract;
-use Valkyrja\Event\Dispatcher\Contract\DispatcherContract as Contract;
+use Valkyrja\Event\Dispatcher\Contract\DispatcherContract;
 
-class Dispatcher implements Contract
+class Dispatcher implements DispatcherContract
 {
     public function __construct(
         protected CollectionContract $collection = new Collection(),

--- a/src/Valkyrja/Http/Middleware/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Http/Middleware/Provider/ServiceProvider.php
@@ -39,7 +39,7 @@ use Valkyrja\Http\Middleware\Handler\SendingResponseHandler;
 use Valkyrja\Http\Middleware\Handler\TerminatedHandler;
 use Valkyrja\Http\Middleware\Handler\ThrowableCaughtHandler;
 use Valkyrja\Http\Server\Middleware\RouteNotMatched\ViewRouteNotMatchedMiddleware;
-use Valkyrja\Http\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware as HttpLogThrowableCaughtMiddleware;
+use Valkyrja\Http\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware;
 use Valkyrja\Http\Server\Middleware\ThrowableCaught\ViewThrowableCaughtMiddleware;
 
 final class ServiceProvider extends Provider
@@ -129,7 +129,7 @@ final class ServiceProvider extends Provider
         /** @var class-string<ThrowableCaughtMiddlewareContract>[] $middleware */
         $middleware = $env::HTTP_MIDDLEWARE_THROWABLE_CAUGHT
             ?? [
-                HttpLogThrowableCaughtMiddleware::class,
+                LogThrowableCaughtMiddleware::class,
                 ViewThrowableCaughtMiddleware::class,
             ];
 

--- a/src/Valkyrja/Http/Routing/Collector/AttributeCollector.php
+++ b/src/Valkyrja/Http/Routing/Collector/AttributeCollector.php
@@ -17,7 +17,7 @@ use Override;
 use ReflectionException;
 use ReflectionMethod;
 use Valkyrja\Attribute\Collector\Collector;
-use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeContract;
+use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
 use Valkyrja\Http\Middleware\Contract\RouteDispatchedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\RouteMatchedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\SendingResponseMiddlewareContract;
@@ -31,7 +31,7 @@ use Valkyrja\Http\Routing\Attribute\Route\Path;
 use Valkyrja\Http\Routing\Attribute\Route\RequestMethod;
 use Valkyrja\Http\Routing\Attribute\Route\RequestStruct;
 use Valkyrja\Http\Routing\Attribute\Route\ResponseStruct;
-use Valkyrja\Http\Routing\Collector\Contract\CollectorContract as Contract;
+use Valkyrja\Http\Routing\Collector\Contract\CollectorContract;
 use Valkyrja\Http\Routing\Data\Contract\ParameterContract;
 use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\Parameter as DataParameter;
@@ -46,10 +46,10 @@ use Valkyrja\Reflection\Reflector\Reflector;
 use function array_column;
 use function is_a;
 
-class AttributeCollector implements Contract
+class AttributeCollector implements CollectorContract
 {
     public function __construct(
-        protected AttributeContract $attributes = new Collector(),
+        protected AttributeCollectorContract $attributes = new Collector(),
         protected ReflectorContract $reflection = new Reflector(),
         protected ProcessorContract $processor = new Processor()
     ) {

--- a/src/Valkyrja/Http/Routing/Factory/ResponseFactory.php
+++ b/src/Valkyrja/Http/Routing/Factory/ResponseFactory.php
@@ -17,10 +17,10 @@ use Override;
 use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Response\Contract\RedirectResponseContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactory;
-use Valkyrja\Http\Routing\Factory\Contract\ResponseFactoryContract as Contract;
+use Valkyrja\Http\Routing\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\Http\Routing\Url\Contract\UrlContract;
 
-class ResponseFactory implements Contract
+class ResponseFactory implements ResponseFactoryContract
 {
     public function __construct(
         protected HttpMessageResponseFactory $responseFactory,

--- a/src/Valkyrja/View/Factory/ResponseFactory.php
+++ b/src/Valkyrja/View/Factory/ResponseFactory.php
@@ -18,11 +18,11 @@ use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactoryContract;
 use Valkyrja\Http\Message\Response\Factory\ResponseFactory as HttpMessageResponseFactory;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract as Contract;
+use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\PhpRenderer;
 
-class ResponseFactory implements Contract
+class ResponseFactory implements ResponseFactoryContract
 {
     public function __construct(
         protected HttpMessageResponseFactoryContract $responseFactory = new HttpMessageResponseFactory(),

--- a/tests/Tests/Unit/Application/Constant/ComponentClassTest.php
+++ b/tests/Tests/Unit/Application/Constant/ComponentClassTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Application\Constant;
 
-use Valkyrja\Api\Provider\ComponentProvider as ApiComponentProvider;
+use Valkyrja\Api\Provider\ComponentProvider;
 use Valkyrja\Application\Constant\ComponentClass;
 use Valkyrja\Application\Provider\ComponentProvider as ApplicationComponentProvider;
 use Valkyrja\Attribute\Provider\ComponentProvider as AttributeComponentProvider;
@@ -52,7 +52,7 @@ class ComponentClassTest extends TestCase
     public function testValues(): void
     {
         self::assertSame(ApplicationComponentProvider::class, ComponentClass::APPLICATION);
-        self::assertSame(ApiComponentProvider::class, ComponentClass::API);
+        self::assertSame(ComponentProvider::class, ComponentClass::API);
         self::assertSame(AttributeComponentProvider::class, ComponentClass::ATTRIBUTE);
         self::assertSame(AuthComponentProvider::class, ComponentClass::AUTH);
         self::assertSame(BroadcastComponentProvider::class, ComponentClass::BROADCAST);

--- a/tests/Tests/Unit/Application/Entry/Abstract/AppTest.php
+++ b/tests/Tests/Unit/Application/Entry/Abstract/AppTest.php
@@ -20,21 +20,21 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Application\Provider\Provider;
 use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
-use Valkyrja\Cli\Interaction\Data\Config as CliInteractionConfig;
+use Valkyrja\Cli\Interaction\Data\Config;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Middleware\Handler\Contract\ExitedHandlerContract;
 use Valkyrja\Cli\Middleware\Handler\Contract\InputReceivedHandlerContract;
-use Valkyrja\Cli\Middleware\Handler\Contract\RouteDispatchedHandlerContract as CliRouteDispatchedHandlerContract;
-use Valkyrja\Cli\Middleware\Handler\Contract\RouteMatchedHandlerContract as CliRouteMatchedHandlerContract;
-use Valkyrja\Cli\Middleware\Handler\Contract\RouteNotMatchedHandlerContract as CliRouteNotMatchedHandlerContract;
-use Valkyrja\Cli\Middleware\Handler\Contract\ThrowableCaughtHandlerContract as CliThrowableCaughtHandlerContract;
-use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract as CliRoutingCollection;
+use Valkyrja\Cli\Middleware\Handler\Contract\RouteDispatchedHandlerContract;
+use Valkyrja\Cli\Middleware\Handler\Contract\RouteMatchedHandlerContract;
+use Valkyrja\Cli\Middleware\Handler\Contract\RouteNotMatchedHandlerContract;
+use Valkyrja\Cli\Middleware\Handler\Contract\ThrowableCaughtHandlerContract;
+use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Cli\Routing\Collector\Contract\CollectorContract as CliRoutingCollector;
-use Valkyrja\Cli\Routing\Data\Data as CliData;
-use Valkyrja\Cli\Routing\Dispatcher\Contract\RouterContract as CliRoutingRouter;
+use Valkyrja\Cli\Routing\Data\Data;
+use Valkyrja\Cli\Routing\Dispatcher\Contract\RouterContract;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
-use Valkyrja\Cli\Server\Command\ListCommand as CliListCommand;
+use Valkyrja\Cli\Server\Command\ListCommand;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Cli\Server\Handler\Contract\InputHandlerContract;
 use Valkyrja\Cli\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware as CliLogThrowableCaughtMiddleware;
@@ -73,7 +73,7 @@ use Valkyrja\Support\Directory\Directory;
 use Valkyrja\Support\Time\Microtime;
 use Valkyrja\Tests\EnvClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\View\Provider\ComponentProvider as ViewComponentProvider;
+use Valkyrja\View\Provider\ComponentProvider;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Template\Contract\TemplateContract;
 
@@ -155,7 +155,7 @@ class AppTest extends TestCase
 
         self::assertTrue($container->has(ContainerData::class));
         self::assertFalse($container->has(EventData::class));
-        self::assertFalse($container->has(CliData::class));
+        self::assertFalse($container->has(Data::class));
         self::assertFalse($container->has(HttpData::class));
         self::assertSame($env, $container->getSingleton(Env::class));
         self::assertSame($env::APP_TIMEZONE, date_default_timezone_get());
@@ -178,17 +178,17 @@ class AppTest extends TestCase
         self::assertTrue($container->has(Env::class));
         self::assertTrue($container->has(ApplicationContract::class));
         self::assertTrue($container->has(AttributeCollectorContract::class));
-        self::assertTrue($container->has(CliInteractionConfig::class));
+        self::assertTrue($container->has(Config::class));
         self::assertTrue($container->has(OutputFactoryContract::class));
         self::assertTrue($container->has(InputReceivedHandlerContract::class));
-        self::assertTrue($container->has(CliThrowableCaughtHandlerContract::class));
-        self::assertTrue($container->has(CliRouteMatchedHandlerContract::class));
-        self::assertTrue($container->has(CliRouteNotMatchedHandlerContract::class));
-        self::assertTrue($container->has(CliRouteDispatchedHandlerContract::class));
+        self::assertTrue($container->has(ThrowableCaughtHandlerContract::class));
+        self::assertTrue($container->has(RouteMatchedHandlerContract::class));
+        self::assertTrue($container->has(RouteNotMatchedHandlerContract::class));
+        self::assertTrue($container->has(RouteDispatchedHandlerContract::class));
         self::assertTrue($container->has(ExitedHandlerContract::class));
         self::assertTrue($container->has(CliRoutingCollector::class));
-        self::assertTrue($container->has(CliRoutingRouter::class));
-        self::assertTrue($container->has(CliRoutingCollection::class));
+        self::assertTrue($container->has(RouterContract::class));
+        self::assertTrue($container->has(CollectionContract::class));
         self::assertTrue($container->has(InputHandlerContract::class));
         self::assertTrue($container->has(CliLogThrowableCaughtMiddleware::class));
         self::assertTrue($container->has(DispatcherContract::class));
@@ -223,7 +223,7 @@ class AppTest extends TestCase
 
         self::assertContains(HelpCommand::class, $commands);
         self::assertContains(ListBashCommand::class, $commands);
-        self::assertContains(CliListCommand::class, $commands);
+        self::assertContains(ListCommand::class, $commands);
         self::assertContains(VersionCommand::class, $commands);
         self::assertContains(HttpListCommand::class, $commands);
 
@@ -254,7 +254,7 @@ class AppTest extends TestCase
             public const array APP_COMPONENTS = [];
             /** @var class-string<Provider>[] */
             public const array APP_CUSTOM_COMPONENTS = [
-                ViewComponentProvider::class,
+                ComponentProvider::class,
             ];
         };
         $application2 = App::app($env2);

--- a/tests/Tests/Unit/Http/Message/Uri/Psr/UriTest.php
+++ b/tests/Tests/Unit/Http/Message/Uri/Psr/UriTest.php
@@ -15,7 +15,7 @@ namespace Valkyrja\Tests\Unit\Http\Message\Uri\Psr;
 
 use Valkyrja\Http\Message\Uri\Enum\Scheme;
 use Valkyrja\Http\Message\Uri\Factory\UriFactory;
-use Valkyrja\Http\Message\Uri\Psr\Uri as Psr;
+use Valkyrja\Http\Message\Uri\Psr\Uri;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 class UriTest extends TestCase
@@ -26,7 +26,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getScheme()->value, $psr->getScheme());
     }
@@ -35,7 +35,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getAuthority(), $psr->getAuthority());
     }
@@ -44,7 +44,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getUserInfo(), $psr->getUserInfo());
     }
@@ -53,7 +53,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getHost(), $psr->getHost());
     }
@@ -62,7 +62,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getPort(), $psr->getPort());
     }
@@ -71,7 +71,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getPath(), $psr->getPath());
     }
@@ -80,7 +80,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getQuery(), $psr->getQuery());
     }
@@ -89,7 +89,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->getFragment(), $psr->getFragment());
     }
@@ -100,7 +100,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withScheme($value);
 
         self::assertSame($value, $psr->getScheme());
@@ -113,7 +113,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withUserInfo($value);
 
         self::assertSame($value, $psr->getUserInfo());
@@ -126,7 +126,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withHost($value);
 
         self::assertSame($value, $psr->getHost());
@@ -139,7 +139,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withPort($value);
 
         self::assertSame($value, $psr->getPort());
@@ -152,7 +152,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withPath($value);
 
         self::assertSame($value, $psr->getPath());
@@ -165,7 +165,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withQuery($value);
 
         self::assertSame($value, $psr->getQuery());
@@ -178,7 +178,7 @@ class UriTest extends TestCase
 
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
         $psr = $psr->withFragment($value);
 
         self::assertSame($value, $psr->getFragment());
@@ -189,7 +189,7 @@ class UriTest extends TestCase
     {
         $uri = UriFactory::fromString(self::URI_ALL_PARTS);
 
-        $psr = new Psr($uri);
+        $psr = new Uri($uri);
 
         self::assertSame($uri->__toString(), $psr->__toString());
     }

--- a/tests/Tests/Unit/Sms/Messenger/VonageMessengerTest.php
+++ b/tests/Tests/Unit/Sms/Messenger/VonageMessengerTest.php
@@ -21,7 +21,7 @@ use Valkyrja\Sms\Messenger\VonageMessenger;
 use Valkyrja\Tests\Classes\Vendor\Vonage\ClientClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Vonage\Client;
-use Vonage\Client\Exception\Exception as VonageException;
+use Vonage\Client\Exception\Exception;
 use Vonage\SMS\Client as SmsClient;
 use Vonage\SMS\Message\SMS;
 
@@ -48,7 +48,7 @@ class VonageMessengerTest extends TestCase
 
     /**
      * @throws ClientExceptionInterface
-     * @throws VonageException
+     * @throws Exception
      */
     public function testSendSuccess(): void
     {
@@ -97,9 +97,9 @@ class VonageMessengerTest extends TestCase
         $this->smsClient
             ->expects($this->once())
             ->method('send')
-            ->willThrowException(new VonageException('Failed to send SMS'));
+            ->willThrowException(new Exception('Failed to send SMS'));
 
-        $this->expectException(VonageException::class);
+        $this->expectException(Exception::class);
         $this->expectExceptionMessage('Failed to send SMS');
 
         $messenger = new VonageMessenger($this->vonageClient);

--- a/tests/Tests/Unit/Type/Uid/UidTest.php
+++ b/tests/Tests/Unit/Type/Uid/UidTest.php
@@ -16,7 +16,7 @@ namespace Valkyrja\Tests\Unit\Type\Uid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uid\Factory\UidFactory as Helper;
+use Valkyrja\Type\Uid\Factory\UidFactory;
 use Valkyrja\Type\Uid\Throwable\Exception\InvalidUidException;
 use Valkyrja\Type\Uid\Uid;
 
@@ -28,14 +28,14 @@ class UidTest extends TestCase
     {
         $id = new Uid('abc123');
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UidFactory::isValid($id->asValue()));
     }
 
     public function testFromValue(): void
     {
         $id = Uid::fromValue('abc123');
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -52,7 +52,7 @@ class UidTest extends TestCase
     {
         $id = new Uid('abc123');
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UidFactory::isValid($id->asFlatValue()));
     }
 
     /**

--- a/tests/Tests/Unit/Type/Ulid/UlidTest.php
+++ b/tests/Tests/Unit/Type/Ulid/UlidTest.php
@@ -16,7 +16,7 @@ namespace Valkyrja\Tests\Unit\Type\Ulid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Ulid\Factory\UlidFactory as Helper;
+use Valkyrja\Type\Ulid\Factory\UlidFactory;
 use Valkyrja\Type\Ulid\Ulid;
 
 use function json_encode;
@@ -30,7 +30,7 @@ class UlidTest extends TestCase
     {
         $id = new Ulid();
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UlidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UlidTest extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Ulid::fromValue(Helper::generate());
+        $id = Ulid::fromValue(UlidFactory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UlidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -57,7 +57,7 @@ class UlidTest extends TestCase
     {
         $id = new Ulid();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UlidFactory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -65,9 +65,9 @@ class UlidTest extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
+        $value    = UlidFactory::generate();
         $type     = new Ulid($value);
-        $newValue = Helper::generate();
+        $newValue = UlidFactory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -83,7 +83,7 @@ class UlidTest extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
+        $value = UlidFactory::generate();
         $type  = new Ulid($value);
 
         self::assertSame(json_encode($value), json_encode($type));

--- a/tests/Tests/Unit/Type/Uuid/UuidTest.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidTest.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidFactory as Helper;
-use Valkyrja\Type\Uuid\Uuid as Id;
+use Valkyrja\Type\Uuid\Factory\UuidFactory;
+use Valkyrja\Type\Uuid\Uuid;
 
 use function json_encode;
 
@@ -30,7 +30,7 @@ class UuidTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        Uuid::fromValue(1);
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidTest extends TestCase
      */
     public function testUuidV1(): void
     {
-        $id = new Id(Helper::v1());
+        $id = new Uuid(UuidFactory::v1());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -48,9 +48,9 @@ class UuidTest extends TestCase
      */
     public function testUuidV3(): void
     {
-        $id = new Id(Helper::v3(Helper::v1(), 'test'));
+        $id = new Uuid(UuidFactory::v3(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -58,9 +58,9 @@ class UuidTest extends TestCase
      */
     public function testUuidV4(): void
     {
-        $id = new Id(Helper::v4());
+        $id = new Uuid(UuidFactory::v4());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -68,9 +68,9 @@ class UuidTest extends TestCase
      */
     public function testUuidV5(): void
     {
-        $id = new Id(Helper::v5(Helper::v1(), 'test'));
+        $id = new Uuid(UuidFactory::v5(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -78,9 +78,9 @@ class UuidTest extends TestCase
      */
     public function testUuidV6(): void
     {
-        $id = new Id(Helper::v6());
+        $id = new Uuid(UuidFactory::v6());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidFactory::isValid($id->asValue()));
     }
 
     /**
@@ -88,9 +88,9 @@ class UuidTest extends TestCase
      */
     public function testAsFlatValue(): void
     {
-        $id = new Id(Helper::v1());
+        $id = new Uuid(UuidFactory::v1());
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidFactory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -98,9 +98,9 @@ class UuidTest extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::v1();
-        $type     = new Id($value);
-        $newValue = Helper::v1();
+        $value    = UuidFactory::v1();
+        $type     = new Uuid($value);
+        $newValue = UuidFactory::v1();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -116,8 +116,8 @@ class UuidTest extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::v1();
-        $type  = new Id($value);
+        $value = UuidFactory::v1();
+        $type  = new Uuid($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV1Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV1Test.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidV1Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV1 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV1Factory;
+use Valkyrja\Type\Uuid\UuidV1;
 
 use function json_encode;
 
@@ -28,9 +28,9 @@ class UuidV1Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id();
+        $id = new UuidV1();
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV1Factory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidV1Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = UuidV1::fromValue(UuidV1Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV1Factory::isValid($id->asValue()));
     }
 
     /**
@@ -50,14 +50,14 @@ class UuidV1Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV1::fromValue(1);
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new UuidV1();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV1Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -65,9 +65,9 @@ class UuidV1Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = UuidV1Factory::generate();
+        $type     = new UuidV1($value);
+        $newValue = UuidV1Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -83,8 +83,8 @@ class UuidV1Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = UuidV1Factory::generate();
+        $type  = new UuidV1($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV3Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV3Test.php
@@ -17,8 +17,8 @@ use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
 use Valkyrja\Type\Uuid\Factory\UuidFactory;
-use Valkyrja\Type\Uuid\Factory\UuidV3Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV3 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV3Factory;
+use Valkyrja\Type\Uuid\UuidV3;
 
 use function json_encode;
 
@@ -29,9 +29,9 @@ class UuidV3Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = new UuidV3(UuidV3Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV3Factory::isValid($id->asValue()));
     }
 
     /**
@@ -39,9 +39,9 @@ class UuidV3Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = UuidV3::fromValue(UuidV3Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV3Factory::isValid($id->asValue()));
     }
 
     /**
@@ -51,7 +51,7 @@ class UuidV3Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV3::fromValue(1);
     }
 
     /**
@@ -59,9 +59,9 @@ class UuidV3Test extends TestCase
      */
     public function testAsFlatValue(): void
     {
-        $id = new Id(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = new UuidV3(UuidV3Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV3Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -69,9 +69,9 @@ class UuidV3Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate(UuidFactory::v1(), 'test');
-        $type     = new Id($value);
-        $newValue = Helper::generate(UuidFactory::v1(), 'test');
+        $value    = UuidV3Factory::generate(UuidFactory::v1(), 'test');
+        $type     = new UuidV3($value);
+        $newValue = UuidV3Factory::generate(UuidFactory::v1(), 'test');
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -87,8 +87,8 @@ class UuidV3Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate(UuidFactory::v1(), 'test');
-        $type  = new Id($value);
+        $value = UuidV3Factory::generate(UuidFactory::v1(), 'test');
+        $type  = new UuidV3($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV4Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV4Test.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidV4Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV4 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV4Factory;
+use Valkyrja\Type\Uuid\UuidV4;
 
 use function json_encode;
 
@@ -28,9 +28,9 @@ class UuidV4Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id();
+        $id = new UuidV4();
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV4Factory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidV4Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = UuidV4::fromValue(UuidV4Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV4Factory::isValid($id->asValue()));
     }
 
     /**
@@ -50,14 +50,14 @@ class UuidV4Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV4::fromValue(1);
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new UuidV4();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV4Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -65,9 +65,9 @@ class UuidV4Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = UuidV4Factory::generate();
+        $type     = new UuidV4($value);
+        $newValue = UuidV4Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -83,8 +83,8 @@ class UuidV4Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = UuidV4Factory::generate();
+        $type  = new UuidV4($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV5Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV5Test.php
@@ -17,8 +17,8 @@ use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
 use Valkyrja\Type\Uuid\Factory\UuidFactory;
-use Valkyrja\Type\Uuid\Factory\UuidV5Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV5 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV5Factory;
+use Valkyrja\Type\Uuid\UuidV5;
 
 use function json_encode;
 
@@ -29,9 +29,9 @@ class UuidV5Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = new UuidV5(UuidV5Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV5Factory::isValid($id->asValue()));
     }
 
     /**
@@ -39,9 +39,9 @@ class UuidV5Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = UuidV5::fromValue(UuidV5Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV5Factory::isValid($id->asValue()));
     }
 
     /**
@@ -51,7 +51,7 @@ class UuidV5Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV5::fromValue(1);
     }
 
     /**
@@ -59,9 +59,9 @@ class UuidV5Test extends TestCase
      */
     public function testAsFlatValue(): void
     {
-        $id = new Id(Helper::generate(UuidFactory::v1(), 'test'));
+        $id = new UuidV5(UuidV5Factory::generate(UuidFactory::v1(), 'test'));
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV5Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -69,9 +69,9 @@ class UuidV5Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate(UuidFactory::v1(), 'test');
-        $type     = new Id($value);
-        $newValue = Helper::generate(UuidFactory::v1(), 'test');
+        $value    = UuidV5Factory::generate(UuidFactory::v1(), 'test');
+        $type     = new UuidV5($value);
+        $newValue = UuidV5Factory::generate(UuidFactory::v1(), 'test');
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -87,8 +87,8 @@ class UuidV5Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate(UuidFactory::v1(), 'test');
-        $type  = new Id($value);
+        $value = UuidV5Factory::generate(UuidFactory::v1(), 'test');
+        $type  = new UuidV5($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV6Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV6Test.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidV6Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV6 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV6Factory;
+use Valkyrja\Type\Uuid\UuidV6;
 
 use function json_encode;
 
@@ -28,9 +28,9 @@ class UuidV6Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id();
+        $id = new UuidV6();
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV6Factory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidV6Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = UuidV6::fromValue(UuidV6Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV6Factory::isValid($id->asValue()));
     }
 
     /**
@@ -50,14 +50,14 @@ class UuidV6Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV6::fromValue(1);
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new UuidV6();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV6Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -65,9 +65,9 @@ class UuidV6Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = UuidV6Factory::generate();
+        $type     = new UuidV6($value);
+        $newValue = UuidV6Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -83,8 +83,8 @@ class UuidV6Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = UuidV6Factory::generate();
+        $type  = new UuidV6($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV7Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV7Test.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidV7Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV7 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV7Factory;
+use Valkyrja\Type\Uuid\UuidV7;
 
 use function json_encode;
 
@@ -28,9 +28,9 @@ class UuidV7Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id(Helper::generate());
+        $id = new UuidV7(UuidV7Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV7Factory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidV7Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = UuidV7::fromValue(UuidV7Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV7Factory::isValid($id->asValue()));
     }
 
     /**
@@ -50,7 +50,7 @@ class UuidV7Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV7::fromValue(1);
     }
 
     /**
@@ -58,9 +58,9 @@ class UuidV7Test extends TestCase
      */
     public function testAsFlatValue(): void
     {
-        $id = new Id(Helper::generate());
+        $id = new UuidV7(UuidV7Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV7Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -68,9 +68,9 @@ class UuidV7Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = UuidV7Factory::generate();
+        $type     = new UuidV7($value);
+        $newValue = UuidV7Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -86,8 +86,8 @@ class UuidV7Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = UuidV7Factory::generate();
+        $type  = new UuidV7($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Uuid/UuidV8Test.php
+++ b/tests/Tests/Unit/Type/Uuid/UuidV8Test.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Uuid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Uuid\Factory\UuidV8Factory as Helper;
-use Valkyrja\Type\Uuid\UuidV8 as Id;
+use Valkyrja\Type\Uuid\Factory\UuidV8Factory;
+use Valkyrja\Type\Uuid\UuidV8;
 
 use function json_encode;
 
@@ -28,9 +28,9 @@ class UuidV8Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $id = new Id(Helper::generate());
+        $id = new UuidV8(UuidV8Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV8Factory::isValid($id->asValue()));
     }
 
     /**
@@ -38,9 +38,9 @@ class UuidV8Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = UuidV8::fromValue(UuidV8Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(UuidV8Factory::isValid($id->asValue()));
     }
 
     /**
@@ -50,7 +50,7 @@ class UuidV8Test extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        UuidV8::fromValue(1);
     }
 
     /**
@@ -58,9 +58,9 @@ class UuidV8Test extends TestCase
      */
     public function testAsFlatValue(): void
     {
-        $id = new Id(Helper::generate());
+        $id = new UuidV8(UuidV8Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(UuidV8Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -68,9 +68,9 @@ class UuidV8Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = UuidV8Factory::generate();
+        $type     = new UuidV8($value);
+        $newValue = UuidV8Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -86,8 +86,8 @@ class UuidV8Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = UuidV8Factory::generate();
+        $type  = new UuidV8($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Vlid/VlidTest.php
+++ b/tests/Tests/Unit/Type/Vlid/VlidTest.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Tests\Unit\Type\Vlid;
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Throwable\Exception\InvalidArgumentException;
-use Valkyrja\Type\Vlid\Factory\VlidFactory as Helper;
-use Valkyrja\Type\Vlid\Vlid as Id;
+use Valkyrja\Type\Vlid\Factory\VlidFactory;
+use Valkyrja\Type\Vlid\Vlid;
 
 use function json_encode;
 
@@ -25,9 +25,9 @@ class VlidTest extends TestCase
 {
     public function testConstruct(): void
     {
-        $vlid = new Id();
+        $vlid = new Vlid();
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidFactory::isValid($vlid->asValue()));
     }
 
     /**
@@ -35,9 +35,9 @@ class VlidTest extends TestCase
      */
     public function testFromValue(): void
     {
-        $vlid = Id::fromValue(Helper::v1());
+        $vlid = Vlid::fromValue(VlidFactory::v1());
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidFactory::isValid($vlid->asValue()));
     }
 
     /**
@@ -47,14 +47,14 @@ class VlidTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        Id::fromValue(1);
+        Vlid::fromValue(1);
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new Vlid();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(VlidFactory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -62,9 +62,9 @@ class VlidTest extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = VlidFactory::generate();
+        $type     = new Vlid($value);
+        $newValue = VlidFactory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -80,8 +80,8 @@ class VlidTest extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = VlidFactory::generate();
+        $type  = new Vlid($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Vlid/VlidV1Test.php
+++ b/tests/Tests/Unit/Type/Vlid/VlidV1Test.php
@@ -15,8 +15,8 @@ namespace Valkyrja\Tests\Unit\Type\Vlid;
 
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\Type\Vlid\Factory\VlidV1Factory as Helper;
-use Valkyrja\Type\Vlid\VlidV1 as Id;
+use Valkyrja\Type\Vlid\Factory\VlidV1Factory;
+use Valkyrja\Type\Vlid\VlidV1;
 
 use function json_encode;
 
@@ -27,9 +27,9 @@ class VlidV1Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $vlid = new Id();
+        $vlid = new VlidV1();
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV1Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -37,9 +37,9 @@ class VlidV1Test extends TestCase
      */
     public function testLowercase(): void
     {
-        $vlid = new Id(Helper::generateLowerCase());
+        $vlid = new VlidV1(VlidV1Factory::generateLowerCase());
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV1Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -47,16 +47,16 @@ class VlidV1Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = VlidV1::fromValue(VlidV1Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(VlidV1Factory::isValid($id->asValue()));
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new VlidV1();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(VlidV1Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -64,9 +64,9 @@ class VlidV1Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = VlidV1Factory::generate();
+        $type     = new VlidV1($value);
+        $newValue = VlidV1Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -82,8 +82,8 @@ class VlidV1Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = VlidV1Factory::generate();
+        $type  = new VlidV1($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Vlid/VlidV2Test.php
+++ b/tests/Tests/Unit/Type/Vlid/VlidV2Test.php
@@ -15,8 +15,8 @@ namespace Valkyrja\Tests\Unit\Type\Vlid;
 
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\Type\Vlid\Factory\VlidV2Factory as Helper;
-use Valkyrja\Type\Vlid\VlidV2 as Id;
+use Valkyrja\Type\Vlid\Factory\VlidV2Factory;
+use Valkyrja\Type\Vlid\VlidV2;
 
 use function json_encode;
 
@@ -27,9 +27,9 @@ class VlidV2Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $vlid = new Id();
+        $vlid = new VlidV2();
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV2Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -37,9 +37,9 @@ class VlidV2Test extends TestCase
      */
     public function testLowercase(): void
     {
-        $vlid = new Id(Helper::generateLowerCase());
+        $vlid = new VlidV2(VlidV2Factory::generateLowerCase());
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV2Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -47,16 +47,16 @@ class VlidV2Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = VlidV2::fromValue(VlidV2Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(VlidV2Factory::isValid($id->asValue()));
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new VlidV2();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(VlidV2Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -64,9 +64,9 @@ class VlidV2Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = VlidV2Factory::generate();
+        $type     = new VlidV2($value);
+        $newValue = VlidV2Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -82,8 +82,8 @@ class VlidV2Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = VlidV2Factory::generate();
+        $type  = new VlidV2($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Vlid/VlidV3Test.php
+++ b/tests/Tests/Unit/Type/Vlid/VlidV3Test.php
@@ -15,8 +15,8 @@ namespace Valkyrja\Tests\Unit\Type\Vlid;
 
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\Type\Vlid\Factory\VlidV3Factory as Helper;
-use Valkyrja\Type\Vlid\VlidV3 as Id;
+use Valkyrja\Type\Vlid\Factory\VlidV3Factory;
+use Valkyrja\Type\Vlid\VlidV3;
 
 use function json_encode;
 
@@ -27,9 +27,9 @@ class VlidV3Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $vlid = new Id();
+        $vlid = new VlidV3();
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV3Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -37,9 +37,9 @@ class VlidV3Test extends TestCase
      */
     public function testLowercase(): void
     {
-        $vlid = new Id(Helper::generateLowerCase());
+        $vlid = new VlidV3(VlidV3Factory::generateLowerCase());
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV3Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -47,16 +47,16 @@ class VlidV3Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = VlidV3::fromValue(VlidV3Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(VlidV3Factory::isValid($id->asValue()));
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new VlidV3();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(VlidV3Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -64,9 +64,9 @@ class VlidV3Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = VlidV3Factory::generate();
+        $type     = new VlidV3($value);
+        $newValue = VlidV3Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -82,8 +82,8 @@ class VlidV3Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = VlidV3Factory::generate();
+        $type  = new VlidV3($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }

--- a/tests/Tests/Unit/Type/Vlid/VlidV4Test.php
+++ b/tests/Tests/Unit/Type/Vlid/VlidV4Test.php
@@ -15,8 +15,8 @@ namespace Valkyrja\Tests\Unit\Type\Vlid;
 
 use Exception;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\Type\Vlid\Factory\VlidV4Factory as Helper;
-use Valkyrja\Type\Vlid\VlidV4 as Id;
+use Valkyrja\Type\Vlid\Factory\VlidV4Factory;
+use Valkyrja\Type\Vlid\VlidV4;
 
 use function json_encode;
 
@@ -27,9 +27,9 @@ class VlidV4Test extends TestCase
      */
     public function testConstruct(): void
     {
-        $vlid = new Id();
+        $vlid = new VlidV4();
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV4Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -37,9 +37,9 @@ class VlidV4Test extends TestCase
      */
     public function testLowercase(): void
     {
-        $vlid = new Id(Helper::generateLowerCase());
+        $vlid = new VlidV4(VlidV4Factory::generateLowerCase());
 
-        self::assertTrue(Helper::isValid($vlid->asValue()));
+        self::assertTrue(VlidV4Factory::isValid($vlid->asValue()));
     }
 
     /**
@@ -47,16 +47,16 @@ class VlidV4Test extends TestCase
      */
     public function testFromValue(): void
     {
-        $id = Id::fromValue(Helper::generate());
+        $id = VlidV4::fromValue(VlidV4Factory::generate());
 
-        self::assertTrue(Helper::isValid($id->asValue()));
+        self::assertTrue(VlidV4Factory::isValid($id->asValue()));
     }
 
     public function testAsFlatValue(): void
     {
-        $id = new Id();
+        $id = new VlidV4();
 
-        self::assertTrue(Helper::isValid($id->asFlatValue()));
+        self::assertTrue(VlidV4Factory::isValid($id->asFlatValue()));
     }
 
     /**
@@ -64,9 +64,9 @@ class VlidV4Test extends TestCase
      */
     public function testModify(): void
     {
-        $value    = Helper::generate();
-        $type     = new Id($value);
-        $newValue = Helper::generate();
+        $value    = VlidV4Factory::generate();
+        $type     = new VlidV4($value);
+        $newValue = VlidV4Factory::generate();
 
         $modified = $type->modify(static fn (string $subject): string => $newValue);
 
@@ -82,8 +82,8 @@ class VlidV4Test extends TestCase
      */
     public function testIntJsonSerialize(): void
     {
-        $value = Helper::generate();
-        $type  = new Id($value);
+        $value = VlidV4Factory::generate();
+        $type  = new VlidV4($value);
 
         self::assertSame(json_encode($value), json_encode($type));
     }


### PR DESCRIPTION
# Description

Fix bug in RemoveNonConflictingAliasInUseStatementRector where we were comparing the alias to itself.

Updating classes accordingly.

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->