### PR TITLE
[Http] Add route processing to routes collected through provider.

### DIFF
--- a/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
@@ -269,7 +269,8 @@ final class ServiceProvider extends Provider
         $application = $container->getSingleton(ApplicationContract::class);
 
         /** @var CollectorContract $collector */
-        $collector   = $container->getSingleton(CollectorContract::class);
+        $collector = $container->getSingleton(CollectorContract::class);
+        $processor = $container->getSingleton(ProcessorContract::class);
 
         $providers = $application->getHttpProviders();
 
@@ -297,7 +298,9 @@ final class ServiceProvider extends Provider
         }
 
         foreach ($routes as $route) {
-            $collection->add($route);
+            $collection->add(
+                $processor->route($route)
+            );
         }
 
         $dataGenerator = $container->getSingleton(DataFileGeneratorContract::class);

--- a/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
@@ -157,9 +157,10 @@ final class ServiceProviderTest extends ServiceProviderTestCase
     {
         $container = $this->container;
 
-        $container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
-        $container->setSingleton(CollectorContract::class, $collector = self::createStub(CollectorContract::class));
-        $container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
+        $container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
+        $container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
+        $container->setSingleton(ProcessorContract::class, $processor = $this->createMock(ProcessorContract::class));
 
         self::assertFalse($container->has(CollectionContract::class));
 
@@ -168,10 +169,11 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             name: 'route',
             dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
-        $collector->method('getRoutes')->willReturn([$route]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $collector->expects($this->once())->method('getRoutes')->willReturn([$route]);
+        $generator->expects($this->once())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
-        $application->method('getHttpProviders')->willReturn([RouteProviderClass::class]);
+        $application->expects($this->once())->method('getHttpProviders')->willReturn([RouteProviderClass::class]);
+        $processor->expects($this->once())->method('route')->willReturnArgument(0);
 
         $callback = ServiceProvider::publishers()[CollectionContract::class];
         $callback($this->container);


### PR DESCRIPTION
# Description

Add route processing to routes collected through provider.

Prior to this routes provided by a provider via the getRoutes method were not processed, and all properties had to be set perfectly (unlike routes collected via attributed controllers or actions).

## Types of changes

- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->