### PR TITLE
[Cache] Remove null types where sensible

### DIFF
--- a/src/Valkyrja/Cache/Manager/Contract/CacheContract.php
+++ b/src/Valkyrja/Cache/Manager/Contract/CacheContract.php
@@ -25,7 +25,7 @@ interface CacheContract
     /**
      * Retrieve an item from the cache by key.
      */
-    public function get(string $key): string|null;
+    public function get(string $key): string;
 
     /**
      * Retrieve multiple items from the cache by key.

--- a/src/Valkyrja/Cache/Manager/LogCache.php
+++ b/src/Valkyrja/Cache/Manager/LogCache.php
@@ -46,7 +46,7 @@ class LogCache implements CacheContract
      * @inheritDoc
      */
     #[Override]
-    public function get(string $key): string|null
+    public function get(string $key): string
     {
         $key = $this->getKey($key);
 

--- a/src/Valkyrja/Cache/Manager/NullCache.php
+++ b/src/Valkyrja/Cache/Manager/NullCache.php
@@ -38,7 +38,7 @@ class NullCache implements CacheContract
      * @inheritDoc
      */
     #[Override]
-    public function get(string $key): string|null
+    public function get(string $key): string
     {
         return '';
     }

--- a/src/Valkyrja/Cache/Manager/RedisCache.php
+++ b/src/Valkyrja/Cache/Manager/RedisCache.php
@@ -18,6 +18,7 @@ use Predis\Client;
 use Valkyrja\Cache\Manager\Contract\CacheContract;
 use Valkyrja\Cache\Tagger\Contract\TaggerContract;
 use Valkyrja\Cache\Tagger\Tagger;
+use Valkyrja\Cache\Throwable\Exception\InvalidCacheKeyException;
 
 class RedisCache implements CacheContract
 {
@@ -40,9 +41,10 @@ class RedisCache implements CacheContract
      * @inheritDoc
      */
     #[Override]
-    public function get(string $key): string|null
+    public function get(string $key): string
     {
-        return $this->client->get($this->getKey($key));
+        return $this->client->get($this->getKey($key))
+            ?? throw new InvalidCacheKeyException("Cache miss for key: $key");
     }
 
     /**

--- a/src/Valkyrja/Cache/Tagger/Contract/TaggerContract.php
+++ b/src/Valkyrja/Cache/Tagger/Contract/TaggerContract.php
@@ -35,7 +35,7 @@ interface TaggerContract
     /**
      * Retrieve an item from the cache by key.
      */
-    public function get(string $key): string|null;
+    public function get(string $key): string;
 
     /**
      * Retrieve multiple items from the cache by key.

--- a/src/Valkyrja/Cache/Tagger/Tagger.php
+++ b/src/Valkyrja/Cache/Tagger/Tagger.php
@@ -17,6 +17,7 @@ use JsonException;
 use Override;
 use Valkyrja\Cache\Manager\Contract\CacheContract;
 use Valkyrja\Cache\Tagger\Contract\TaggerContract;
+use Valkyrja\Cache\Throwable\Exception\InvalidCacheKeyException;
 use Valkyrja\Type\Array\Factory\ArrayFactory;
 
 class Tagger implements TaggerContract
@@ -76,7 +77,7 @@ class Tagger implements TaggerContract
      * @throws JsonException
      */
     #[Override]
-    public function get(string $key): string|null
+    public function get(string $key): string
     {
         foreach ($this->tags as $tag) {
             if (isset($this->getKeys($tag)[$key])) {
@@ -84,7 +85,7 @@ class Tagger implements TaggerContract
             }
         }
 
-        return null;
+        throw new InvalidCacheKeyException("Cache miss for key: $key");
     }
 
     /**
@@ -103,10 +104,6 @@ class Tagger implements TaggerContract
             foreach ($keys as $key) {
                 if (isset($cachedKeys[$key])) {
                     $value = $this->adapter->get($key);
-
-                    if ($value === null) {
-                        continue;
-                    }
 
                     $items[] = $value;
                 }
@@ -290,7 +287,7 @@ class Tagger implements TaggerContract
     {
         $keysFromCache = $this->adapter->get($tag);
 
-        if ($keysFromCache !== null && $keysFromCache !== '') {
+        if ($keysFromCache !== '') {
             /** @var string[] $keys */
             $keys = ArrayFactory::fromString($keysFromCache);
 

--- a/src/Valkyrja/Cache/Throwable/Exception/InvalidCacheKeyException.php
+++ b/src/Valkyrja/Cache/Throwable/Exception/InvalidCacheKeyException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Cache\Throwable\Exception;
+
+class InvalidCacheKeyException extends InvalidArgumentException
+{
+}

--- a/src/Valkyrja/Session/Manager/CacheSession.php
+++ b/src/Valkyrja/Session/Manager/CacheSession.php
@@ -44,10 +44,15 @@ class CacheSession extends Session
     #[Override]
     public function start(): void
     {
+        // If the session data isn't present
+        if (! $this->cache->has($this->getCacheSessionId())) {
+            return;
+        }
+
         $cachedData = $this->cache->get($this->getCacheSessionId());
 
         // If the session data isn't present
-        if ($cachedData === null || $cachedData === '') {
+        if ($cachedData === '') {
             return;
         }
 

--- a/tests/Tests/Unit/Cache/Manager/RedisCacheTest.php
+++ b/tests/Tests/Unit/Cache/Manager/RedisCacheTest.php
@@ -18,6 +18,7 @@ use Predis\Client;
 use Valkyrja\Cache\Manager\Contract\CacheContract;
 use Valkyrja\Cache\Manager\RedisCache;
 use Valkyrja\Cache\Tagger\Contract\TaggerContract;
+use Valkyrja\Cache\Throwable\Exception\InvalidCacheKeyException;
 use Valkyrja\Tests\Classes\Vendor\Predis\ClientClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -78,15 +79,20 @@ final class RedisCacheTest extends TestCase
         self::assertSame('cached-value', $this->cache->get('my-key'));
     }
 
-    public function testGetReturnsNullWhenKeyNotFound(): void
+    public function testGetThrowsWhenKeyNotFound(): void
     {
+        $key = 'my-key';
+
+        $this->expectException(InvalidCacheKeyException::class);
+        $this->expectExceptionMessage("Cache miss for key: $key");
+
         $this->client
             ->expects($this->once())
             ->method('get')
-            ->with($this->prefix . 'my-key')
+            ->with($this->prefix . $key)
             ->willReturn(null);
 
-        self::assertNull($this->cache->get('my-key'));
+        self::assertNull($this->cache->get($key));
     }
 
     public function testManyReturnsValuesFromRedis(): void

--- a/tests/Tests/Unit/Session/Manager/CacheSessionTest.php
+++ b/tests/Tests/Unit/Session/Manager/CacheSessionTest.php
@@ -31,9 +31,15 @@ final class CacheSessionTest extends TestCase
 
         $this->cache
             ->expects($this->once())
+            ->method('has')
+            ->with('_session')
+            ->willReturn(true);
+
+        $this->cache
+            ->expects($this->once())
             ->method('get')
             ->with('_session')
-            ->willReturn(null);
+            ->willReturn('');
 
         $this->session = new CacheSession($this->cache);
     }
@@ -46,6 +52,12 @@ final class CacheSessionTest extends TestCase
     public function testStartLoadsCachedDataWhenAvailable(): void
     {
         $cache = $this->createMock(CacheContract::class);
+
+        $cache
+            ->expects($this->once())
+            ->method('has')
+            ->with('test-session_session')
+            ->willReturn(true);
 
         $cache
             ->expects($this->once())
@@ -65,9 +77,9 @@ final class CacheSessionTest extends TestCase
 
         $cache
             ->expects($this->once())
-            ->method('get')
+            ->method('has')
             ->with('test-session_session')
-            ->willReturn(null);
+            ->willReturn(false);
 
         $session = new CacheSession($cache, 'test-session');
 
@@ -77,6 +89,12 @@ final class CacheSessionTest extends TestCase
     public function testStartDoesNotLoadDataWhenCacheReturnsEmptyString(): void
     {
         $cache = $this->createMock(CacheContract::class);
+
+        $cache
+            ->expects($this->once())
+            ->method('has')
+            ->with('test-session_session')
+            ->willReturn(true);
 
         $cache
             ->expects($this->once())
@@ -95,9 +113,9 @@ final class CacheSessionTest extends TestCase
 
         $cache
             ->expects($this->once())
-            ->method('get')
+            ->method('has')
             ->with('session-id_session')
-            ->willReturn(null);
+            ->willReturn(false);
 
         $cache
             ->expects($this->once())
@@ -113,6 +131,12 @@ final class CacheSessionTest extends TestCase
     public function testRemoveUpdatesCacheSessionWhenItemExists(): void
     {
         $cache = $this->createMock(CacheContract::class);
+
+        $cache
+            ->expects($this->once())
+            ->method('has')
+            ->with('session-id_session')
+            ->willReturn(true);
 
         $cache
             ->expects($this->once())
@@ -138,9 +162,9 @@ final class CacheSessionTest extends TestCase
 
         $cache
             ->expects($this->once())
-            ->method('get')
+            ->method('has')
             ->with('session-id_session')
-            ->willReturn(null);
+            ->willReturn(false);
 
         $cache
             ->expects($this->never())
@@ -155,6 +179,12 @@ final class CacheSessionTest extends TestCase
     public function testClearUpdatesCacheSession(): void
     {
         $cache = $this->createMock(CacheContract::class);
+
+        $cache
+            ->expects($this->once())
+            ->method('has')
+            ->with('session-id_session')
+            ->willReturn(true);
 
         $cache
             ->expects($this->once())
@@ -179,6 +209,12 @@ final class CacheSessionTest extends TestCase
 
         $cache
             ->expects($this->once())
+            ->method('has')
+            ->with('session-id_session')
+            ->willReturn(true);
+
+        $cache
+            ->expects($this->once())
             ->method('get')
             ->with('session-id_session')
             ->willReturn('{"key":"value"}');
@@ -200,8 +236,8 @@ final class CacheSessionTest extends TestCase
 
         $cache
             ->expects($this->once())
-            ->method('get')
-            ->willReturn(null);
+            ->method('has')
+            ->willReturn(false);
 
         $session = new CacheSession($cache, 'session-id', 'MY_SESSION');
 


### PR DESCRIPTION
# Description

Remove null types where sensible.

If you're getting a specific key it should exist, and if it doesn't that's unexpected behavior. If you need to ensure a key exists without throwing an exception you should check the key existing first, then get it.

## Types of changes

- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->