### PR TITLE
[Data] Add data generation commands for Cli and Http

### DIFF
--- a/src/Valkyrja/Application/Cli/Command/Abstract/GenerateData.php
+++ b/src/Valkyrja/Application/Cli/Command/Abstract/GenerateData.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Application\Cli\Command\Abstract;
+
+use Valkyrja\Application\Data\Config;
+use Valkyrja\Application\Entry\Http;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Cli\Interaction\Formatter\ErrorFormatter;
+use Valkyrja\Cli\Interaction\Formatter\HighlightedTextFormatter;
+use Valkyrja\Cli\Interaction\Formatter\SuccessFormatter;
+use Valkyrja\Cli\Interaction\Formatter\WarningFormatter;
+use Valkyrja\Cli\Interaction\Message\Message;
+use Valkyrja\Cli\Interaction\Message\NewLine;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Generator\Contract\DataFileGeneratorContract;
+use Valkyrja\Container\Generator\Contract\DataFileGeneratorContract as ContainerDataFileGeneratorContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Event\Generator\Contract\DataFileGeneratorContract as EventDataFileGeneratorContract;
+use Valkyrja\Http\Routing\Generator\Contract\DataFileGeneratorContract as HttpDataFileGeneratorContract;
+use Valkyrja\Support\Generator\Enum\GenerateStatus;
+
+abstract class GenerateData
+{
+    public function __construct(
+        protected Env $env,
+        protected OutputFactoryContract $outputFactory,
+    ) {
+    }
+
+    /**
+     * Generate the data.
+     */
+    protected function generateData(): OutputContract
+    {
+        $output    = $this->getOutput();
+        $container = $this->getContainer();
+
+        $output = $this->generateContainerData($container, $output);
+        $output = $this->generateEventData($container, $output);
+        $output = $this->generateCliData($container, $output);
+        $output = $this->generateHttpData($container, $output);
+
+        return $output->withAddedMessages(new NewLine());
+    }
+
+    /**
+     * Get the output.
+     */
+    protected function getOutput(): OutputContract
+    {
+        return $this->outputFactory
+            ->createOutput()
+            ->withAddedMessages(
+                new NewLine(),
+                new Message('Generating Data:', new HighlightedTextFormatter()),
+                new NewLine(),
+                new NewLine(),
+            )
+            ->writeMessages();
+    }
+
+    /**
+     * Get the container.
+     */
+    protected function getContainer(): ContainerContract
+    {
+        $config = $this->getDebugConfig();
+        $app    = Http::app($this->env, $config);
+
+        return $app->getContainer();
+    }
+
+    /**
+     * Generate the container data.
+     */
+    protected function generateContainerData(ContainerContract $container, OutputContract $output): OutputContract
+    {
+        $output = $output->withAddedMessages(
+            new Message('Generating Container Data......................'),
+        )->writeMessages();
+
+        $dataFileGenerator = $container->getSingleton(ContainerDataFileGeneratorContract::class);
+        $status            = $dataFileGenerator->generateFile();
+
+        return $this->addMessagesForGenerateStatus($output, $status)
+            ->withAddedMessages(
+                new NewLine()
+            )
+            ->writeMessages();
+    }
+
+    /**
+     * Generate the event data.
+     */
+    protected function generateEventData(ContainerContract $container, OutputContract $output): OutputContract
+    {
+        $output = $output->withAddedMessages(
+            new Message('Generating Event Data..........................'),
+        )->writeMessages();
+
+        $dataFileGenerator = $container->getSingleton(EventDataFileGeneratorContract::class);
+        $status            = $dataFileGenerator->generateFile();
+
+        return $this->addMessagesForGenerateStatus($output, $status)
+            ->withAddedMessages(
+                new NewLine()
+            )
+            ->writeMessages();
+    }
+
+    /**
+     * Generate the cli data.
+     */
+    protected function generateCliData(ContainerContract $container, OutputContract $output): OutputContract
+    {
+        $output = $output->withAddedMessages(
+            new Message('Generating Cli Routes Data.....................'),
+        )->writeMessages();
+
+        $dataFileGenerator = $container->getSingleton(DataFileGeneratorContract::class);
+        $status            = $dataFileGenerator->generateFile();
+
+        return $this->addMessagesForGenerateStatus($output, $status)
+            ->withAddedMessages(
+                new NewLine()
+            )
+            ->writeMessages();
+    }
+
+    /**
+     * Generate the http data.
+     */
+    protected function generateHttpData(ContainerContract $container, OutputContract $output): OutputContract
+    {
+        $output = $output->withAddedMessages(
+            new Message('Generating Http Routes Data....................'),
+        )->writeMessages();
+
+        $dataFileGenerator = $container->getSingleton(HttpDataFileGeneratorContract::class);
+        $status            = $dataFileGenerator->generateFile();
+
+        return $this->addMessagesForGenerateStatus($output, $status)
+            ->withAddedMessages(
+                new NewLine()
+            )
+            ->writeMessages();
+    }
+
+    /**
+     * Add messages for the generate status.
+     */
+    protected function addMessagesForGenerateStatus(OutputContract $output, GenerateStatus $status): OutputContract
+    {
+        $text      = 'Failed';
+        $formatter = new ErrorFormatter();
+
+        if ($status === GenerateStatus::SUCCESS) {
+            $text      = 'Success';
+            $formatter = new SuccessFormatter();
+        }
+
+        if ($status === GenerateStatus::SKIPPED) {
+            $text      = 'Skipped';
+            $formatter = new WarningFormatter();
+        }
+
+        return $output->withAddedMessages(
+            new Message($text, $formatter),
+            new NewLine()
+        );
+    }
+
+    /**
+     * Get the debug config.
+     */
+    abstract protected function getDebugConfig(): Config;
+}

--- a/src/Valkyrja/Application/Entry/Abstract/App.php
+++ b/src/Valkyrja/Application/Entry/Abstract/App.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Valkyrja\Application\Entry\Abstract;
 
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Data\Config;
+use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
@@ -113,8 +115,18 @@ abstract class App
     {
         $container->setSingleton(Env::class, $env);
         $container->setSingleton(Config::class, $config);
+        $container->setSingleton($config::class, $config);
         $container->setSingleton(ContainerContract::class, $container);
         $container->setSingleton(ApplicationContract::class, $app);
+
+        if ($config instanceof CliConfig) {
+            $container->setSingleton(CliConfig::class, $config);
+            $container->setSingleton(HttpConfig::class, $config->http);
+        }
+
+        if ($config instanceof HttpConfig) {
+            $container->setSingleton(HttpConfig::class, $config);
+        }
 
         $app->publishProviderCallbacks();
 

--- a/src/Valkyrja/Cli/Routing/Provider/CliRouteProvider.php
+++ b/src/Valkyrja/Cli/Routing/Provider/CliRouteProvider.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Cli\Routing\Provider;
 
 use Override;
 use Valkyrja\Cli\Routing\Provider\Abstract\Provider;
+use Valkyrja\Cli\Server\Command\GenerateDataCommand;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
@@ -33,6 +34,7 @@ class CliRouteProvider extends Provider
             ListBashCommand::class,
             ListCommand::class,
             VersionCommand::class,
+            GenerateDataCommand::class,
         ];
     }
 }

--- a/src/Valkyrja/Cli/Routing/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Routing/Provider/ServiceProvider.php
@@ -213,9 +213,6 @@ final class ServiceProvider extends Provider
 
         $collection->add(...$routes);
 
-        $dataGenerator = $container->getSingleton(DataFileGeneratorContract::class);
-        $dataGenerator->generateFile();
-
         $container->setSingleton(Data::class, $collection->getData());
     }
 }

--- a/src/Valkyrja/Cli/Server/Command/GenerateDataCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/GenerateDataCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Cli\Server\Command;
+
+use Override;
+use Valkyrja\Application\Cli\Command\Abstract\GenerateData;
+use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Message;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Attribute\Route;
+use Valkyrja\Cli\Server\Constant\CommandName;
+
+class GenerateDataCommand extends GenerateData
+{
+    public function __construct(
+        Env $env,
+        protected CliConfig $config,
+        OutputFactoryContract $outputFactory,
+    ) {
+        parent::__construct($env, $outputFactory);
+    }
+
+    /**
+     * The help text.
+     */
+    public static function help(): MessageContract
+    {
+        return new Message('A command to generate all data classes for the Cli component.');
+    }
+
+    #[Route(
+        name: CommandName::DATA_GENERATE,
+        description: 'Generate data for the cli component',
+        helpText: [self::class, 'help'],
+    )]
+    public function run(): OutputContract
+    {
+        return $this->generateData();
+    }
+
+    /**
+     * Get the debug config.
+     */
+    #[Override]
+    protected function getDebugConfig(): CliConfig
+    {
+        $config = $this->config;
+
+        return new CliConfig(
+            namespace: $config->namespace,
+            dir: $config->dir,
+            version: $config->version,
+            environment: $config->environment,
+            debugMode: true,
+            timezone: $config->timezone,
+            key: $config->key,
+            dataPath: $config->dataPath,
+            dataNamespace: $config->dataNamespace,
+            applicationName: $config->applicationName,
+            defaultCommandName: $config->defaultCommandName,
+            providers: $config->providers,
+            callbacks: $config->callbacks,
+            http: $config->http,
+        );
+    }
+}

--- a/src/Valkyrja/Cli/Server/Constant/CommandName.php
+++ b/src/Valkyrja/Cli/Server/Constant/CommandName.php
@@ -23,4 +23,6 @@ final class CommandName
     public const string LIST_BASH = 'list:bash';
     /** @var non-empty-string */
     public const string VERSION = 'version';
+    /** @var non-empty-string */
+    public const string DATA_GENERATE = 'data:generate';
 }

--- a/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Cli/Server/Provider/ServiceProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Server\Provider;
 
 use Override;
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Data\Config;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
@@ -25,6 +26,7 @@ use Valkyrja\Cli\Routing\Constant\OptionName;
 use Valkyrja\Cli\Routing\Constant\OptionShortName;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Dispatcher\Contract\RouterContract;
+use Valkyrja\Cli\Server\Command\GenerateDataCommand;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
@@ -56,6 +58,7 @@ final class ServiceProvider extends Provider
             ListBashCommand::class                         => [self::class, 'publishListBashCommand'],
             ListCommand::class                             => [self::class, 'publishListCommand'],
             VersionCommand::class                          => [self::class, 'publishVersionCommand'],
+            GenerateDataCommand::class                     => [self::class, 'publishGenerateDataCommand'],
             LogThrowableCaughtMiddleware::class            => [self::class, 'publishLogThrowableCaughtMiddleware'],
             OutputThrowableCaughtMiddleware::class         => [self::class, 'publishOutputThrowableCaughtMiddleware'],
             CheckForHelpOptionsMiddleware::class           => [self::class, 'publishCheckForHelpOptionsMiddleware'],
@@ -77,6 +80,7 @@ final class ServiceProvider extends Provider
             ListBashCommand::class,
             ListCommand::class,
             VersionCommand::class,
+            GenerateDataCommand::class,
             LogThrowableCaughtMiddleware::class,
             OutputThrowableCaughtMiddleware::class,
             CheckForHelpOptionsMiddleware::class,
@@ -161,6 +165,21 @@ final class ServiceProvider extends Provider
         $container->setSingleton(
             VersionCommand::class,
             new VersionCommand(
+                outputFactory: $container->getSingleton(OutputFactoryContract::class),
+            )
+        );
+    }
+
+    /**
+     * Publish the GenerateDataCommand service.
+     */
+    public static function publishGenerateDataCommand(ContainerContract $container): void
+    {
+        $container->setSingleton(
+            GenerateDataCommand::class,
+            new GenerateDataCommand(
+                env: $container->getSingleton(Env::class),
+                config: $container->getSingleton(CliConfig::class),
                 outputFactory: $container->getSingleton(OutputFactoryContract::class),
             )
         );

--- a/src/Valkyrja/Container/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Container/Provider/ServiceProvider.php
@@ -90,9 +90,6 @@ final class ServiceProvider extends Provider
             $container->register($provider);
         }
 
-        $dataGenerator = $container->getSingleton(DataFileGeneratorContract::class);
-        $dataGenerator->generateFile();
-
         $container->setSingleton(Data::class, $container->getData());
     }
 }

--- a/src/Valkyrja/Event/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Event/Provider/ServiceProvider.php
@@ -139,7 +139,7 @@ final class ServiceProvider extends Provider
         $namespace = $config->dataNamespace;
         /** @var non-empty-string $className */
         $className = $env::EVENT_DATA_CLASS_NAME
-            ?? 'EventRoutingData';
+            ?? 'EventData';
 
         $directory = Directory::srcPath($dataPath);
 
@@ -197,9 +197,6 @@ final class ServiceProvider extends Provider
         foreach ($listeners as $listener) {
             $collection->addListener($listener);
         }
-
-        $dataGenerator = $container->getSingleton(DataFileGeneratorContract::class);
-        $dataGenerator->generateFile();
 
         $container->setSingleton(Data::class, $collection->getData());
     }

--- a/src/Valkyrja/Http/Routing/Cli/Command/Constant/CommandName.php
+++ b/src/Valkyrja/Http/Routing/Cli/Command/Constant/CommandName.php
@@ -17,4 +17,6 @@ final class CommandName
 {
     /** @var non-empty-string */
     public const string LIST = 'http:list';
+    /** @var non-empty-string */
+    public const string DATA_GENERATE = 'http:data:generate';
 }

--- a/src/Valkyrja/Http/Routing/Cli/Command/GenerateDataCommand.php
+++ b/src/Valkyrja/Http/Routing/Cli/Command/GenerateDataCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Http\Routing\Cli\Command;
+
+use Override;
+use Valkyrja\Application\Cli\Command\Abstract\GenerateData;
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Message;
+use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Attribute\Route;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Http\Routing\Cli\Command\Constant\CommandName;
+
+class GenerateDataCommand extends GenerateData
+{
+    public function __construct(
+        protected Env $env,
+        protected HttpConfig $config,
+        protected OutputFactoryContract $outputFactory,
+    ) {
+        parent::__construct($env, $outputFactory);
+    }
+
+    /**
+     * The help text.
+     */
+    public static function help(): MessageContract
+    {
+        return new Message('A command to generate all data classes for the Http component.');
+    }
+
+    #[Route(
+        name: CommandName::DATA_GENERATE,
+        description: 'Generate data for the http component',
+        helpText: [self::class, 'help'],
+    )]
+    public function run(): OutputContract
+    {
+        return $this->generateData();
+    }
+
+    /**
+     * Get the debug config.
+     */
+    #[Override]
+    protected function getDebugConfig(): HttpConfig
+    {
+        $config = $this->config;
+
+        return new HttpConfig(
+            namespace: $config->namespace,
+            dir: $config->dir,
+            version: $config->version,
+            environment: $config->environment,
+            debugMode: true,
+            timezone: $config->timezone,
+            key: $config->key,
+            dataPath: $config->dataPath,
+            dataNamespace: $config->dataNamespace,
+            providers: $config->providers,
+            callbacks: $config->callbacks,
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    protected function generateCliData(ContainerContract $container, OutputContract $output): OutputContract
+    {
+        // No cli data to generate
+
+        return $output;
+    }
+}

--- a/src/Valkyrja/Http/Routing/Provider/CliRouteProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/CliRouteProvider.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Http\Routing\Provider;
 
 use Override;
 use Valkyrja\Cli\Routing\Provider\Abstract\Provider;
+use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
 use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 
 class CliRouteProvider extends Provider
@@ -27,6 +28,7 @@ class CliRouteProvider extends Provider
     {
         return [
             ListCommand::class,
+            GenerateDataCommand::class,
         ];
     }
 }

--- a/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/ServiceProvider.php
@@ -15,11 +15,13 @@ namespace Valkyrja\Http\Routing\Provider;
 
 use Override;
 use Valkyrja\Application\Data\Config;
+use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
 use Valkyrja\Attribute\Provider\ServiceProvider as AttributeServiceCollector;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Abstract\Provider;
 use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
@@ -30,6 +32,7 @@ use Valkyrja\Http\Middleware\Handler\Contract\RouteNotMatchedHandlerContract;
 use Valkyrja\Http\Middleware\Handler\Contract\SendingResponseHandlerContract;
 use Valkyrja\Http\Middleware\Handler\Contract\TerminatedHandlerContract;
 use Valkyrja\Http\Middleware\Handler\Contract\ThrowableCaughtHandlerContract;
+use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
 use Valkyrja\Http\Routing\Collection\Collection;
 use Valkyrja\Http\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Http\Routing\Collector\AttributeCollector;
@@ -69,6 +72,7 @@ final class ServiceProvider extends Provider
             ProcessorContract::class         => [self::class, 'publishProcessor'],
             ResponseFactoryContract::class   => [self::class, 'publishResponseFactory'],
             Data::class                      => [self::class, 'publishData'],
+            GenerateDataCommand::class       => [self::class, 'publishGenerateDataCommand'],
         ];
     }
 
@@ -88,6 +92,7 @@ final class ServiceProvider extends Provider
             ProcessorContract::class,
             ResponseFactoryContract::class,
             Data::class,
+            GenerateDataCommand::class,
         ];
     }
 
@@ -306,9 +311,21 @@ final class ServiceProvider extends Provider
             );
         }
 
-        $dataGenerator = $container->getSingleton(DataFileGeneratorContract::class);
-        $dataGenerator->generateFile();
-
         $container->setSingleton(Data::class, $collection->getData());
+    }
+
+    /**
+     * Publish the generate data command service.
+     */
+    public static function publishGenerateDataCommand(ContainerContract $container): void
+    {
+        $container->setSingleton(
+            GenerateDataCommand::class,
+            new GenerateDataCommand(
+                $container->getSingleton(Env::class),
+                $container->getSingleton(HttpConfig::class),
+                $container->getSingleton(OutputFactoryContract::class),
+            )
+        );
     }
 }

--- a/tests/Tests/Functional/Application/Entry/CliTest.php
+++ b/tests/Tests/Functional/Application/Entry/CliTest.php
@@ -16,14 +16,18 @@ namespace Valkyrja\Tests\Functional\Application\Entry;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Valkyrja\Application\Constant\ComponentClass;
 use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Entry\Cli;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Cli\Interaction\Output\Output;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Cli\Routing\Generator\DataFileGenerator as CliDataFileGenerator;
 use Valkyrja\Cli\Server\Support\Exiter;
 use Valkyrja\Container\Generator\DataFileGenerator;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Tests\Classes\Application\Provider\CliComponentProviderClass;
 use Valkyrja\Tests\Classes\Application\Provider\CliRouteProviderClass;
 use Valkyrja\Tests\EnvClass;
@@ -106,6 +110,12 @@ final class CliTest extends TestCase
         $container   = $application->getContainer();
 
         $cli = $container->getSingleton(CollectionContract::class);
+
+        self::assertTrue($container->has(CliConfig::class));
+        self::assertTrue($container->has(HttpConfig::class));
+        self::assertTrue($container->has(Env::class));
+        self::assertTrue($container->has(ContainerContract::class));
+        self::assertTrue($container->has(ApplicationContract::class));
 
         $dataFileGenerator = new DataFileGenerator(
             directory: $containerDirectory,

--- a/tests/Tests/Functional/Application/Entry/HttpTest.php
+++ b/tests/Tests/Functional/Application/Entry/HttpTest.php
@@ -15,10 +15,14 @@ namespace Valkyrja\Tests\Functional\Application\Entry;
 
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Valkyrja\Application\Constant\ComponentClass;
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Entry\Http;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Generator\DataFileGenerator;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Message\Response\Response;
 use Valkyrja\Http\Routing\Attribute\Route;
 use Valkyrja\Http\Routing\Collection\Contract\CollectionContract;
@@ -93,6 +97,12 @@ final class HttpTest extends TestCase
         $container   = $application->getContainer();
 
         $http = $container->getSingleton(CollectionContract::class);
+
+        self::assertFalse($container->has(CliConfig::class));
+        self::assertTrue($container->has(HttpConfig::class));
+        self::assertTrue($container->has(Env::class));
+        self::assertTrue($container->has(ContainerContract::class));
+        self::assertTrue($container->has(ApplicationContract::class));
 
         $dataFileGenerator = new DataFileGenerator(
             directory: $containerDirectory,

--- a/tests/Tests/Unit/Cli/Routing/Provider/CliRouteProviderTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Provider/CliRouteProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Cli\Routing\Provider;
 
 use Valkyrja\Cli\Routing\Provider\CliRouteProvider;
+use Valkyrja\Cli\Server\Command\GenerateDataCommand;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
@@ -38,5 +39,6 @@ final class CliRouteProviderTest extends TestCase
         self::assertContains(ListBashCommand::class, $controllers);
         self::assertContains(ListCommand::class, $controllers);
         self::assertContains(VersionCommand::class, $controllers);
+        self::assertContains(GenerateDataCommand::class, $controllers);
     }
 }

--- a/tests/Tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Provider/ServiceProviderTest.php
@@ -159,7 +159,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(false);
 
         $command = new Route(
@@ -168,7 +168,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch')
         );
         $collector->expects($this->once())->method('getRoutes')->willReturn([$command]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getCliProviders')->willReturn([RouteProviderClass::class]);
 
@@ -189,7 +189,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(true);
 
         $command = new Route(
@@ -198,7 +198,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch')
         );
         $collector->expects($this->once())->method('getRoutes')->willReturn([$command]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getCliProviders')->willReturn([RouteProviderClass::class]);
 
@@ -219,7 +219,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(true);
 
         $command = new Route(
@@ -228,7 +228,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch')
         );
         $collector->expects($this->never())->method('getRoutes')->willReturn([$command]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getCliProviders')->willReturn([]);
 

--- a/tests/Tests/Unit/Cli/Server/Command/GenerateDataCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/GenerateDataCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Cli\Server\Command;
+
+use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Directory\Directory;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Interaction\Output\PlainOutput;
+use Valkyrja\Cli\Server\Command\GenerateDataCommand;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+final class GenerateDataCommandTest extends TestCase
+{
+    public function testHelp(): void
+    {
+        $message = GenerateDataCommand::help();
+
+        self::assertSame('A command to generate all data classes for the Cli component.', $message->getText());
+    }
+
+    public function testRun(): void
+    {
+        $originalPath = Directory::$basePath;
+
+        $env           = new Env();
+        $config        = new CliConfig(
+            dir: $originalPath
+        );
+        $output        = new PlainOutput();
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $containerDataPath = Directory::srcPath($config->dataPath . '/ContainerData.php');
+        $eventDataPath     = Directory::srcPath($config->dataPath . '/EventData.php');
+        $cliDataPath       = Directory::srcPath($config->dataPath . '/CliRoutingData.php');
+        $httpDataPath      = Directory::srcPath($config->dataPath . '/HttpRoutingData.php');
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+
+        $outputFactory->expects($this->exactly(2))
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Success', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Success', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Success', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Success', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Success
+
+            Generating Event Data..........................Success
+
+            Generating Cli Routes Data.....................Success
+
+            Generating Http Routes Data....................Success
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Skipped', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Skipped', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Skipped', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Skipped
+
+            Generating Event Data..........................Skipped
+
+            Generating Cli Routes Data.....................Skipped
+
+            Generating Http Routes Data....................Skipped
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        $config = new CliConfig(
+            dir: '/non-existent-dir'
+        );
+
+        Directory::$basePath = '/non-existent-dir';
+
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $outputFactory->expects($this->once())
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        // We expect warnings here due to the non-existent directory
+        @$command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Failed', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Failed', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Failed', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Failed', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Failed
+
+            Generating Event Data..........................Failed
+
+            Generating Cli Routes Data.....................Failed
+
+            Generating Http Routes Data....................Failed
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        Directory::$basePath = $originalPath;
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+    }
+}

--- a/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Cli\Server\Provider;
 
 use PHPUnit\Framework\MockObject\Exception;
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Data\Config;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
@@ -23,6 +24,7 @@ use Valkyrja\Cli\Middleware\Handler\Contract\ThrowableCaughtHandlerContract;
 use Valkyrja\Cli\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Dispatcher\Contract\RouterContract;
+use Valkyrja\Cli\Server\Command\GenerateDataCommand;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
 use Valkyrja\Cli\Server\Command\ListCommand;
@@ -54,6 +56,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertArrayHasKey(ListBashCommand::class, ServiceProvider::publishers());
         self::assertArrayHasKey(ListCommand::class, ServiceProvider::publishers());
         self::assertArrayHasKey(VersionCommand::class, ServiceProvider::publishers());
+        self::assertArrayHasKey(GenerateDataCommand::class, ServiceProvider::publishers());
         self::assertArrayHasKey(LogThrowableCaughtMiddleware::class, ServiceProvider::publishers());
         self::assertArrayHasKey(OutputThrowableCaughtMiddleware::class, ServiceProvider::publishers());
         self::assertArrayHasKey(CheckForHelpOptionsMiddleware::class, ServiceProvider::publishers());
@@ -69,6 +72,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertContains(ListBashCommand::class, ServiceProvider::provides());
         self::assertContains(ListCommand::class, ServiceProvider::provides());
         self::assertContains(VersionCommand::class, ServiceProvider::provides());
+        self::assertContains(GenerateDataCommand::class, ServiceProvider::provides());
         self::assertContains(LogThrowableCaughtMiddleware::class, ServiceProvider::provides());
         self::assertContains(OutputThrowableCaughtMiddleware::class, ServiceProvider::provides());
         self::assertContains(CheckForHelpOptionsMiddleware::class, ServiceProvider::provides());
@@ -218,5 +222,23 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $callback($this->container);
 
         self::assertInstanceOf(CheckCommandForTypoMiddleware::class, $this->container->getSingleton(CheckCommandForTypoMiddleware::class));
+    }
+
+    public function testGenerateDataCommand(): void
+    {
+        $container = $this->container;
+
+        $container->setSingleton(Env::class, self::createStub(Env::class));
+        $container->setSingleton(CliConfig::class, self::createStub(CliConfig::class));
+        $container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
+
+        self::assertFalse($container->has(GenerateDataCommand::class));
+
+        $callback = ServiceProvider::publishers()[GenerateDataCommand::class];
+        $callback($this->container);
+
+        self::assertTrue($container->has(GenerateDataCommand::class));
+        self::assertTrue($container->isSingleton(GenerateDataCommand::class));
+        self::assertInstanceOf(GenerateDataCommand::class, $container->getSingleton(GenerateDataCommand::class));
     }
 }

--- a/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
@@ -146,7 +146,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(false);
 
         $eventId      = self::class;
@@ -154,7 +154,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $listener     = new Listener(eventId: $eventId, name: $listenerName);
 
         $collector->expects($this->once())->method('getListeners')->willReturn([$listener]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getEventProviders')->willReturn([ListenerProviderClass::class]);
 
@@ -183,7 +183,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(true);
 
         $eventId      = self::class;
@@ -191,7 +191,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $listener     = new Listener(eventId: $eventId, name: $listenerName);
 
         $collector->expects($this->once())->method('getListeners')->willReturn([$listener]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getEventProviders')->willReturn([ListenerProviderClass::class]);
 
@@ -220,7 +220,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $this->container->setSingleton(ApplicationContract::class, $application = $this->createMock(ApplicationContract::class));
         $this->container->setSingleton(CollectorContract::class, $collector = $this->createMock(CollectorContract::class));
-        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = self::createStub(DataFileGeneratorContract::class));
+        $this->container->setSingleton(DataFileGeneratorContract::class, $generator = $this->createMock(DataFileGeneratorContract::class));
         $application->method('getDebugMode')->willReturn(true);
 
         $eventId      = self::class;
@@ -228,7 +228,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $listener     = new Listener(eventId: $eventId, name: $listenerName);
 
         $collector->expects($this->never())->method('getListeners')->willReturn([$listener]);
-        $generator->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getEventProviders')->willReturn([]);
 

--- a/tests/Tests/Unit/Http/Routing/Cli/Command/GenerateDataCommandTest.php
+++ b/tests/Tests/Unit/Http/Routing/Cli/Command/GenerateDataCommandTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Http\Routing\Cli\Command;
+
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Directory\Directory;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Interaction\Output\PlainOutput;
+use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+final class GenerateDataCommandTest extends TestCase
+{
+    public function testHelp(): void
+    {
+        $message = GenerateDataCommand::help();
+
+        self::assertSame('A command to generate all data classes for the Http component.', $message->getText());
+    }
+
+    public function testRun(): void
+    {
+        $originalPath = Directory::$basePath;
+
+        $env           = new Env();
+        $config        = new HttpConfig(
+            dir: $originalPath
+        );
+        $output        = new PlainOutput();
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $containerDataPath = Directory::srcPath($config->dataPath . '/ContainerData.php');
+        $eventDataPath     = Directory::srcPath($config->dataPath . '/EventData.php');
+        $cliDataPath       = Directory::srcPath($config->dataPath . '/CliRoutingData.php');
+        $httpDataPath      = Directory::srcPath($config->dataPath . '/HttpRoutingData.php');
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+
+        $outputFactory->expects($this->exactly(2))
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Success', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Success', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Success', $contents);
+        self::assertStringNotContainsString('Generating Cli Routes Data.....................Success', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Success
+
+            Generating Event Data..........................Success
+
+            Generating Http Routes Data....................Success
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Skipped', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Skipped', $contents);
+        self::assertStringNotContainsString('Generating Cli Routes Data.....................Skipped', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Skipped
+
+            Generating Event Data..........................Skipped
+
+            Generating Http Routes Data....................Skipped
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        $config = new HttpConfig(
+            dir: '/non-existent-dir'
+        );
+
+        Directory::$basePath = '/non-existent-dir';
+
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $outputFactory->expects($this->once())
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        // We expect warnings here due to the non-existent directory
+        @$command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileExists($eventDataPath);
+        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Failed', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Failed', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Failed', $contents);
+        self::assertStringNotContainsString('Generating Cli Routes Data.....................Failed', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Data:
+
+            Generating Container Data......................Failed
+
+            Generating Event Data..........................Failed
+
+            Generating Http Routes Data....................Failed
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        Directory::$basePath = $originalPath;
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+    }
+}

--- a/tests/Tests/Unit/Http/Routing/Provider/CliRouteProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/CliRouteProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Provider;
 
+use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
 use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 use Valkyrja\Http\Routing\Provider\CliRouteProvider;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -30,5 +31,6 @@ final class CliRouteProviderTest extends TestCase
     public function testGetControllerClasses(): void
     {
         self::assertContains(ListCommand::class, CliRouteProvider::getControllerClasses());
+        self::assertContains(GenerateDataCommand::class, CliRouteProvider::getControllerClasses());
     }
 }

--- a/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/ServiceProviderTest.php
@@ -13,8 +13,11 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Provider;
 
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributesContract;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
 use Valkyrja\Http\Message\Enum\RequestMethod;
@@ -32,6 +35,7 @@ use Valkyrja\Http\Middleware\Handler\RouteNotMatchedHandler;
 use Valkyrja\Http\Middleware\Handler\SendingResponseHandler;
 use Valkyrja\Http\Middleware\Handler\TerminatedHandler;
 use Valkyrja\Http\Middleware\Handler\ThrowableCaughtHandler;
+use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
 use Valkyrja\Http\Routing\Collection\Collection;
 use Valkyrja\Http\Routing\Collection\Contract\CollectionContract;
 use Valkyrja\Http\Routing\Collector\AttributeCollector;
@@ -75,6 +79,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertArrayHasKey(ResponseFactoryContract::class, ServiceProvider::publishers());
         self::assertArrayHasKey(DataFileGeneratorContract::class, ServiceProvider::publishers());
         self::assertArrayHasKey(Data::class, ServiceProvider::publishers());
+        self::assertArrayHasKey(GenerateDataCommand::class, ServiceProvider::publishers());
     }
 
     public function testExpectedProvides(): void
@@ -88,6 +93,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertContains(ResponseFactoryContract::class, ServiceProvider::provides());
         self::assertContains(DataFileGeneratorContract::class, ServiceProvider::provides());
         self::assertContains(Data::class, ServiceProvider::provides());
+        self::assertContains(GenerateDataCommand::class, ServiceProvider::provides());
     }
 
     public function testPublishRouter(): void
@@ -179,7 +185,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
         $collector->expects($this->once())->method('getRoutes')->willReturn([$route]);
-        $generator->expects($this->once())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getHttpProviders')->willReturn([RouteProviderClass::class]);
         $processor->expects($this->once())->method('route')->willReturnArgument(0);
@@ -215,7 +221,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
         $collector->expects($this->once())->method('getRoutes')->willReturn([$route]);
-        $generator->expects($this->once())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getHttpProviders')->willReturn([RouteProviderClass::class]);
         $processor->expects($this->once())->method('route')->willReturnArgument(0);
@@ -251,7 +257,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
             dispatch: new MethodDispatch(self::class, 'dispatch'),
         );
         $collector->expects($this->never())->method('getRoutes')->willReturn([$route]);
-        $generator->expects($this->once())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
+        $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
 
         $application->expects($this->once())->method('getHttpProviders')->willReturn([]);
         $processor->expects($this->never())->method('route')->willReturnArgument(0);
@@ -380,5 +386,23 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertTrue($container->has(ResponseFactoryContract::class));
         self::assertTrue($container->isSingleton(ResponseFactoryContract::class));
         self::assertInstanceOf(ResponseFactory::class, $container->getSingleton(ResponseFactoryContract::class));
+    }
+
+    public function testGenerateDataCommand(): void
+    {
+        $container = $this->container;
+
+        $container->setSingleton(Env::class, self::createStub(Env::class));
+        $container->setSingleton(HttpConfig::class, self::createStub(HttpConfig::class));
+        $container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
+
+        self::assertFalse($container->has(GenerateDataCommand::class));
+
+        $callback = ServiceProvider::publishers()[GenerateDataCommand::class];
+        $callback($this->container);
+
+        self::assertTrue($container->has(GenerateDataCommand::class));
+        self::assertTrue($container->isSingleton(GenerateDataCommand::class));
+        self::assertInstanceOf(GenerateDataCommand::class, $container->getSingleton(GenerateDataCommand::class));
     }
 }


### PR DESCRIPTION
# Description

Add data generation commands for Cli and Http.
No longer generating data in publishData methods.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->