### PR TITLE
[Session] Remove ability to specify session id.

### DIFF
--- a/src/Valkyrja/Session/Manager/PhpSession.php
+++ b/src/Valkyrja/Session/Manager/PhpSession.php
@@ -102,7 +102,7 @@ class PhpSession extends Session
     {
         parent::setId($id);
 
-        $this->sessionId($id);
+        $this->sessionId();
     }
 
     /**
@@ -165,9 +165,9 @@ class PhpSession extends Session
     /**
      * Get or set the session id.
      */
-    protected function sessionId(string|null $sessionId = null): string|false
+    protected function sessionId(): string|false
     {
-        return session_id($sessionId);
+        return session_id();
     }
 
     /**

--- a/tests/Tests/Unit/Session/Manager/PhpSessionTest.php
+++ b/tests/Tests/Unit/Session/Manager/PhpSessionTest.php
@@ -88,7 +88,7 @@ final class PhpSessionTest extends TestCase
     {
         $session = new PhpSession($this->cookieParams, 'test-session-id', 'MY_SESSION');
 
-        self::assertSame('test-session-id', $session->getId());
+        self::assertNotSame('test-session-id', $session->getId());
         self::assertSame('MY_SESSION', $session->getName());
     }
 


### PR DESCRIPTION
# Description

Remove ability to specify session id.

https://sonarcloud.io/organizations/valkyrjaio/rules?open=php%3AS5328&rule_key=php%3AS5328

https://sonarcloud.io/project/issues?issues=AZw2mYAEf9UPpisrjh3V&open=AZw2mYAEf9UPpisrjh3V&id=valkyrjaio_valkyrja

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->