### PR TITLE
[Data] Update the bypass logic for data providers

### DIFF
--- a/src/Valkyrja/Cli/Routing/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Cli/Routing/Generator/DataFileGenerator.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Routing\Generator;
 
 use Override;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\Data;
 use Valkyrja\Cli\Routing\Generator\Contract\DataFileGeneratorContract;
-use Valkyrja\Cli\Routing\Provider\ServiceProvider;
 use Valkyrja\Container\Generator\Abstract\ProviderFileGenerator;
 
 use function is_callable;
@@ -71,13 +69,7 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     #[Override]
     protected function getImports(): string
     {
-        $applicationContract = ApplicationContract::class;
-        $serviceProvider     = ServiceProvider::class;
-
-        return <<<PHP
-            use $applicationContract;
-            use $serviceProvider;
-            PHP;
+        return '';
     }
 
     /**
@@ -87,33 +79,12 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     protected function getPublishContents(): string
     {
         $dataContents = $this->generateClassContents();
-        $bypassLogic  = $this->getDataBypassLogic();
 
         return <<<PHP
-            $bypassLogic
-
             \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
             PHP;
-    }
-
-    /**
-     * Bypass logic for the data.
-     */
-    protected function getDataBypassLogic(): string
-    {
-        // phpcs:disable
-        return <<<'PHP'
-            $app = $container->getSingleton(ApplicationContract::class);
-
-            if ($app->getDebugMode()) {
-                ServiceProvider::publishData($container);
-
-                return;
-            }
-            PHP;
-        // phpcs:enable
     }
 
     /**

--- a/src/Valkyrja/Cli/Routing/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Routing/Provider/ServiceProvider.php
@@ -122,6 +122,14 @@ final class ServiceProvider extends Provider
             $collection = new Collection()
         );
 
+        $app = $container->getSingleton(ApplicationContract::class);
+
+        if ($app->getDebugMode()) {
+            self::publishData($container);
+
+            return;
+        }
+
         $data = $container->getSingleton(Data::class);
 
         $collection->setFromData($data);

--- a/src/Valkyrja/Container/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Container/Generator/DataFileGenerator.php
@@ -14,11 +14,9 @@ declare(strict_types=1);
 namespace Valkyrja\Container\Generator;
 
 use Override;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Data\Data;
 use Valkyrja\Container\Generator\Abstract\ProviderFileGenerator;
 use Valkyrja\Container\Generator\Contract\DataFileGeneratorContract;
-use Valkyrja\Container\Provider\ServiceProvider;
 
 class DataFileGenerator extends ProviderFileGenerator implements DataFileGeneratorContract
 {
@@ -79,13 +77,7 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     #[Override]
     protected function getImports(): string
     {
-        $applicationContract = ApplicationContract::class;
-        $serviceProvider     = ServiceProvider::class;
-
-        return <<<PHP
-            use $applicationContract;
-            use $serviceProvider;
-            PHP;
+        return '';
     }
 
     /**
@@ -95,32 +87,11 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     protected function getPublishContents(): string
     {
         $dataContents = $this->generateClassContents();
-        $bypassLogic  = $this->getDataBypassLogic();
 
         return <<<PHP
-            $bypassLogic
-
             \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
             PHP;
-    }
-
-    /**
-     * Bypass logic for the data.
-     */
-    protected function getDataBypassLogic(): string
-    {
-        // phpcs:disable
-        return <<<'PHP'
-            $app = $container->getSingleton(ApplicationContract::class);
-
-            if ($app->getDebugMode()) {
-                ServiceProvider::publishData($container);
-
-                return;
-            }
-            PHP;
-        // phpcs:enable
     }
 }

--- a/src/Valkyrja/Event/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Event/Generator/DataFileGenerator.php
@@ -14,12 +14,10 @@ declare(strict_types=1);
 namespace Valkyrja\Event\Generator;
 
 use Override;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Generator\Abstract\ProviderFileGenerator;
 use Valkyrja\Event\Data\Contract\ListenerContract;
 use Valkyrja\Event\Data\Data;
 use Valkyrja\Event\Generator\Contract\DataFileGeneratorContract;
-use Valkyrja\Event\Provider\ServiceProvider;
 
 use function is_callable;
 
@@ -73,13 +71,7 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     #[Override]
     protected function getImports(): string
     {
-        $applicationContract = ApplicationContract::class;
-        $serviceProvider     = ServiceProvider::class;
-
-        return <<<PHP
-            use $applicationContract;
-            use $serviceProvider;
-            PHP;
+        return '';
     }
 
     /**
@@ -89,33 +81,12 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     protected function getPublishContents(): string
     {
         $dataContents = $this->generateClassContents();
-        $bypassLogic  = $this->getDataBypassLogic();
 
         return <<<PHP
-            $bypassLogic
-
             \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
             PHP;
-    }
-
-    /**
-     * Bypass logic for the data.
-     */
-    protected function getDataBypassLogic(): string
-    {
-        // phpcs:disable
-        return <<<'PHP'
-            $app = $container->getSingleton(ApplicationContract::class);
-
-            if ($app->getDebugMode()) {
-                ServiceProvider::publishData($container);
-
-                return;
-            }
-            PHP;
-        // phpcs:enable
     }
 
     /**

--- a/src/Valkyrja/Event/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Event/Provider/ServiceProvider.php
@@ -103,6 +103,14 @@ final class ServiceProvider extends Provider
             $collection = new Collection()
         );
 
+        $app = $container->getSingleton(ApplicationContract::class);
+
+        if ($app->getDebugMode()) {
+            self::publishData($container);
+
+            return;
+        }
+
         $data = $container->getSingleton(Data::class);
 
         $collection->setFromData($data);

--- a/src/Valkyrja/Http/Routing/Generator/DataFileGenerator.php
+++ b/src/Valkyrja/Http/Routing/Generator/DataFileGenerator.php
@@ -14,12 +14,10 @@ declare(strict_types=1);
 namespace Valkyrja\Http\Routing\Generator;
 
 use Override;
-use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Generator\Abstract\ProviderFileGenerator;
 use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\Data;
 use Valkyrja\Http\Routing\Generator\Contract\DataFileGeneratorContract;
-use Valkyrja\Http\Routing\Provider\ServiceProvider;
 
 use function is_callable;
 
@@ -78,13 +76,7 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     #[Override]
     protected function getImports(): string
     {
-        $applicationContract = ApplicationContract::class;
-        $serviceProvider     = ServiceProvider::class;
-
-        return <<<PHP
-            use $applicationContract;
-            use $serviceProvider;
-            PHP;
+        return '';
     }
 
     /**
@@ -94,33 +86,12 @@ class DataFileGenerator extends ProviderFileGenerator implements DataFileGenerat
     protected function getPublishContents(): string
     {
         $dataContents = $this->generateClassContents();
-        $bypassLogic  = $this->getDataBypassLogic();
 
         return <<<PHP
-            $bypassLogic
-
             \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
             PHP;
-    }
-
-    /**
-     * Bypass logic for the data.
-     */
-    protected function getDataBypassLogic(): string
-    {
-        // phpcs:disable
-        return <<<'PHP'
-            $app = $container->getSingleton(ApplicationContract::class);
-
-            if ($app->getDebugMode()) {
-                ServiceProvider::publishData($container);
-
-                return;
-            }
-            PHP;
-        // phpcs:enable
     }
 
     /**

--- a/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
@@ -131,6 +131,14 @@ final class ServiceProvider extends Provider
             $collection = new Collection()
         );
 
+        $app = $container->getSingleton(ApplicationContract::class);
+
+        if ($app->getDebugMode()) {
+            self::publishData($container);
+
+            return;
+        }
+
         $data = $container->getSingleton(Data::class);
 
         $collection->setFromData($data);

--- a/tests/Tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Generator/DataFileGeneratorTest.php
@@ -74,8 +74,7 @@ final class DataFileGeneratorTest extends TestCase
             use Valkyrja\Cli\Routing\Data\Data;
             use Valkyrja\Container\Provider\Provider;
             use Valkyrja\Container\Manager\Contract\ContainerContract;
-            use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-            use Valkyrja\Cli\Routing\Provider\ServiceProvider;
+
 
             final class CliDataTestRoutingDataProvider extends Provider
             {
@@ -106,15 +105,7 @@ final class DataFileGeneratorTest extends TestCase
                  */
                 public static function publishData(ContainerContract \$container): void
                 {
-                    \$app = \$container->getSingleton(ApplicationContract::class);
-            
-            if (\$app->getDebugMode()) {
-                ServiceProvider::publishData(\$container);
-            
-                return;
-            }
-
-            \$data = $dataContents;
+                    \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
                 }

--- a/tests/Tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
@@ -102,7 +102,9 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
     public function testPublishCollectionWithCustomDataProvided(): void
     {
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(Data::class, new Data());
+        $application->method('getDebugMode')->willReturn(false);
 
         $callback = ServiceProvider::publishers()[CollectionContract::class];
         $callback($this->container);
@@ -121,9 +123,10 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             ]
         );
 
-        $container->setSingleton(ApplicationContract::class, self::createStub(ApplicationContract::class));
+        $container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $container->setSingleton(CollectorContract::class, self::createStub(CollectorContract::class));
         $container->setSingleton(Data::class, $data);
+        $application->method('getDebugMode')->willReturn(false);
 
         self::assertFalse($container->has(CollectionContract::class));
 
@@ -146,6 +149,37 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = self::createStub(CollectorContract::class));
         $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $application->method('getDebugMode')->willReturn(false);
+
+        $command = new Route(
+            name: 'test',
+            description: 'test',
+            dispatch: new MethodDispatch(self::class, 'dispatch')
+        );
+        $collector->method('getRoutes')->willReturn([$command]);
+        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+
+        $application->method('getCliProviders')->willReturn([RouteProviderClass::class]);
+
+        $callback = ServiceProvider::publishers()[CollectionContract::class];
+        $callback($this->container);
+
+        self::assertInstanceOf(Collection::class, $collection = $this->container->getSingleton(CollectionContract::class));
+        self::assertNotNull($collection->get('test'));
+        self::assertNotNull($collection->get('test-provider'));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testPublishCollectionWithoutDataDebugModeTrue(): void
+    {
+        $this->container->register(ServiceProvider::class);
+
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
+        $this->container->setSingleton(CollectorContract::class, $collector = self::createStub(CollectorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $application->method('getDebugMode')->willReturn(true);
 
         $command = new Route(
             name: 'test',

--- a/tests/Tests/Unit/Container/Generator/DataFileGeneratorTest.php
+++ b/tests/Tests/Unit/Container/Generator/DataFileGeneratorTest.php
@@ -72,8 +72,7 @@ final class DataFileGeneratorTest extends TestCase
             use Valkyrja\Container\Data\Data;
             use Valkyrja\Container\Provider\Provider;
             use Valkyrja\Container\Manager\Contract\ContainerContract;
-            use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-            use Valkyrja\Container\Provider\ServiceProvider;
+
 
             final class ContainerDataTestDataProvider extends Provider
             {
@@ -104,15 +103,7 @@ final class DataFileGeneratorTest extends TestCase
                  */
                 public static function publishData(ContainerContract \$container): void
                 {
-                    \$app = \$container->getSingleton(ApplicationContract::class);
-            
-            if (\$app->getDebugMode()) {
-                ServiceProvider::publishData(\$container);
-            
-                return;
-            }
-
-            \$data = $dataContents;
+                    \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
                 }

--- a/tests/Tests/Unit/Event/Generator/DataFileGeneratorTest.php
+++ b/tests/Tests/Unit/Event/Generator/DataFileGeneratorTest.php
@@ -74,8 +74,7 @@ final class DataFileGeneratorTest extends TestCase
             use Valkyrja\Event\Data\Data;
             use Valkyrja\Container\Provider\Provider;
             use Valkyrja\Container\Manager\Contract\ContainerContract;
-            use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-            use Valkyrja\Event\Provider\ServiceProvider;
+
 
             final class EventDataTestDataProvider extends Provider
             {
@@ -106,15 +105,7 @@ final class DataFileGeneratorTest extends TestCase
                  */
                 public static function publishData(ContainerContract \$container): void
                 {
-                    \$app = \$container->getSingleton(ApplicationContract::class);
-            
-            if (\$app->getDebugMode()) {
-                ServiceProvider::publishData(\$container);
-            
-                return;
-            }
-
-            \$data = $dataContents;
+                    \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
                 }

--- a/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
@@ -91,7 +91,9 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
     public function testPublishCollectionWithCustomDataProvided(): void
     {
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(Data::class, new Data());
+        $application->method('getDebugMode')->willReturn(false);
 
         $callback = ServiceProvider::publishers()[CollectionContract::class];
         $callback($this->container);
@@ -108,9 +110,10 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             listeners: [$listenerName => new Listener(eventId: $eventId, name: $listenerName)]
         );
 
-        $this->container->setSingleton(ApplicationContract::class, self::createStub(ApplicationContract::class));
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, self::createStub(CollectorContract::class));
         $this->container->setSingleton(Data::class, $data);
+        $application->method('getDebugMode')->willReturn(false);
 
         self::assertFalse($this->container->has(CollectionContract::class));
 
@@ -133,6 +136,44 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = self::createStub(CollectorContract::class));
         $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $application->method('getDebugMode')->willReturn(false);
+
+        $eventId      = self::class;
+        $listenerName = 'listener-name';
+        $listener     = new Listener(eventId: $eventId, name: $listenerName);
+
+        $collector->method('getListeners')->willReturn([$listener]);
+        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+
+        $application->method('getEventProviders')->willReturn([ListenerProviderClass::class]);
+
+        self::assertTrue($this->container->has(Data::class));
+
+        $callback = ServiceProvider::publishers()[CollectionContract::class];
+        $callback($this->container);
+
+        self::assertInstanceOf(Collection::class, $collection = $this->container->getSingleton(CollectionContract::class));
+        self::assertTrue($this->container->has(Data::class));
+        self::assertContains($eventId, $collection->getEvents());
+        self::assertTrue($collection->hasListenerById($listenerName));
+        self::assertTrue($collection->hasListener($listener));
+        self::assertTrue($collection->hasListenersForEventById($eventId));
+        self::assertContains(ListenerProviderClass::class, $collection->getEvents());
+        self::assertTrue($collection->hasListenerById('listener-from-provider-name'));
+        self::assertTrue($collection->hasListenersForEventById(ListenerProviderClass::class));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testPublishCollectionWithoutDataDebugModeFalse(): void
+    {
+        $this->container->register(ServiceProvider::class);
+
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
+        $this->container->setSingleton(CollectorContract::class, $collector = self::createStub(CollectorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $application->method('getDebugMode')->willReturn(true);
 
         $eventId      = self::class;
         $listenerName = 'listener-name';

--- a/tests/Tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
+++ b/tests/Tests/Unit/Http/Routing/Generator/DataFileGeneratorTest.php
@@ -74,8 +74,7 @@ final class DataFileGeneratorTest extends TestCase
             use Valkyrja\Http\Routing\Data\Data;
             use Valkyrja\Container\Provider\Provider;
             use Valkyrja\Container\Manager\Contract\ContainerContract;
-            use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-            use Valkyrja\Http\Routing\Provider\ServiceProvider;
+
 
             final class HttpDataTestRoutingDataProvider extends Provider
             {
@@ -106,15 +105,7 @@ final class DataFileGeneratorTest extends TestCase
                  */
                 public static function publishData(ContainerContract \$container): void
                 {
-                    \$app = \$container->getSingleton(ApplicationContract::class);
-            
-            if (\$app->getDebugMode()) {
-                ServiceProvider::publishData(\$container);
-            
-                return;
-            }
-
-            \$data = $dataContents;
+                    \$data = $dataContents;
 
             \$container->setSingleton(Data::class, \$data);
                 }

--- a/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
@@ -117,7 +117,9 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
     public function testPublishCollectionWithCustomDataProvided(): void
     {
+        $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $this->container->setSingleton(Data::class, new Data());
+        $application->method('getDebugMode')->willReturn(false);
 
         $callback = ServiceProvider::publishers()[CollectionContract::class];
         $callback($this->container);
@@ -140,9 +142,10 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             ],
         );
 
-        $container->setSingleton(ApplicationContract::class, self::createStub(ApplicationContract::class));
+        $container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
         $container->setSingleton(CollectorContract::class, self::createStub(CollectorContract::class));
         $container->setSingleton(Data::class, $data);
+        $application->method('getDebugMode')->willReturn(false);
 
         self::assertFalse($container->has(CollectionContract::class));
 
@@ -166,6 +169,43 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
         $container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $container->setSingleton(ProcessorContract::class, $processor = $this->createMock(ProcessorContract::class));
+        $application->method('getDebugMode')->willReturn(false);
+
+        self::assertTrue($container->has(CollectionContract::class));
+
+        $route = new Route(
+            path: '/',
+            name: 'route',
+            dispatch: new MethodDispatch(self::class, 'dispatch'),
+        );
+        $collector->expects($this->once())->method('getRoutes')->willReturn([$route]);
+        $generator->expects($this->once())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+
+        $application->expects($this->once())->method('getHttpProviders')->willReturn([RouteProviderClass::class]);
+        $processor->expects($this->once())->method('route')->willReturnArgument(0);
+
+        $callback = ServiceProvider::publishers()[CollectionContract::class];
+        $callback($this->container);
+
+        self::assertTrue($container->has(CollectionContract::class));
+        self::assertTrue($container->isSingleton(CollectionContract::class));
+        self::assertInstanceOf(Collection::class, $collection = $container->getSingleton(CollectionContract::class));
+
+        self::assertNotNull($collection->getByPath('/', RequestMethod::ANY));
+        self::assertNotNull($collection->getByPath('/from-provider', RequestMethod::ANY));
+    }
+
+    public function testPublishCollectionWithoutDataDebugModeFalse(): void
+    {
+        $this->container->register(ServiceProvider::class);
+
+        $container = $this->container;
+
+        $container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
+        $container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
+        $container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
+        $container->setSingleton(ProcessorContract::class, $processor = $this->createMock(ProcessorContract::class));
+        $application->method('getDebugMode')->willReturn(true);
 
         self::assertTrue($container->has(CollectionContract::class));
 


### PR DESCRIPTION
# Description

Update the bypass logic for data providers.

Fixes the issue of the data providers being used in debug mode whilst being generated.

Update: That was a lie. It's still bottlenecked somehow. I think the simple act of those files being included in any way shape or form is causing said bottleneck.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [X] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->