### PR TITLE
[CI] Ensure only v26+ branches can cherry-pick to from

### DIFF
--- a/.github/workflows/cherry-pick-commits.yml
+++ b/.github/workflows/cherry-pick-commits.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [[ "$BRANCH" == "master" ] || [ $BRANCH =~ ^(2[5-9].x)$ ]]; then
+          if [[ "$BRANCH" == "master" ] || [ $BRANCH =~ ^(2[6-9].x)$ ]]; then
             echo "All new major release version branches must be made from latest master."
             echo "Using master or major version branch. Proceed."
 


### PR DESCRIPTION
# Description

Ensure only v26+ branches can cherry-pick to from

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->