### PR TITLE
[Data] Fix bug in data generation commands for non-existent components

### DIFF
--- a/src/Valkyrja/Application/Cli/Command/Abstract/GenerateData.php
+++ b/src/Valkyrja/Application/Cli/Command/Abstract/GenerateData.php
@@ -24,8 +24,8 @@ use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
-use Valkyrja\Cli\Routing\Generator\Contract\DataFileGeneratorContract;
-use Valkyrja\Container\Generator\Contract\DataFileGeneratorContract as ContainerDataFileGeneratorContract;
+use Valkyrja\Cli\Routing\Generator\Contract\DataFileGeneratorContract as CliDataFileGeneratorContract;
+use Valkyrja\Container\Generator\Contract\DataFileGeneratorContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Generator\Contract\DataFileGeneratorContract as EventDataFileGeneratorContract;
 use Valkyrja\Http\Routing\Generator\Contract\DataFileGeneratorContract as HttpDataFileGeneratorContract;
@@ -36,6 +36,7 @@ abstract class GenerateData
     public function __construct(
         protected Env $env,
         protected OutputFactoryContract $outputFactory,
+        protected string $title = 'Generating Data',
     ) {
     }
 
@@ -64,7 +65,7 @@ abstract class GenerateData
             ->createOutput()
             ->withAddedMessages(
                 new NewLine(),
-                new Message('Generating Data:', new HighlightedTextFormatter()),
+                new Message("$this->title:", new HighlightedTextFormatter()),
                 new NewLine(),
                 new NewLine(),
             )
@@ -91,7 +92,7 @@ abstract class GenerateData
             new Message('Generating Container Data......................'),
         )->writeMessages();
 
-        $dataFileGenerator = $container->getSingleton(ContainerDataFileGeneratorContract::class);
+        $dataFileGenerator = $container->getSingleton(DataFileGeneratorContract::class);
         $status            = $dataFileGenerator->generateFile();
 
         return $this->addMessagesForGenerateStatus($output, $status)
@@ -106,6 +107,10 @@ abstract class GenerateData
      */
     protected function generateEventData(ContainerContract $container, OutputContract $output): OutputContract
     {
+        if (! $container->has(EventDataFileGeneratorContract::class)) {
+            return $output;
+        }
+
         $output = $output->withAddedMessages(
             new Message('Generating Event Data..........................'),
         )->writeMessages();
@@ -125,11 +130,15 @@ abstract class GenerateData
      */
     protected function generateCliData(ContainerContract $container, OutputContract $output): OutputContract
     {
+        if (! $container->has(CliDataFileGeneratorContract::class)) {
+            return $output;
+        }
+
         $output = $output->withAddedMessages(
             new Message('Generating Cli Routes Data.....................'),
         )->writeMessages();
 
-        $dataFileGenerator = $container->getSingleton(DataFileGeneratorContract::class);
+        $dataFileGenerator = $container->getSingleton(CliDataFileGeneratorContract::class);
         $status            = $dataFileGenerator->generateFile();
 
         return $this->addMessagesForGenerateStatus($output, $status)
@@ -144,6 +153,10 @@ abstract class GenerateData
      */
     protected function generateHttpData(ContainerContract $container, OutputContract $output): OutputContract
     {
+        if (! $container->has(HttpDataFileGeneratorContract::class)) {
+            return $output;
+        }
+
         $output = $output->withAddedMessages(
             new Message('Generating Http Routes Data....................'),
         )->writeMessages();

--- a/src/Valkyrja/Cli/Server/Command/GenerateDataCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/GenerateDataCommand.php
@@ -31,7 +31,11 @@ class GenerateDataCommand extends GenerateData
         protected CliConfig $config,
         OutputFactoryContract $outputFactory,
     ) {
-        parent::__construct($env, $outputFactory);
+        parent::__construct(
+            env: $env,
+            outputFactory: $outputFactory,
+            title: 'Generating Cli Component Data',
+        );
     }
 
     /**

--- a/src/Valkyrja/Http/Routing/Cli/Command/GenerateDataCommand.php
+++ b/src/Valkyrja/Http/Routing/Cli/Command/GenerateDataCommand.php
@@ -22,7 +22,6 @@ use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
-use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Routing\Cli\Command\Constant\CommandName;
 
 class GenerateDataCommand extends GenerateData
@@ -32,7 +31,11 @@ class GenerateDataCommand extends GenerateData
         protected HttpConfig $config,
         protected OutputFactoryContract $outputFactory,
     ) {
-        parent::__construct($env, $outputFactory);
+        parent::__construct(
+            env: $env,
+            outputFactory: $outputFactory,
+            title: 'Generating Http Component Data',
+        );
     }
 
     /**
@@ -74,16 +77,5 @@ class GenerateDataCommand extends GenerateData
             providers: $config->providers,
             callbacks: $config->callbacks,
         );
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    protected function generateCliData(ContainerContract $container, OutputContract $output): OutputContract
-    {
-        // No cli data to generate
-
-        return $output;
     }
 }

--- a/tests/Tests/Unit/Cli/Server/Command/GenerateDataCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/GenerateDataCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Cli\Server\Command;
 
+use Valkyrja\Application\Constant\ComponentClass;
 use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Env\Env;
@@ -36,7 +37,20 @@ final class GenerateDataCommandTest extends TestCase
 
         $env           = new Env();
         $config        = new CliConfig(
-            dir: $originalPath
+            dir: $originalPath,
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+                ComponentClass::EVENT,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
         );
         $output        = new PlainOutput();
         $outputFactory = $this->createMock(OutputFactoryContract::class);
@@ -70,7 +84,7 @@ final class GenerateDataCommandTest extends TestCase
         self::assertFileExists($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Success', $contents);
         self::assertStringContainsString('Generating Event Data..........................Success', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Success', $contents);
@@ -78,7 +92,7 @@ final class GenerateDataCommandTest extends TestCase
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Cli Component Data:
 
             Generating Container Data......................Success
 
@@ -102,7 +116,7 @@ final class GenerateDataCommandTest extends TestCase
         self::assertFileExists($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
         self::assertStringContainsString('Generating Event Data..........................Skipped', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Skipped', $contents);
@@ -110,7 +124,7 @@ final class GenerateDataCommandTest extends TestCase
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Cli Component Data:
 
             Generating Container Data......................Skipped
 
@@ -126,7 +140,20 @@ final class GenerateDataCommandTest extends TestCase
         self::assertSame($expectedOutput, $contents);
 
         $config = new CliConfig(
-            dir: '/non-existent-dir'
+            dir: '/non-existent-dir',
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+                ComponentClass::EVENT,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
         );
 
         Directory::$basePath = '/non-existent-dir';
@@ -153,7 +180,7 @@ final class GenerateDataCommandTest extends TestCase
         self::assertFileExists($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Failed', $contents);
         self::assertStringContainsString('Generating Event Data..........................Failed', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Failed', $contents);
@@ -161,7 +188,7 @@ final class GenerateDataCommandTest extends TestCase
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Cli Component Data:
 
             Generating Container Data......................Failed
 
@@ -170,6 +197,164 @@ final class GenerateDataCommandTest extends TestCase
             Generating Cli Routes Data.....................Failed
 
             Generating Http Routes Data....................Failed
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        Directory::$basePath = $originalPath;
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+    }
+
+    public function testRunWithoutEventAndHttp(): void
+    {
+        $originalPath = Directory::$basePath;
+
+        $env           = new Env();
+        $config        = new CliConfig(
+            dir: $originalPath,
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+            ],
+        );
+        $output        = new PlainOutput();
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $containerDataPath = Directory::srcPath($config->dataPath . '/ContainerData.php');
+        $eventDataPath     = Directory::srcPath($config->dataPath . '/EventData.php');
+        $cliDataPath       = Directory::srcPath($config->dataPath . '/CliRoutingData.php');
+        $httpDataPath      = Directory::srcPath($config->dataPath . '/HttpRoutingData.php');
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+
+        $outputFactory->expects($this->exactly(2))
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileDoesNotExist($httpDataPath);
+
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Success', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Success', $contents);
+        self::assertStringNotContainsString('Generating Http Routes Data....................Success', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Success', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Cli Component Data:
+
+            Generating Container Data......................Success
+
+            Generating Cli Routes Data.....................Success
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileDoesNotExist($httpDataPath);
+
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Skipped', $contents);
+        self::assertStringNotContainsString('Generating Http Routes Data....................Skipped', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Skipped', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Cli Component Data:
+
+            Generating Container Data......................Skipped
+
+            Generating Cli Routes Data.....................Skipped
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        $config = new CliConfig(
+            dir: '/non-existent-dir',
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+            ],
+        );
+
+        Directory::$basePath = '/non-existent-dir';
+
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $outputFactory->expects($this->once())
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        // We expect warnings here due to the non-existent directory
+        @$command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileDoesNotExist($httpDataPath);
+
+        self::assertStringContainsString('Generating Cli Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Failed', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Failed', $contents);
+        self::assertStringNotContainsString('Generating Http Routes Data....................Failed', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Failed', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Cli Component Data:
+
+            Generating Container Data......................Failed
+
+            Generating Cli Routes Data.....................Failed
 
 
             TEXT;

--- a/tests/Tests/Unit/Http/Routing/Cli/Command/GenerateDataCommandTest.php
+++ b/tests/Tests/Unit/Http/Routing/Cli/Command/GenerateDataCommandTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Cli\Command;
 
+use Valkyrja\Application\Constant\ComponentClass;
 use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Directory\Directory;
 use Valkyrja\Application\Env\Env;
@@ -36,7 +37,20 @@ final class GenerateDataCommandTest extends TestCase
 
         $env           = new Env();
         $config        = new HttpConfig(
-            dir: $originalPath
+            dir: $originalPath,
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+                ComponentClass::EVENT,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
         );
         $output        = new PlainOutput();
         $outputFactory = $this->createMock(OutputFactoryContract::class);
@@ -67,22 +81,24 @@ final class GenerateDataCommandTest extends TestCase
 
         self::assertFileExists($containerDataPath);
         self::assertFileExists($eventDataPath);
-        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Success', $contents);
         self::assertStringContainsString('Generating Event Data..........................Success', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Success', $contents);
-        self::assertStringNotContainsString('Generating Cli Routes Data.....................Success', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Success', $contents);
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Http Component Data:
 
             Generating Container Data......................Success
 
             Generating Event Data..........................Success
+
+            Generating Cli Routes Data.....................Success
 
             Generating Http Routes Data....................Success
 
@@ -97,22 +113,24 @@ final class GenerateDataCommandTest extends TestCase
 
         self::assertFileExists($containerDataPath);
         self::assertFileExists($eventDataPath);
-        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
         self::assertStringContainsString('Generating Event Data..........................Skipped', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Skipped', $contents);
-        self::assertStringNotContainsString('Generating Cli Routes Data.....................Skipped', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Skipped', $contents);
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Http Component Data:
 
             Generating Container Data......................Skipped
 
             Generating Event Data..........................Skipped
+
+            Generating Cli Routes Data.....................Skipped
 
             Generating Http Routes Data....................Skipped
 
@@ -122,7 +140,20 @@ final class GenerateDataCommandTest extends TestCase
         self::assertSame($expectedOutput, $contents);
 
         $config = new HttpConfig(
-            dir: '/non-existent-dir'
+            dir: '/non-existent-dir',
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::CLI_INTERACTION,
+                ComponentClass::CLI_MIDDLEWARE,
+                ComponentClass::CLI_ROUTING,
+                ComponentClass::CLI_SERVER,
+                ComponentClass::EVENT,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
         );
 
         Directory::$basePath = '/non-existent-dir';
@@ -146,22 +177,182 @@ final class GenerateDataCommandTest extends TestCase
 
         self::assertFileExists($containerDataPath);
         self::assertFileExists($eventDataPath);
+        self::assertFileExists($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Failed', $contents);
+        self::assertStringContainsString('Generating Event Data..........................Failed', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Failed', $contents);
+        self::assertStringContainsString('Generating Cli Routes Data.....................Failed', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Http Component Data:
+
+            Generating Container Data......................Failed
+
+            Generating Event Data..........................Failed
+
+            Generating Cli Routes Data.....................Failed
+
+            Generating Http Routes Data....................Failed
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        Directory::$basePath = $originalPath;
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+    }
+
+    public function testRunWithoutEventAndCli(): void
+    {
+        $originalPath = Directory::$basePath;
+
+        $env           = new Env();
+        $config        = new HttpConfig(
+            dir: $originalPath,
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
+        );
+        $output        = new PlainOutput();
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $containerDataPath = Directory::srcPath($config->dataPath . '/ContainerData.php');
+        $eventDataPath     = Directory::srcPath($config->dataPath . '/EventData.php');
+        $cliDataPath       = Directory::srcPath($config->dataPath . '/CliRoutingData.php');
+        $httpDataPath      = Directory::srcPath($config->dataPath . '/HttpRoutingData.php');
+
+        @unlink($containerDataPath);
+        @unlink($eventDataPath);
+        @unlink($cliDataPath);
+        @unlink($httpDataPath);
+
+        $outputFactory->expects($this->exactly(2))
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
         self::assertFileDoesNotExist($cliDataPath);
         self::assertFileExists($httpDataPath);
 
-        self::assertStringContainsString('Generating Data:', $contents);
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Success', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Success', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Success', $contents);
+        self::assertStringNotContainsString('Generating Cli Routes Data.....................Success', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Http Component Data:
+
+            Generating Container Data......................Success
+
+            Generating Http Routes Data....................Success
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        ob_start();
+        $command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
+        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
+        self::assertStringContainsString('Generating Container Data......................Skipped', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Skipped', $contents);
+        self::assertStringContainsString('Generating Http Routes Data....................Skipped', $contents);
+        self::assertStringNotContainsString('Generating Cli Routes Data.....................Skipped', $contents);
+
+        $expectedOutput = <<<'TEXT'
+
+            Generating Http Component Data:
+
+            Generating Container Data......................Skipped
+
+            Generating Http Routes Data....................Skipped
+
+
+            TEXT;
+
+        self::assertSame($expectedOutput, $contents);
+
+        $config = new HttpConfig(
+            dir: '/non-existent-dir',
+            providers: [
+                ComponentClass::CONTAINER,
+                ComponentClass::DISPATCHER,
+                ComponentClass::HTTP_MESSAGE,
+                ComponentClass::HTTP_MIDDLEWARE,
+                ComponentClass::HTTP_ROUTING,
+                ComponentClass::HTTP_SERVER,
+            ],
+        );
+
+        Directory::$basePath = '/non-existent-dir';
+
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+
+        $outputFactory->expects($this->once())
+            ->method('createOutput')
+            ->willReturn($output);
+
+        $command = new GenerateDataCommand(
+            env: $env,
+            config: $config,
+            outputFactory: $outputFactory,
+        );
+
+        ob_start();
+        // We expect warnings here due to the non-existent directory
+        @$command->run();
+        $contents = ob_get_clean();
+
+        self::assertFileExists($containerDataPath);
+        self::assertFileDoesNotExist($eventDataPath);
+        self::assertFileDoesNotExist($cliDataPath);
+        self::assertFileExists($httpDataPath);
+
+        self::assertStringContainsString('Generating Http Component Data:', $contents);
         self::assertStringContainsString('Generating Container Data......................Failed', $contents);
-        self::assertStringContainsString('Generating Event Data..........................Failed', $contents);
+        self::assertStringNotContainsString('Generating Event Data..........................Failed', $contents);
         self::assertStringContainsString('Generating Http Routes Data....................Failed', $contents);
         self::assertStringNotContainsString('Generating Cli Routes Data.....................Failed', $contents);
 
         $expectedOutput = <<<'TEXT'
 
-            Generating Data:
+            Generating Http Component Data:
 
             Generating Container Data......................Failed
-
-            Generating Event Data..........................Failed
 
             Generating Http Routes Data....................Failed
 


### PR DESCRIPTION
# Description

Fix bug in data generation commands for non-existent components.

For example if the event component wasn't included, or http, or cli, or any combination of these.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->