### PR TITLE
[Http] Update collection to get dynamic routes by path

### DIFF
--- a/src/Valkyrja/Http/Routing/Collection/Collection.php
+++ b/src/Valkyrja/Http/Routing/Collection/Collection.php
@@ -233,17 +233,20 @@ class Collection implements CollectionContract
     protected function setRouteToRequestMethod(RouteContract $route, RequestMethod $requestMethod): void
     {
         $name  = $route->getName();
+        $path  = $route->getPath();
         $regex = $route->getRegex();
 
         // If this is a dynamic route
         if ($regex !== null) {
             // Set the route in the dynamic routes list
-            $this->dynamic[$requestMethod->value][$regex] = $name;
-        } else {
-            // Otherwise set it in the static routes array
-            // Set the route in the static routes list
-            $this->static[$requestMethod->value][$route->getPath()] = $name;
+            $this->dynamic[$requestMethod->value][$path] = $name;
+
+            return;
         }
+
+        // Otherwise set it in the static routes array
+        // Set the route in the static routes list
+        $this->static[$requestMethod->value][$path] = $name;
     }
 
     /**

--- a/src/Valkyrja/Http/Routing/Collection/Contract/CollectionContract.php
+++ b/src/Valkyrja/Http/Routing/Collection/Contract/CollectionContract.php
@@ -102,9 +102,7 @@ interface CollectionContract
     /**
      * Get static routes of a certain request method.
      *
-     * @param RequestMethod|null $method [optional] The request method
-     *
-     * @return array<string, RouteContract>|array<string, array<string, RouteContract>>
+     * @return ($method is null ? array<string, array<string, RouteContract>> : array<string, RouteContract>)
      */
     public function allStatic(RequestMethod|null $method = null): array;
 
@@ -131,7 +129,7 @@ interface CollectionContract
     /**
      * Get the dynamic routes in this collection.
      *
-     * @return array<string, RouteContract>|array<string, array<string, RouteContract>>
+     * @return ($method is null ? array<string, array<string, RouteContract>> : array<string, RouteContract>)
      */
     public function allDynamic(RequestMethod|null $method = null): array;
 

--- a/tests/Tests/Unit/Http/Routing/Collection/CollectionTest.php
+++ b/tests/Tests/Unit/Http/Routing/Collection/CollectionTest.php
@@ -135,7 +135,7 @@ final class CollectionTest extends TestCase
     public function testHas(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $collection = $this->collection;
 
@@ -164,7 +164,7 @@ final class CollectionTest extends TestCase
     public function testGet(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $route        = $this->route;
         $dynamicRoute = $this->dynamicRoute;
@@ -195,7 +195,7 @@ final class CollectionTest extends TestCase
     public function testHasStatic(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $collection = $this->collection;
 
@@ -224,7 +224,7 @@ final class CollectionTest extends TestCase
     public function testGetStatic(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $route      = $this->route;
         $collection = $this->collection;
@@ -254,7 +254,7 @@ final class CollectionTest extends TestCase
     public function testHasDynamic(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $collection = $this->collection;
 
@@ -283,7 +283,7 @@ final class CollectionTest extends TestCase
     public function testGetDynamic(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $dynamicRoute = $this->dynamicRoute;
         $collection   = $this->collection;
@@ -338,7 +338,7 @@ final class CollectionTest extends TestCase
     public function testAll(): void
     {
         $routePath        = self::ROUTE_PATH;
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $route        = $this->route;
         $dynamicRoute = $this->dynamicRoute;
@@ -403,7 +403,7 @@ final class CollectionTest extends TestCase
 
     public function testAllDynamic(): void
     {
-        $dynamicRoutePath = self::DYNAMIC_ROUTE_REGEX;
+        $dynamicRoutePath = self::DYNAMIC_ROUTE_PATH;
 
         $dynamicRoute = $this->dynamicRoute;
         $collection   = $this->collection;


### PR DESCRIPTION
# Description

Update collection to get dynamic routes by path instead of needing to know their final regex.

Prior you could only look up dynamic routes by their final regex, which usually was only known after processing, which to a human developer is kind of hard to figure out, vs. using the human readable path the dev created in the first place.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->