### PR TITLE
[Attribute] Remove unnecessary null return type from ReflectionAwareAttribute

### DIFF
--- a/src/Valkyrja/Attribute/Contract/ReflectionAwareAttributeContract.php
+++ b/src/Valkyrja/Attribute/Contract/ReflectionAwareAttributeContract.php
@@ -20,7 +20,7 @@ interface ReflectionAwareAttributeContract
     /**
      * Get the reflection.
      */
-    public function getReflection(): Reflector|null;
+    public function getReflection(): Reflector;
 
     /**
      * Set the reflection.

--- a/src/Valkyrja/Attribute/Trait/ReflectionAwareAttribute.php
+++ b/src/Valkyrja/Attribute/Trait/ReflectionAwareAttribute.php
@@ -17,12 +17,12 @@ use Reflector;
 
 trait ReflectionAwareAttribute
 {
-    protected Reflector|null $reflection = null;
+    protected Reflector $reflection;
 
     /**
      * Get the reflection.
      */
-    public function getReflection(): Reflector|null
+    public function getReflection(): Reflector
     {
         return $this->reflection;
     }


### PR DESCRIPTION
# Description

Remove unnecessary null return type from ReflectionAwareAttribute.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->