### PR TITLE
[Application] Only call defaultExceptionHandler on debug mode

### DIFF
--- a/src/Valkyrja/Application/Entry/Abstract/App.php
+++ b/src/Valkyrja/Application/Entry/Abstract/App.php
@@ -38,7 +38,10 @@ abstract class App
      */
     public static function start(Env $env, Config $config): ApplicationContract
     {
-        static::defaultExceptionHandler();
+        if ($config->debugMode) {
+            static::defaultExceptionHandler();
+        }
+
         static::appStart();
         static::directory(dir: $config->dir);
 
@@ -170,13 +173,13 @@ abstract class App
      */
     protected static function bootstrapThrowableHandler(ApplicationContract $app, ContainerContract $container): void
     {
-        $errorHandler = static::getThrowableHandler();
-
-        // Set error handler in the service container
-        $container->setSingleton(ThrowableHandlerContract::class, $errorHandler);
-
         // If debug is on, enable debug handling
         if ($app->getDebugMode()) {
+            $errorHandler = static::getThrowableHandler();
+
+            // Set error handler in the service container
+            $container->setSingleton(ThrowableHandlerContract::class, $errorHandler);
+
             // Enable error handling
             $errorHandler::enable(
                 displayErrors: true

--- a/tests/Tests/Classes/Application/Entry/AppExceptionHandlerClass.php
+++ b/tests/Tests/Classes/Application/Entry/AppExceptionHandlerClass.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Classes\Application\Entry;
+
+use Override;
+use Valkyrja\Application\Data\Config;
+use Valkyrja\Application\Entry\Abstract\App;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Application\Kernel\Valkyrja;
+use Valkyrja\Container\Manager\Container;
+
+abstract class AppExceptionHandlerClass extends App
+{
+    public static bool $called = false;
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function appStart(): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function directory(string $dir): void
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public static function app(Env $env, Config $config): ApplicationContract
+    {
+        return new Valkyrja(new Container(), $config);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    protected static function defaultExceptionHandler(): void
+    {
+        self::$called = true;
+    }
+}

--- a/tests/Tests/Unit/Application/Entry/Abstract/AppTest.php
+++ b/tests/Tests/Unit/Application/Entry/Abstract/AppTest.php
@@ -70,6 +70,7 @@ use Valkyrja\Http\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware
 use Valkyrja\Http\Server\Middleware\ThrowableCaught\ViewThrowableCaughtMiddleware;
 use Valkyrja\Reflection\Reflector\Contract\ReflectorContract;
 use Valkyrja\Support\Time\Microtime;
+use Valkyrja\Tests\Classes\Application\Entry\AppExceptionHandlerClass;
 use Valkyrja\Tests\EnvClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\View\Provider\ComponentProvider;
@@ -109,6 +110,27 @@ final class AppTest extends TestCase
         self::assertSame(APP_START, $time);
 
         Microtime::unfreeze();
+    }
+
+    /**
+     * Test the appStart method with all debug modes.
+     */
+    #[RunInSeparateProcess]
+    public function testStartExceptionHandlerDebugModes(): void
+    {
+        AppExceptionHandlerClass::$called = false;
+
+        AppExceptionHandlerClass::start(new Env(), new Config(debugMode: true));
+
+        self::assertTrue(AppExceptionHandlerClass::$called);
+
+        AppExceptionHandlerClass::$called = false;
+
+        AppExceptionHandlerClass::start(new Env(), new Config(debugMode: false));
+
+        self::assertFalse(AppExceptionHandlerClass::$called);
+
+        AppExceptionHandlerClass::$called = false;
     }
 
     /**


### PR DESCRIPTION
# Description

Only call defaultExceptionHandler when debug mode is enabled.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->