### PR TITLE
[CI] Fix typo where phpstan outdate check was running phparkitect

### DIFF
--- a/.github/workflows/create-version-branch.yml
+++ b/.github/workflows/create-version-branch.yml
@@ -25,7 +25,7 @@ jobs:
           - name: PHP Metrics
             command: phpmetrics-outdated-check-major-release
           - name: PHPStan
-            command: phparkitect-outdated-check-major-release
+            command: phpstan-outdated-check-major-release
           - name: PHPUnit
             command: phpunit-outdated-check-major-release
           - name: Psalm


### PR DESCRIPTION
# Description

Fix typo where phpstan outdate check was running phparkitect.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [X] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->