### PR TITLE
[Application] Add persistent worker HTTP support

### DIFF
--- a/src/Valkyrja/Application/Entry/Abstract/App.php
+++ b/src/Valkyrja/Application/Entry/Abstract/App.php
@@ -98,7 +98,7 @@ abstract class App
     /**
      * Get the application.
      */
-    protected static function getApplication(ContainerContract $container, Config $config): ApplicationContract
+    public static function getApplication(ContainerContract $container, Config $config): ApplicationContract
     {
         return new Valkyrja(
             container: $container,
@@ -109,7 +109,7 @@ abstract class App
     /**
      * Bootstrap container services.
      */
-    protected static function bootstrapServices(ApplicationContract $app, ContainerContract $container, Env $env, Config $config): void
+    public static function bootstrapServices(ApplicationContract $app, ContainerContract $container, Env $env, Config $config): void
     {
         $container->setSingleton(Env::class, $env);
         $container->setSingleton(Config::class, $config);
@@ -134,7 +134,7 @@ abstract class App
     /**
      * Load container data.
      */
-    protected static function loadContainerData(ContainerContract $container): void
+    public static function loadContainerData(ContainerContract $container): void
     {
         if (! $container->isSingleton(ContainerData::class)) {
             self::publishContainerData(container: $container);
@@ -148,7 +148,7 @@ abstract class App
     /**
      * Publish the container data.
      */
-    protected static function publishContainerData(ContainerContract $container): void
+    public static function publishContainerData(ContainerContract $container): void
     {
         ServiceProvider::publishData(container: $container);
     }
@@ -156,7 +156,7 @@ abstract class App
     /**
      * Set a default exception handler until the one specified in config is set in the Container\AppProvider.
      */
-    protected static function defaultExceptionHandler(): void
+    public static function defaultExceptionHandler(): void
     {
         WhoopsThrowableHandler::enable(
             displayErrors: true
@@ -166,7 +166,7 @@ abstract class App
     /**
      * Bootstrap throwable handler.
      */
-    protected static function bootstrapThrowableHandler(ApplicationContract $app, ContainerContract $container): void
+    public static function bootstrapThrowableHandler(ApplicationContract $app, ContainerContract $container): void
     {
         // If debug is on, enable debug handling
         if ($app->getDebugMode()) {
@@ -185,7 +185,7 @@ abstract class App
     /**
      * Get the throwable handler.
      */
-    protected static function getThrowableHandler(): ThrowableHandlerContract
+    public static function getThrowableHandler(): ThrowableHandlerContract
     {
         return new WhoopsThrowableHandler();
     }
@@ -193,7 +193,7 @@ abstract class App
     /**
      * Get the container.
      */
-    protected static function getContainer(): ContainerContract
+    public static function getContainer(): ContainerContract
     {
         return new Container();
     }

--- a/src/Valkyrja/Application/Entry/Abstract/WorkerHttp.php
+++ b/src/Valkyrja/Application/Entry/Abstract/WorkerHttp.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Application\Entry\Abstract;
+
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\ChildApplication;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\ChildContainer;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Request\Factory\RequestFactory;
+use Valkyrja\Http\Routing\Collection\Contract\CollectionContract;
+use Valkyrja\Http\Server\Handler\Contract\RequestHandlerContract;
+
+/**
+ * HTTP entry point for persistent worker runtimes (FrankenPHP, RoadRunner, Swoole, etc.).
+ *
+ * Usage:
+ *   $app = WorkerHttp::bootstrap($config);  // once — at worker startup
+ *
+ *   // Per request (inside the worker loop):
+ *   WorkerHttp::run($app);
+ *
+ * bootstrap() performs the full bootstrap and force-resolves any services that
+ * must live in the frozen parent container. run() creates an isolated child per
+ * request so state never bleeds between requests.
+ */
+abstract class WorkerHttp extends App
+{
+    /**
+     * Bootstrap the application once at worker startup.
+     *
+     * Call this once before the worker request loop begins. The returned
+     * ApplicationContract is frozen after this call — its container must not
+     * be written to again. Pass it to run() for every subsequent request.
+     */
+    public static function bootstrap(HttpConfig $config, Env $env = new Env()): ApplicationContract
+    {
+        $app = static::start(
+            env: $env,
+            config: $config,
+        );
+
+        $container = $app->getContainer();
+
+        static::bootstrapThrowableHandler($app, $container);
+
+        // Force-resolve services that must live in the parent's frozen map.
+        // Anything not resolved here will be created fresh per request in the
+        // child container, which is correct but incurs creation cost each time.
+        static::bootstrapParentServices($app);
+
+        return $app;
+    }
+
+    /**
+     * Handle a single request using an isolated child application.
+     *
+     * Creates a child application and container for the request, sets the
+     * request-scoped singletons on the child, dispatches the request, then
+     * discards the child. The parent application is never mutated.
+     */
+    public static function handle(ApplicationContract $app, ContainerData $data, ServerRequestContract $request): void
+    {
+        $childContainer = static::getChildContainer($app, $data);
+        $childApp       = static::getChildApplication($app, $childContainer);
+
+        static::bootstrapChildContainer($childApp, $childContainer);
+
+        static::handleRequest($childContainer, $request);
+    }
+
+    /**
+     * Get a child application for the request.
+     */
+    public static function getChildApplication(ApplicationContract $app, ContainerContract $container): ApplicationContract
+    {
+        return new ChildApplication($app, $container);
+    }
+
+    /**
+     * Get a child container for the request.
+     */
+    public static function getChildContainer(ApplicationContract $app, ContainerData $data): ContainerContract
+    {
+        $parent = $app->getContainer();
+
+        return new ChildContainer($parent, $data);
+    }
+
+    /**
+     * Bootstrap a child container with the request-scoped singletons.
+     */
+    public static function bootstrapChildContainer(ApplicationContract $app, ContainerContract $container): void
+    {
+        $container->setSingleton(ApplicationContract::class, $app);
+        $container->setSingleton(ContainerContract::class, $container);
+    }
+
+    /**
+     * Handle a single request.
+     */
+    public static function handleRequest(ContainerContract $container, ServerRequestContract $request): void
+    {
+        $handler = $container->getSingleton(RequestHandlerContract::class);
+        $handler->run($request);
+    }
+
+    /**
+     * Get the current request.
+     */
+    public static function getRequest(): ServerRequestContract
+    {
+        return RequestFactory::fromGlobals();
+    }
+
+    /**
+     * Force-resolve services that must be pre-built in the parent container.
+     *
+     * Override in subclasses to eagerly resolve additional services (e.g. the
+     * route matcher) so they are cached in the frozen parent rather than being
+     * re-created on every request's child container.
+     */
+    public static function bootstrapParentServices(ApplicationContract $app): void
+    {
+        // Subclasses may force-resolve expensive shared services here, e.g.:
+        $app->getContainer()->getSingleton(CollectionContract::class);
+    }
+}

--- a/src/Valkyrja/Application/Entry/Cli.php
+++ b/src/Valkyrja/Application/Entry/Cli.php
@@ -44,7 +44,7 @@ class Cli extends App
     /**
      * Get the input.
      */
-    protected static function getInput(CliConfig $config): InputContract
+    public static function getInput(CliConfig $config): InputContract
     {
         /** @var non-empty-string[] $args */
         $args = $_SERVER['argv'] ?? [];

--- a/src/Valkyrja/Application/Entry/Http.php
+++ b/src/Valkyrja/Application/Entry/Http.php
@@ -44,7 +44,7 @@ class Http extends App
     /**
      * Get the request.
      */
-    protected static function getRequest(): ServerRequestContract
+    public static function getRequest(): ServerRequestContract
     {
         return RequestFactory::fromGlobals();
     }

--- a/src/Valkyrja/Application/Kernel/ChildApplication.php
+++ b/src/Valkyrja/Application/Kernel/ChildApplication.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Application\Kernel;
+
+use Override;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+
+class ChildApplication implements ApplicationContract
+{
+    public function __construct(
+        protected ApplicationContract $parent,
+        protected ContainerContract $container,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getContainer(): ContainerContract
+    {
+        return $this->container;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function publishProviderCallbacks(): void
+    {
+        $this->parent->publishProviderCallbacks();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getProviders(): array
+    {
+        return $this->parent->getProviders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getContainerProviders(): array
+    {
+        return $this->parent->getContainerProviders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getEventProviders(): array
+    {
+        return $this->parent->getEventProviders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getCliProviders(): array
+    {
+        return $this->parent->getCliProviders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getHttpProviders(): array
+    {
+        return $this->parent->getHttpProviders();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getDebugMode(): bool
+    {
+        return $this->parent->getDebugMode();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getEnvironment(): string
+    {
+        return $this->parent->getEnvironment();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function getVersion(): string
+    {
+        return $this->parent->getVersion();
+    }
+}

--- a/src/Valkyrja/Application/README.md
+++ b/src/Valkyrja/Application/README.md
@@ -17,11 +17,26 @@ framework predictable.
 
 You do not instantiate `Valkyrja` directly. The entry classes handle this:
 
-- `Valkyrja\Application\Entry\Http` — for web applications
+- `Valkyrja\Application\Entry\Http` — for traditional PHP-FPM / CGI web
+  applications
 - `Valkyrja\Application\Entry\Cli` — for console applications
+- Persistent worker entry classes — for long-running worker runtimes (
+  see [Persistent Worker Lifecycle](#persistent-worker-lifecycle))
 
-Both expose a single static `run()` method. Call it with your configuration
-object and the framework handles everything from bootstrap to response:
+The following worker runtime integrations are available as separate packages,
+each extending `Valkyrja\Application\Entry\Abstract\WorkerHttp`:
+
+| Package               | Class                                | Runtime                                                          |
+|-----------------------|--------------------------------------|------------------------------------------------------------------|
+| `valkyrja/frankenphp` | `Valkyrja\FrankenPhp\FrankenPhpHttp` | [FrankenPHP](https://frankenphp.dev/docs/worker/)                |
+| `valkyrja/openswoole` | `Valkyrja\OpenSwoole\OpenSwooleHttp` | [OpenSwoole](https://openswoole.com/)                            |
+| `valkyrja/roadrunner` | `Valkyrja\RoadRunner\RoadRunnerHttp` | [RoadRunner](https://docs.roadrunner.dev/docs/php-worker/worker) |
+
+### Standard (PHP-FPM / CGI)
+
+`Http` and `Cli` expose a single static `run()` method. Call it with your
+configuration object and the framework handles everything from bootstrap to
+response:
 
 ```php
 // app/public/index.php
@@ -229,7 +244,7 @@ truly cannot be deferred.
 > Note: The `publish` callback is called before the container is filled with any
 > services. You must be cautious to list your callbacks after any callbacks
 > that would load the container with data. You also do not need to use the
-> contract if you do not wish to, as you will define the callback explicitly in 
+> contract if you do not wish to, as you will define the callback explicitly in
 > the config. However, this can allow you to quickly see any component providers
 > that do have callbacks
 
@@ -331,3 +346,128 @@ Setting `debugMode: true` has two effects:
 Never run with `debugMode: true` in production. The performance difference is
 significant enough, and Whoops output may expose internal details that should
 remain private.
+
+## Persistent Worker Lifecycle
+
+Persistent worker runtimes (where a single PHP process handles many requests
+without restarting) require a different architecture from PHP-FPM. In PHP-FPM
+every request gets a clean process. In a worker, state accumulated during one
+request will bleed into the next unless it is explicitly isolated.
+
+Valkyrja's abstract worker entry class,
+`Valkyrja\Application\Entry\Abstract\WorkerHttp`,
+implements the isolation pattern. Concrete subclasses integrate with a specific
+worker runtime. The abstract class provides the `bootstrap()` and `handle()`
+methods; subclasses supply the request loop and any runtime-specific request
+conversion.
+
+### The Invariant
+
+The parent application and its container are **frozen** after `bootstrap()`
+completes. No code should write to them again. Every request receives its own
+`ChildContainer` and `ChildApplication` that inherit from the frozen parent but
+write only to child-local state. When the request ends, the child is discarded.
+
+### Bootstrap (once, at worker startup)
+
+```php
+$app = static::bootstrap($config, $env);
+
+$container = $app->getContainer();
+$data      = $container->getData(); // captured once, reused each request
+```
+
+`bootstrap()` runs the full application bootstrap sequence and then calls
+`bootstrapParentServices()`. The returned `$app` and the snapshot `$data`
+are captured in the closure or loop scope before any request arrives.
+
+`getData()` returns a `ContainerData` value object holding the parent
+container's maps. It is captured **once**, outside the request loop, and
+passed to every child. Because PHP arrays are copy-on-write, each child gets
+its own logical copy at zero cost until it writes to one of the maps.
+
+### Per-Request Handling
+
+```php
+// Inside the worker request loop:
+static::handle($app, $data, $request);
+```
+
+`handle()` creates a fresh `ChildContainer` and `ChildApplication` for each
+request:
+
+```
+ChildContainer($parent, $data)     ← inherits parent maps; writes stay local
+ChildApplication($app, $container) ← owns child container; delegates everything else to parent
+```
+
+`ChildApplication` owns the child container and returns it from `getContainer()`.
+Every other method — `getEnvironment()`, `getVersion()`, `getProviders()`,
+`getDebugMode()`, and so on — delegates directly to the parent application. No
+re-bootstrapping occurs. The child is a thin wrapper that swaps in a fresh
+container while keeping the rest of the parent's state intact.
+
+The child container checks its own maps first and falls back to the parent via
+the `ContainerContract` interface. Singletons resolved in the child are cached
+in the child only. The parent's `instances` map is never written to after
+`bootstrap()`.
+
+### Lifecycle Flowchart
+
+<p align="center"><a href="https://valkyrja.io" target="_blank">
+    <img src="https://raw.githubusercontent.com/valkyrjaio/art/refs/heads/master/flow-charts/php/worker-http-lifecycle.svg" width="100%">
+</a></p>
+
+```mermaid
+flowchart TD
+    A(["Worker process starts"]) --> B["bootstrap(config)"]
+    B --> C["Full app bootstrap\n(providers, data cache, etc.)"]
+    C --> D["bootstrapParentServices()\nforce-resolve shared singletons"]
+    D --> E["getData()\ncapture ContainerData snapshot"]
+    E --> F(["Parent frozen — request loop begins"])
+    F --> G["Runtime delivers request"]
+    G --> H["handle(app, data, request)"]
+    H --> I["new ChildContainer(parent, data)\nnew ChildApplication(app, container)"]
+    I --> J["Register request-scoped singletons\non child container"]
+    J --> K["Dispatch request"]
+    K --> L["Child discarded"]
+    L --> F
+```
+
+### Customising Bootstrap
+
+Override `bootstrapParentServices()` to force-resolve services that are
+expensive to create and safe to share across requests — for example, the route
+collection:
+
+```php
+protected static function bootstrapParentServices(ApplicationContract $app): void
+{
+    $container = $app->getContainer();
+    $container->getSingleton(CollectionContract::class);
+    $container->getSingleton(MyExpensiveSharedService::class);
+}
+```
+
+Anything resolved here lives in the frozen parent and is shared (read-only)
+across all requests. Anything not resolved here will be created fresh in each
+request's child container, which is correct but pays the creation cost on
+every request.
+
+### Child Container Variants
+
+Two `ChildContainer` implementations are available:
+
+- **`Valkyrja\Container\Manager\ChildContainer`** (default) — delegates to the
+  parent via `ContainerContract`. Works with any parent that implements the
+  contract and is portable to any language or runtime.
+
+- **`Valkyrja\Container\Manager\NativeChildContainer`** — accesses the parent's
+  protected fields directly for slightly lower overhead at construction.
+  Requires
+  a concrete `Container` parent and is PHP-only. Use only when profiling
+  confirms
+  a bottleneck at worker child construction rates.
+
+The abstract worker entry class uses `ChildContainer` by default. Swap in
+`NativeChildContainer` by overriding `handle()` in your concrete subclass.

--- a/src/Valkyrja/Container/Data/ContainerData.php
+++ b/src/Valkyrja/Container/Data/ContainerData.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Container\Data;
 
 use Valkyrja\Container\Contract\ServiceContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 
 readonly class ContainerData
@@ -21,7 +22,7 @@ readonly class ContainerData
     /**
      * @param array<class-string, class-string>                                   $aliases
      * @param array<class-string, class-string>                                   $deferred
-     * @param array<class-string, callable>                                       $deferredCallback
+     * @param array<class-string, callable(ContainerContract):void>               $deferredCallback
      * @param array<class-string<ServiceContract>, class-string<ServiceContract>> $services
      * @param array<class-string, class-string>                                   $singletons
      * @param class-string<ServiceProviderContract>[]                             $providers

--- a/src/Valkyrja/Container/Manager/ChildContainer.php
+++ b/src/Valkyrja/Container/Manager/ChildContainer.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Container\Manager;
+
+use Override;
+use Valkyrja\Container\Contract\ServiceContract;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
+
+class ChildContainer extends Container
+{
+    public function __construct(
+        protected ContainerContract $parent,
+        ContainerData $data,
+    ) {
+        parent::__construct();
+
+        $this->singletons       = $data->singletons;
+        $this->deferredCallback = $data->deferredCallback;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isAlias(string $id): bool
+    {
+        return parent::isAlias($id)
+            || $this->parent->isAlias($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isCallable(string $id): bool
+    {
+        return parent::isCallable($id)
+            || $this->parent->isCallable($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isService(string $id): bool
+    {
+        return parent::isService($id)
+            || $this->parent->isService($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isSingletonInstance(string $id): bool
+    {
+        return parent::isSingletonInstance($id)
+            || $this->parent->isSingletonInstance($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The provided service id
+     */
+    #[Override]
+    public function isDeferred(string $id): bool
+    {
+        return parent::isDeferred($id)
+            || $this->parent->isDeferred($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The provided service id
+     */
+    #[Override]
+    public function isPublished(string $id): bool
+    {
+        return parent::isPublished($id)
+            || $this->parent->isPublished($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string<ServiceProviderContract> $provider The provider
+     */
+    #[Override]
+    public function isRegistered(string $provider): bool
+    {
+        return parent::isRegistered($provider)
+            || $this->parent->isRegistered($provider);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Singleton resolution order:
+     *   1. Child's own cached instance
+     *   2. Parent's cached instance (already resolved, safe to reuse)
+     *   3. Create fresh in child from local binding (isolates from parent)
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    protected function getSingletonWithoutChecks(string $id): object|null
+    {
+        // Parent already has a resolved instance — reuse it (frozen, safe)
+        // and the child has none of its own
+        if (! parent::isSingletonInstance($id) && $this->parent->isSingletonInstance($id)) {
+            return $this->parent->getSingleton($id);
+        }
+
+        return parent::getSingletonWithoutChecks($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string            $id        The service id
+     * @param array<array-key, mixed> $arguments [optional] The arguments
+     */
+    #[Override]
+    protected function getServiceWithoutChecks(string $id, array $arguments = []): ServiceContract|null
+    {
+        if (! parent::isService($id) && $this->parent->isService($id)) {
+            /** @var class-string<ServiceContract> $id */
+            return $this->parent->getService($id, $arguments);
+        }
+
+        return parent::getServiceWithoutChecks($id, $arguments);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string            $id        The service id
+     * @param array<array-key, mixed> $arguments [optional] The arguments
+     */
+    #[Override]
+    protected function getCallableWithoutChecks(string $id, array $arguments = []): object|null
+    {
+        if (! parent::isCallable($id) && $this->parent->isCallable($id)) {
+            return $this->parent->getCallable($id, $arguments);
+        }
+
+        return parent::getCallableWithoutChecks($id, $arguments);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string            $id        The service id
+     * @param array<array-key, mixed> $arguments [optional] The arguments
+     */
+    #[Override]
+    protected function getAliasedWithoutChecks(string $id, array $arguments = []): object|null
+    {
+        if (! parent::isAlias($id) && $this->parent->isAlias($id)) {
+            return $this->parent->getAliased($id, $arguments);
+        }
+
+        return parent::getAliasedWithoutChecks($id, $arguments);
+    }
+}

--- a/src/Valkyrja/Container/Manager/Container.php
+++ b/src/Valkyrja/Container/Manager/Container.php
@@ -240,7 +240,30 @@ class Container implements ContainerContract
     #[Override]
     public function isSingleton(string $id): bool
     {
-        return isset($this->singletons[$id]) || isset($this->instances[$id]);
+        return $this->isSingletonBinding($id)
+            || $this->isSingletonInstance($id);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isSingletonBinding(string $id): bool
+    {
+        return isset($this->singletons[$id]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isSingletonInstance(string $id): bool
+    {
+        return isset($this->instances[$id]);
     }
 
     /**
@@ -340,7 +363,7 @@ class Container implements ContainerContract
      */
     protected function getAliasedWithoutChecks(string $id, array $arguments = []): object|null
     {
-        $aliased = $this->aliases[$id] ?? null;
+        $aliased = $this->getAlias($id);
 
         if ($aliased === null) {
             return null;
@@ -357,7 +380,7 @@ class Container implements ContainerContract
      */
     protected function getCallableWithoutChecks(string $id, array $arguments = []): object|null
     {
-        $closure = $this->callables[$id] ?? null;
+        $closure = $this->getClosure($id);
 
         if ($closure === null) {
             return null;
@@ -373,11 +396,13 @@ class Container implements ContainerContract
      */
     protected function getSingletonWithoutChecks(string $id): object|null
     {
-        if (isset($this->instances[$id])) {
-            return $this->instances[$id];
+        $instance = $this->getSingletonInstance($id);
+
+        if ($instance !== null) {
+            return $instance;
         }
 
-        if (! isset($this->singletons[$id])) {
+        if (! $this->isSingletonBinding($id)) {
             return null;
         }
 
@@ -398,7 +423,7 @@ class Container implements ContainerContract
             return null;
         }
 
-        $service = $this->services[$id] ?? null;
+        $service = $this->getServiceClass($id);
 
         if ($service === null) {
             return null;
@@ -406,6 +431,56 @@ class Container implements ContainerContract
 
         // Make the object by dispatching the service
         return $service::make($this, $arguments);
+    }
+
+    /**
+     * Get the alias target for a given id.
+     *
+     * @param class-string $id The service id
+     *
+     * @return class-string|null
+     */
+    protected function getAlias(string $id): string|null
+    {
+        return $this->aliases[$id]
+            ?? null;
+    }
+
+    /**
+     * Get the callable factory for a given id.
+     *
+     * @param class-string $id The service id
+     *
+     * @return callable(ContainerContract, array<array-key, mixed>):object|null
+     */
+    protected function getClosure(string $id): callable|null
+    {
+        return $this->callables[$id]
+            ?? null;
+    }
+
+    /**
+     * Get a cached singleton instance for a given id.
+     *
+     * @param class-string $id The service id
+     */
+    protected function getSingletonInstance(string $id): object|null
+    {
+        return $this->instances[$id]
+            ?? null;
+    }
+
+    /**
+     * Get the service class binding for a given id.
+     *
+     * @param class-string $id The service id
+     *
+     * @return class-string<ServiceContract>|null
+     */
+    protected function getServiceClass(string $id): string|null
+    {
+        return $this->services[$id]
+            ?? null;
     }
 
     /**

--- a/src/Valkyrja/Container/Manager/Contract/ContainerContract.php
+++ b/src/Valkyrja/Container/Manager/Contract/ContainerContract.php
@@ -116,6 +116,20 @@ interface ContainerContract extends ContainerInterface, ProvidersAwareContract
     public function isSingleton(string $id): bool;
 
     /**
+     * Check whether a given singleton has a class binding (but may not yet be resolved).
+     *
+     * @param class-string $id The service id
+     */
+    public function isSingletonBinding(string $id): bool;
+
+    /**
+     * Check whether a given singleton has already been resolved and cached as an instance.
+     *
+     * @param class-string $id The service id
+     */
+    public function isSingletonInstance(string $id): bool;
+
+    /**
      * Get a service from the container.
      *
      * @template T of object

--- a/src/Valkyrja/Container/Manager/NativeChildContainer.php
+++ b/src/Valkyrja/Container/Manager/NativeChildContainer.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Container\Manager;
+
+use Override;
+use Valkyrja\Container\Contract\ServiceContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
+
+class NativeChildContainer extends Container
+{
+    public function __construct(
+        protected Container $parent
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isAlias(string $id): bool
+    {
+        return $this->getAlias($id) !== null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isCallable(string $id): bool
+    {
+        return $this->getClosure($id) !== null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isService(string $id): bool
+    {
+        return $this->getServiceClass($id) !== null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isSingletonBinding(string $id): bool
+    {
+        return isset($this->singletons[$id])
+            || isset($this->parent->singletons[$id]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    public function isSingletonInstance(string $id): bool
+    {
+        return isset($this->instances[$id])
+            || isset($this->parent->instances[$id]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The provided service id
+     */
+    #[Override]
+    public function isDeferred(string $id): bool
+    {
+        return isset($this->deferred[$id])
+            || isset($this->deferredCallback[$id])
+            || isset($this->parent->deferred[$id])
+            || isset($this->parent->deferredCallback[$id]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The provided service id
+     */
+    #[Override]
+    public function isPublished(string $id): bool
+    {
+        return isset($this->published[$id])
+            || isset($this->parent->published[$id]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string<ServiceProviderContract> $provider The provider
+     */
+    #[Override]
+    public function isRegistered(string $provider): bool
+    {
+        return isset($this->registered[$provider])
+            || isset($this->parent->registered[$provider]);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     *
+     * @return callable(ContainerContract):void|null
+     */
+    #[Override]
+    protected function getDeferredCallback(string $id): callable|null
+    {
+        return $this->deferredCallback[$id]
+            ?? $this->parent->deferredCallback[$id]
+            ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     *
+     * @return class-string|null
+     */
+    #[Override]
+    protected function getAlias(string $id): string|null
+    {
+        return $this->aliases[$id]
+            ?? $this->parent->aliases[$id]
+            ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     *
+     * @return callable(ContainerContract, array<array-key, mixed>):object|null
+     */
+    #[Override]
+    protected function getClosure(string $id): callable|null
+    {
+        return $this->callables[$id]
+            ?? $this->parent->callables[$id]
+            ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     */
+    #[Override]
+    protected function getSingletonInstance(string $id): object|null
+    {
+        return $this->instances[$id]
+            ?? $this->parent->instances[$id]
+            ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @param class-string $id The service id
+     *
+     * @return class-string<ServiceContract>|null
+     */
+    #[Override]
+    protected function getServiceClass(string $id): string|null
+    {
+        return $this->services[$id]
+            ?? $this->parent->services[$id]
+            ?? null;
+    }
+}

--- a/src/Valkyrja/Container/Manager/Trait/ProvidersAware.php
+++ b/src/Valkyrja/Container/Manager/Trait/ProvidersAware.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Container\Manager\Trait;
 
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 use Valkyrja\Container\Throwable\Exception\InvalidArgumentException;
 
@@ -30,7 +31,7 @@ trait ProvidersAware
     /**
      * The custom publish handler for items provided by providers that are deferred.
      *
-     * @var array<class-string, callable>
+     * @var array<class-string, callable(ContainerContract):void>
      */
     protected array $deferredCallback = [];
 
@@ -112,22 +113,32 @@ trait ProvidersAware
      */
     public function publish(string $id): void
     {
-        // The provider for this provided item
-        $provider = $this->deferred[$id] ?? null;
+        // The publish method for this provided item in the provider
+        $publishCallback = $this->getDeferredCallback($id);
 
-        // If there is no provider found then this provided item doesn't exist
-        if ($provider === null) {
+        // If there is no callback found then this provided item doesn't exist
+        if ($publishCallback === null) {
             return;
         }
-
-        // The publish method for this provided item in the provider
-        $publishCallback = $this->deferredCallback[$id];
 
         // Publish the service provider
         $publishCallback($this);
 
         // Set published cache only after the success of a publish (in case of error)
         $this->published[$id] = true;
+    }
+
+    /**
+     * Get the deferred callback.
+     *
+     * @param class-string $id The id
+     *
+     * @return callable(ContainerContract):void|null
+     */
+    protected function getDeferredCallback(string $id): callable|null
+    {
+        return $this->deferredCallback[$id]
+            ?? null;
     }
 
     /**

--- a/src/Valkyrja/Container/README.md
+++ b/src/Valkyrja/Container/README.md
@@ -118,12 +118,20 @@ callbacks.
 Before resolving, you can inspect what is registered:
 
 ```php
-$container->has(string $id): bool          // PSR-11; true if registered in any form
-$container->isSingleton(string $id): bool
+$container->has(string $id): bool                  // PSR-11; true if registered in any form
+$container->isSingleton(string $id): bool          // true if binding OR resolved instance exists
+$container->isSingletonBinding(string $id): bool   // true if class binding exists (not yet resolved)
+$container->isSingletonInstance(string $id): bool  // true if already resolved and cached
 $container->isService(string $id): bool
 $container->isCallable(string $id): bool
 $container->isAlias(string $id): bool
 ```
+
+`isSingleton` is equivalent to `isSingletonBinding || isSingletonInstance`. The
+two fine-grained methods are useful when you need to distinguish between "this
+singleton is registered but not yet built" and "this singleton is already live
+and can be reused" — which is exactly the distinction child containers rely on
+(see [Child Containers](#child-containers)).
 
 ## Resolving Services
 
@@ -202,6 +210,117 @@ public static function publishCache(ContainerContract $container): void
 The publish callback can resolve other services from the container freely. Those
 services are themselves deferred — resolving them here triggers their own
 publish callbacks if they haven't been resolved yet.
+
+## Child Containers
+
+A child container is a per-request container that inherits the parent's frozen
+state at zero cost and writes only to its own local maps. This is the isolation
+mechanism used by Valkyrja's persistent worker entry points (FrankenPHP,
+OpenSwoole, RoadRunner) to ensure that request-scoped state never bleeds between
+concurrent requests.
+
+### The Parent/Child Invariant
+
+The parent container is bootstrapped once when the worker process starts and
+then **frozen** — nothing may write to it again. Each incoming request receives
+a fresh child container. The child checks its own maps first; if a service is
+not registered locally it falls back to the parent. When the request ends the
+child is discarded; the parent is unmodified.
+
+### ContainerData
+
+Before the request loop begins, the parent's `getData()` is captured once:
+
+```php
+$data = $app->getContainer()->getData();
+```
+
+`getData()` returns a `ContainerData` value object. It is passed to every child
+on construction. Because PHP arrays are copy-on-write, each child gets its own
+logical copy of the maps at zero cost until it writes to one.
+
+### Resolution Order
+
+For each lookup the child follows this order:
+
+1. **Child's own maps** — anything registered or resolved locally this request
+2. **Parent** — read-only fallback; the parent is never written to through the child
+
+Singletons resolved in the child are cached in the child only. The parent's
+instance map is never modified after `bootstrap()`.
+
+For singleton resolution specifically, the child applies this three-step strategy:
+
+1. **Child has a cached instance** — return it directly (child-local write, highest priority)
+2. **Parent has a cached instance** — reuse it safely; the parent is frozen so the instance will not change
+3. **Child has a class binding** — create a fresh instance in the child's scope only
+
+`isPublished` follows the same child-first, parent-fallback pattern. If the
+parent has already published a service, the child treats it as published and
+does not re-publish it — preserving the parent's frozen state.
+
+### Available Implementations
+
+Two implementations are provided:
+
+Both implementations share the same invariant: neither triggers deferred
+resolution in the parent. A lookup on the child will reuse a parent singleton
+only if it is already a resolved instance (`isSingletonInstance`). Services that
+are still in the deferred map — registered but never force-resolved — are
+invisible to child containers. Ensure everything needed at request time is
+eagerly resolved in `bootstrapParentServices()` before the request loop begins.
+
+**`Valkyrja\Container\Manager\ChildContainer`** — The default. Delegates to the
+parent via `ContainerContract`, meaning it works with any parent that implements
+the contract. This is the portable, cross-language implementation.
+
+**`Valkyrja\Container\Manager\NativeChildContainer`** — PHP-specific. Reads fall
+back to the parent's maps via direct protected-field access rather than method
+calls, eliminating any risk of accidentally triggering deferred publishing or
+writing to parent state. Requires a concrete `Container` parent. Use only when
+profiling confirms a bottleneck at very high child construction rates.
+
+### Using a Child Container
+
+```php
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\ChildContainer;
+
+// Once, before the request loop:
+$parent = $app->getContainer();
+$data   = $parent->getData();
+
+// Per request, inside the loop:
+$child = new ChildContainer($parent, new ContainerData(
+    deferredCallback: $data->deferredCallback,
+    singletons: $data->singletons,
+));
+
+// Register request-scoped services on the child only:
+$child->setSingleton(RequestContract::class, $request);
+
+// Resolve as normal — falls back to parent transparently:
+$handler = $child->getSingleton(RequestHandlerContract::class);
+```
+
+In practice you will not construct child containers directly. The worker entry
+classes (`WorkerHttp` and its subclasses) handle this for every request. See the
+[Application README](../Application/README.md#persistent-worker-lifecycle) for
+the full lifecycle.
+
+### Singleton State Methods
+
+Child containers rely on the two fine-grained singleton state methods to decide
+how to handle a lookup:
+
+- `isSingletonBinding` — the service is registered as a singleton class but has
+  not yet been resolved. The child should create a fresh instance in its own
+  scope.
+- `isSingletonInstance` — the service has already been resolved and cached. If
+  only the parent has the instance, the child can reuse it safely (the parent is
+  frozen). If the child has its own instance, that takes priority.
+
+Both methods check the child's own state first, then fall back to the parent.
 
 ## A Complete Example
 

--- a/src/Valkyrja/LIFECYCLE.md
+++ b/src/Valkyrja/LIFECYCLE.md
@@ -14,7 +14,8 @@ final response sent or process exited.
 
 ## Entry Points
 
-Every Valkyrja application has one of two entry points depending on its runtime.
+Every Valkyrja application has one of three entry points depending on its
+runtime.
 
 **HTTP** — your web server points to `app/public/index.php`. This file is
 intentionally minimal: it constructs your configuration object and calls
@@ -42,10 +43,26 @@ Cli::run(new CliConfig(
 ));
 ```
 
-Both entry classes — `Valkyrja\Application\Entry\Http` and
-`Valkyrja\Application\Entry\Cli` — exist to give the framework one canonical
-place to evolve the bootstrap sequence. Your entry point files call `run()` and
-are done.
+**Persistent Worker** — for long-running runtimes such as FrankenPHP,
+OpenSwoole, and RoadRunner, where a single PHP process handles many requests
+without restarting. The entry class is runtime-specific but follows the same
+`run()` convention:
+
+```php
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\FrankenPhp\FrankenPhpHttp;
+
+FrankenPhpHttp::run(new HttpConfig(
+    dir: __DIR__ . '/..', // This is the application or module root directory (./app in this case)
+));
+```
+
+Worker entry classes are provided as separate packages — see
+[Worker Mode](#worker-mode-persistent-runtimes) below for the lifecycle details
+and the available runtime integrations.
+
+All three entry classes exist to give the framework one canonical place to
+evolve the bootstrap sequence. Your entry point files call `run()` and are done.
 
 In our examples we're using a module approach where the application code lives
 not in the root of the project folder, but in an app folder. This can allow you
@@ -201,6 +218,85 @@ just due to the nature of an interactive CLI application. The HTTP component has
 a SendingResponse stage because there is only one place in the pipeline where
 the response is actually sent to the client.
 
+## Worker Mode (Persistent Runtimes)
+
+Persistent worker runtimes — FrankenPHP, OpenSwoole, RoadRunner — keep a single
+PHP process alive across many requests. Because state accumulates over time, the
+standard PHP-FPM "clean slate per request" guarantee no longer applies. Valkyrja
+handles this with an explicit parent/child isolation pattern built into
+`Valkyrja\Application\Entry\Abstract\WorkerHttp`.
+
+### The Two-Phase Model
+
+**Phase 1 — Bootstrap (once, at process start)**
+
+`run()` calls `bootstrap()`, which performs the full application bootstrap and
+then calls `bootstrapParentServices()`. After this point the parent application
+and its container are **frozen** — nothing may write to them again.
+
+```
+bootstrap(config)
+  └── App::start()                   ← same sequence as Http/Cli
+        └── bootstrapParentServices()  ← force-resolve shared singletons
+```
+
+A snapshot of the parent container's service maps is captured via `getData()`
+before the request loop begins. Because PHP arrays are copy-on-write, passing
+this snapshot to each child costs nothing until the child writes to it.
+
+**Phase 2 — Handle (once per request, inside the worker loop)**
+
+For every incoming request, `handle()` creates a fresh `ChildContainer` and
+`ChildApplication`. Both inherit from the frozen parent — reads fall through to
+the parent transparently — but all writes stay local to the child. When the
+request ends the child is discarded and the parent is unmodified.
+
+```
+handle(app, data, request)
+  ├── new ChildContainer(parent, data)
+  ├── new ChildApplication(parent, childContainer)
+  ├── Register request-scoped singletons on child
+  └── Dispatch request → (same seven-stage pipeline as Http)
+```
+
+### Available Runtimes
+
+| Package               | Class                                | Runtime       |
+|-----------------------|--------------------------------------|---------------|
+| `valkyrja/frankenphp` | `Valkyrja\FrankenPhp\FrankenPhpHttp` | FrankenPHP    |
+| `valkyrja/openswoole` | `Valkyrja\OpenSwoole\OpenSwooleHttp` | OpenSwoole    |
+| `valkyrja/roadrunner` | `Valkyrja\RoadRunner\RoadRunnerHttp` | RoadRunner    |
+
+### Customising Bootstrap
+
+Override `bootstrapParentServices()` to force-resolve services that are
+expensive to create and safe to share across requests:
+
+```php
+protected static function bootstrapParentServices(ApplicationContract $app): void
+{
+    $container = $app->getContainer();
+    $container->getSingleton(CollectionContract::class);
+    $container->getSingleton(MyExpensiveSharedService::class);
+}
+```
+
+Anything resolved here lives in the frozen parent and is shared read-only across
+all requests. Anything not resolved here is created fresh in each request's child
+container — correct but paying the creation cost per request.
+
+### Child Container Variants
+
+Two implementations are available for the per-request child container:
+
+- **`ChildContainer`** (default) — delegates to the parent via
+  `ContainerContract`. Portable and works with any parent that implements the
+  contract.
+- **`NativeChildContainer`** — accesses the parent's protected fields directly
+  for lower construction overhead. Requires a concrete `Container` parent.
+  Use only when profiling confirms a bottleneck at very high child construction
+  rates.
+
 ## Focus on Configuration
 
 Valkyrja's configuration philosophy is worth internalizing early because it
@@ -219,6 +315,8 @@ The base class is `Valkyrja\Application\Data\Config`. `HttpConfig` and
 See [The Application](Application/README.md) for a full reference.
 
 ## Lifecycle at a Glance
+
+### Standard (HTTP / CLI)
 
 ```
 index.php / bin/cli
@@ -242,6 +340,24 @@ index.php / bin/cli
                                 ├── Stage 6: SendingResponse  [HTTP only]
                                 ├── Send response / write output
                                 └── Stage 7: Terminated / Exited
+```
+
+### Worker Mode (Persistent Runtimes)
+
+```
+Worker process starts
+  └── WorkerHttp::run(HttpConfig)
+        └── bootstrap(config)
+              └── App::start()                    ← full bootstrap (same as Http)
+                    └── bootstrapParentServices()  ← freeze parent; resolve shared singletons
+                          └── getData()            ← snapshot parent maps once
+                                └── [request loop]
+                                      └── handle(app, data, request)
+                                            ├── new ChildContainer(parent, data)
+                                            ├── new ChildApplication(parent, childContainer)
+                                            ├── Register request-scoped singletons on child
+                                            └── Dispatch request  ← same seven-stage pipeline
+                                                  └── Child discarded → loop repeats
 ```
 
 ### HTTP Lifecycle
@@ -309,4 +425,45 @@ flowchart TD
     M --> P[Stage 6 - Exited]
     P --> Q["Exiter::exit(ExitCode)"]
     Q --> R([Process ends])
+```
+
+### Worker HTTP Lifecycle
+
+<p align="center"><a href="https://valkyrja.io" target="_blank">
+    <img src="https://raw.githubusercontent.com/valkyrjaio/art/refs/heads/master/flow-charts/php/worker-http-lifecycle.svg" width="100%">
+</a></p>
+
+```mermaid
+flowchart TD
+    A(["Worker process starts"]) --> B["WorkerHttp::run(HttpConfig)"]
+    B --> C["bootstrap(config)\nApp::start - full bootstrap"]
+    C --> D{Data cache?}
+    D -->|yes| E[Load data cache]
+    D -->|no| F[Iterate providers]
+    E --> G["bootstrapParentServices()\nForce-resolve shared singletons"]
+    F --> G
+    G --> H["getData()\nSnapshot parent maps"]
+    H --> I(["Parent frozen — request loop begins"])
+    I --> J[Runtime delivers request]
+    J --> K["handle(app, data, request)"]
+    K --> L["new ChildContainer(parent, data)\nnew ChildApplication(app, container)"]
+    L --> M["Register request-scoped singletons\non child container"]
+    M --> N[Stage 1 - RequestReceived]
+    N -->|"cache hit / short-circuit"| S[Stage 6 - SendingResponse]
+    N -->|throwable| T[Stage 5 - ThrowableCaught]
+    N --> O{Route matched?}
+    O -->|no| P["Stage 3 - RouteNotMatched (404)"]
+    O -->|yes| Q[Stage 2 - RouteMatched]
+    P --> S
+    Q -->|"short-circuit / throwable"| T
+    Q --> R[Dispatcher - controller method]
+    R -->|throwable| T
+    R --> U[Stage 4 - RouteDispatched]
+    U -->|throwable| T
+    U --> S
+    T --> S
+    S --> V[Write response to output buffer]
+    V --> W[Stage 7 - Terminated]
+    W --> X[Child discarded]
+    X --> I
 ```

--- a/tests/Tests/Classes/Application/Entry/AppExceptionHandlerClass.php
+++ b/tests/Tests/Classes/Application/Entry/AppExceptionHandlerClass.php
@@ -54,7 +54,7 @@ abstract class AppExceptionHandlerClass extends App
      * @inheritDoc
      */
     #[Override]
-    protected static function defaultExceptionHandler(): void
+    public static function defaultExceptionHandler(): void
     {
         self::$called = true;
     }

--- a/tests/Tests/Classes/Application/Entry/WorkerHttpClass.php
+++ b/tests/Tests/Classes/Application/Entry/WorkerHttpClass.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Classes\Application\Entry;
+
+use Override;
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Entry\Abstract\WorkerHttp;
+use Valkyrja\Application\Env\Env;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Dispatch\Data\MethodDispatch;
+use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
+use Valkyrja\Http\Message\Response\TextResponse;
+use Valkyrja\Http\Routing\Collection\Contract\CollectionContract;
+use Valkyrja\Http\Routing\Data\Route;
+
+/**
+ * Testable WorkerHttp subclass.
+ *
+ * Overrides:
+ *   - bootstrapParentServices(): tracks call count; skips real service resolution
+ *     so tests don't require the full HTTP provider stack.
+ *   - getChildContainer(): records every child container created per request.
+ *   - getChildApplication(): records every child application created per request.
+ *   - handleRequest(): no-op; tests verify isolation, not dispatch.
+ */
+final class WorkerHttpClass extends WorkerHttp
+{
+    /** @var list<ContainerContract> Containers created across all handle() calls */
+    public static array $childContainers = [];
+
+    /** @var list<ApplicationContract> Applications created across all handle() calls */
+    public static array $childApplications = [];
+
+    /** @var string[] responses created across all handleRequest() calls */
+    public static array $requestResponses = [];
+
+    /** Number of times bootstrapParentServices() has been called */
+    public static int $bootstrapParentServicesCallCount = 0;
+
+    /** Number of times handleRequest() has been called */
+    public static int $handleRequestCallCount = 0;
+
+    /** Number of times handleRoute() has been called */
+    public static int $handleRouteCallCount = 0;
+
+    /**
+     * Reset all recorded state between tests.
+     */
+    public static function reset(): void
+    {
+        self::$childContainers                  = [];
+        self::$childApplications                = [];
+        self::$requestResponses                 = [];
+        self::$bootstrapParentServicesCallCount = 0;
+        self::$handleRequestCallCount           = 0;
+    }
+
+    /**
+     * Run the faux worker app for a given number of requests.
+     *
+     * Mirrors the real worker entry class pattern: bootstrap once, capture data,
+     * build a handler closure, then invoke it requestCount times.
+     */
+    public static function run(HttpConfig $config, int $requestCount = 1, Env $env = new Env()): void
+    {
+        $app  = self::bootstrap(config: $config, env: $env);
+        $data = $app->getContainer()->getData();
+
+        $handler = static function () use ($app, $data): void {
+            self::handle($app, $data, self::getRequest());
+        };
+
+        for ($i = 0; $i < $requestCount; $i++) {
+            $handler();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * No-op: skips CollectionContract resolution so tests run without the full
+     * HTTP provider stack. Tracks the call count so tests can assert it was
+     * called exactly once (during bootstrap, not per request).
+     */
+    #[Override]
+    public static function bootstrapParentServices(ApplicationContract $app): void
+    {
+        self::$bootstrapParentServicesCallCount++;
+
+        parent::bootstrapParentServices($app);
+
+        $collection = $app->getContainer()->getSingleton(CollectionContract::class);
+
+        $collection->add(
+            new Route(
+                path: '/',
+                name: 'home',
+                dispatch: MethodDispatch::fromCallableOrArray([self::class, 'handleRoute'])
+            )
+        );
+    }
+
+    /**
+     * Handle the route.
+     */
+    public static function handleRoute(): TextResponse
+    {
+        self::$handleRouteCallCount++;
+
+        return new TextResponse('Hello World!');
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Records the created container before returning it.
+     */
+    #[Override]
+    public static function getChildContainer(ApplicationContract $app, ContainerData $data): ContainerContract
+    {
+        $container = parent::getChildContainer($app, $data);
+
+        self::$childContainers[] = $container;
+
+        return $container;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Records the created child application before returning it.
+     */
+    #[Override]
+    public static function getChildApplication(ApplicationContract $app, ContainerContract $container): ApplicationContract
+    {
+        $childApp = parent::getChildApplication($app, $container);
+
+        self::$childApplications[] = $childApp;
+
+        return $childApp;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * No-op: tests verify isolation, not actual request dispatch.
+     */
+    #[Override]
+    public static function handleRequest(ContainerContract $container, ServerRequestContract $request): void
+    {
+        self::$handleRequestCallCount++;
+
+        ob_start();
+        parent::handleRequest($container, $request);
+
+        self::$requestResponses[] = (string) ob_get_clean();
+    }
+}

--- a/tests/Tests/Classes/Application/Entry/WorkerHttpClass.php
+++ b/tests/Tests/Classes/Application/Entry/WorkerHttpClass.php
@@ -66,6 +66,7 @@ final class WorkerHttpClass extends WorkerHttp
         self::$requestResponses                 = [];
         self::$bootstrapParentServicesCallCount = 0;
         self::$handleRequestCallCount           = 0;
+        self::$handleRouteCallCount             = 0;
     }
 
     /**

--- a/tests/Tests/Unit/Application/Entry/WorkerHttpTest.php
+++ b/tests/Tests/Unit/Application/Entry/WorkerHttpTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Application\Entry;
+
+use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Directory\Directory;
+use Valkyrja\Application\Kernel\ChildApplication;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+use Valkyrja\Http\Message\Request\ServerRequest;
+use Valkyrja\Tests\Classes\Application\Entry\WorkerHttpClass;
+use Valkyrja\Tests\Classes\Container\SingletonClass;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+/**
+ * Test WorkerHttp: parent bootstrapped once, children created per request,
+ * no state leaks from child to parent or between siblings.
+ */
+final class WorkerHttpTest extends TestCase
+{
+    private ApplicationContract $app;
+
+    private ContainerData $data;
+
+    private ServerRequest $request;
+
+    protected function setUp(): void
+    {
+        WorkerHttpClass::reset();
+
+        $this->app     = WorkerHttpClass::bootstrap(new HttpConfig(dir: Directory::$basePath));
+        $this->data    = $this->app->getContainer()->getData();
+        $this->request = new ServerRequest();
+    }
+
+    // -----------------------------------------------------------------------
+    // bootstrap() — called once before the request loop
+    // -----------------------------------------------------------------------
+
+    public function testBootstrapReturnsApplicationContract(): void
+    {
+        self::assertInstanceOf(ApplicationContract::class, $this->app);
+    }
+
+    public function testBootstrapCallsBootstrapParentServicesExactlyOnce(): void
+    {
+        self::assertSame(1, WorkerHttpClass::$bootstrapParentServicesCallCount);
+    }
+
+    public function testBootstrapDoesNotCreateAnyChildren(): void
+    {
+        self::assertCount(0, WorkerHttpClass::$childContainers);
+        self::assertCount(0, WorkerHttpClass::$childApplications);
+    }
+
+    public function testParentContainerIsRegisteredAsSingleton(): void
+    {
+        $container = $this->app->getContainer();
+
+        self::assertSame($container, $container->getSingleton(ContainerContract::class));
+    }
+
+    public function testParentApplicationIsRegisteredAsSingleton(): void
+    {
+        $container = $this->app->getContainer();
+
+        self::assertSame($this->app, $container->getSingleton(ApplicationContract::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // handle() — one child created per request
+    // -----------------------------------------------------------------------
+
+    public function testHandleCreatesOneChildContainerPerRequest(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertCount(3, WorkerHttpClass::$childContainers);
+    }
+
+    public function testHandleCreatesOneChildApplicationPerRequest(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertCount(3, WorkerHttpClass::$childApplications);
+    }
+
+    public function testEachHandleProducesADistinctChildContainer(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertNotSame(
+            WorkerHttpClass::$childContainers[0],
+            WorkerHttpClass::$childContainers[1]
+        );
+    }
+
+    public function testEachHandleProducesADistinctChildApplication(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertNotSame(
+            WorkerHttpClass::$childApplications[0],
+            WorkerHttpClass::$childApplications[1]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Child container setup — request-scoped singletons
+    // -----------------------------------------------------------------------
+
+    public function testChildContainerHasApplicationContractSingleton(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child = WorkerHttpClass::$childContainers[0];
+
+        self::assertTrue($child->isSingletonInstance(ApplicationContract::class));
+    }
+
+    public function testChildContainerHasContainerContractSingleton(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child = WorkerHttpClass::$childContainers[0];
+
+        self::assertTrue($child->isSingletonInstance(ContainerContract::class));
+    }
+
+    public function testChildApplicationContractIsChildApplication(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child    = WorkerHttpClass::$childContainers[0];
+        $childApp = $child->getSingleton(ApplicationContract::class);
+
+        self::assertInstanceOf(ChildApplication::class, $childApp);
+    }
+
+    public function testChildContainerContractIsChildContainer(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child = WorkerHttpClass::$childContainers[0];
+
+        self::assertSame($child, $child->getSingleton(ContainerContract::class));
+    }
+
+    public function testChildApplicationIsNotParentApplication(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $childApp = WorkerHttpClass::$childApplications[0];
+
+        self::assertNotSame($this->app, $childApp);
+    }
+
+    // -----------------------------------------------------------------------
+    // No leaking — parent unchanged after handle()
+    // -----------------------------------------------------------------------
+
+    public function testParentApplicationContractUnchangedAfterHandle(): void
+    {
+        $parentContainer = $this->app->getContainer();
+        $before          = $parentContainer->getSingleton(ApplicationContract::class);
+
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertSame($before, $parentContainer->getSingleton(ApplicationContract::class));
+        self::assertSame($this->app, $parentContainer->getSingleton(ApplicationContract::class));
+    }
+
+    public function testParentContainerContractUnchangedAfterHandle(): void
+    {
+        $parentContainer = $this->app->getContainer();
+        $before          = $parentContainer->getSingleton(ContainerContract::class);
+
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertSame($before, $parentContainer->getSingleton(ContainerContract::class));
+        self::assertSame($parentContainer, $parentContainer->getSingleton(ContainerContract::class));
+    }
+
+    public function testChildSingletonDoesNotLeakToParent(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child    = WorkerHttpClass::$childContainers[0];
+        $instance = new SingletonClass();
+        $child->setSingleton(SingletonClass::class, $instance);
+
+        self::assertFalse($this->app->getContainer()->isSingletonInstance(SingletonClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // No leaking — child state does not reach sibling children
+    // -----------------------------------------------------------------------
+
+    public function testChildSingletonDoesNotLeakToSiblingChild(): void
+    {
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        $child1   = WorkerHttpClass::$childContainers[0];
+        $child2   = WorkerHttpClass::$childContainers[1];
+        $instance = new SingletonClass();
+        $child1->setSingleton(SingletonClass::class, $instance);
+
+        self::assertFalse($child2->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testBootstrapParentServicesNotCalledAgainOnHandle(): void
+    {
+        $countAfterBootstrap = WorkerHttpClass::$bootstrapParentServicesCallCount;
+
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+        WorkerHttpClass::handle($this->app, $this->data, $this->request);
+
+        self::assertSame($countAfterBootstrap, WorkerHttpClass::$bootstrapParentServicesCallCount);
+    }
+
+    // -----------------------------------------------------------------------
+    // run() — faux worker loop
+    // -----------------------------------------------------------------------
+
+    public function testRun(): void
+    {
+        WorkerHttpClass::reset();
+        WorkerHttpClass::run(new HttpConfig(dir: Directory::$basePath), requestCount: 3);
+
+        self::assertCount(3, WorkerHttpClass::$childContainers);
+        self::assertCount(3, WorkerHttpClass::$childApplications);
+        self::assertCount(3, WorkerHttpClass::$requestResponses);
+        self::assertSame(3, WorkerHttpClass::$handleRouteCallCount);
+        self::assertSame(3, WorkerHttpClass::$handleRequestCallCount);
+        self::assertSame(1, WorkerHttpClass::$bootstrapParentServicesCallCount);
+    }
+}

--- a/tests/Tests/Unit/Application/Kernel/ChildApplicationTest.php
+++ b/tests/Tests/Unit/Application/Kernel/ChildApplicationTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Application\Kernel;
+
+use Valkyrja\Application\Data\Config;
+use Valkyrja\Application\Kernel\ChildApplication;
+use Valkyrja\Application\Kernel\Contract\ApplicationContract;
+use Valkyrja\Application\Kernel\Valkyrja;
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\ChildContainer;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Container\Manager\NativeChildContainer;
+use Valkyrja\Tests\Classes\Container\SingletonClass;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+/**
+ * Test the ChildApplication: own container, all other methods delegate to parent.
+ */
+final class ChildApplicationTest extends TestCase
+{
+    private Valkyrja $parent;
+    private ChildApplication $child;
+    private NativeChildContainer $childContainer;
+
+    protected function setUp(): void
+    {
+        $config          = new Config();
+        $parentContainer = new Container();
+        $this->parent    = new Valkyrja(container: $parentContainer, config: $config);
+
+        $this->childContainer = new NativeChildContainer($parentContainer);
+        $this->child          = new ChildApplication($this->parent, $this->childContainer);
+    }
+
+    // -----------------------------------------------------------------------
+    // getContainer
+    // -----------------------------------------------------------------------
+
+    public function testGetContainerReturnsChildContainer(): void
+    {
+        self::assertSame($this->childContainer, $this->child->getContainer());
+        self::assertNotSame($this->parent->getContainer(), $this->child->getContainer());
+    }
+
+    // -----------------------------------------------------------------------
+    // publishProviderCallbacks — delegates to parent, parent app is passed
+    // -----------------------------------------------------------------------
+
+    public function testPublishProviderCallbacksDelegatesToParent(): void
+    {
+        $received = null;
+
+        $config = new Config(
+            callbacks: [static function (ApplicationContract $app) use (&$received): void {
+                $received = $app;
+            }],
+        );
+
+        $parentContainer = new Container();
+        $parent          = new Valkyrja(container: $parentContainer, config: $config);
+        $child           = new ChildApplication($parent, new NativeChildContainer($parentContainer));
+
+        $child->publishProviderCallbacks();
+
+        // The callback must be invoked with the parent application, not the child
+        self::assertSame($parent, $received);
+        self::assertNotSame($child, $received);
+    }
+
+    // -----------------------------------------------------------------------
+    // Delegation — all non-container methods return the parent's values
+    // -----------------------------------------------------------------------
+
+    public function testGetProvidersDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getProviders(), $this->child->getProviders());
+    }
+
+    public function testGetContainerProvidersDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getContainerProviders(), $this->child->getContainerProviders());
+    }
+
+    public function testGetEventProvidersDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getEventProviders(), $this->child->getEventProviders());
+    }
+
+    public function testGetCliProvidersDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getCliProviders(), $this->child->getCliProviders());
+    }
+
+    public function testGetHttpProvidersDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getHttpProviders(), $this->child->getHttpProviders());
+    }
+
+    public function testGetDebugModeDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getDebugMode(), $this->child->getDebugMode());
+    }
+
+    public function testGetEnvironmentDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getEnvironment(), $this->child->getEnvironment());
+    }
+
+    public function testGetVersionDelegatesToParent(): void
+    {
+        self::assertSame($this->parent->getVersion(), $this->child->getVersion());
+    }
+
+    // -----------------------------------------------------------------------
+    // Container isolation — child writes must not reach the parent container
+    // -----------------------------------------------------------------------
+
+    public function testChildContainerWriteDoesNotAffectParentContainer(): void
+    {
+        $instance = new SingletonClass();
+        $this->child->getContainer()->setSingleton(SingletonClass::class, $instance);
+
+        self::assertFalse($this->parent->getContainer()->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testChildContainerServesItsOwnRegistrations(): void
+    {
+        $instance = new SingletonClass();
+        $this->child->getContainer()->setSingleton(SingletonClass::class, $instance);
+
+        self::assertSame($instance, $this->child->getContainer()->getSingleton(SingletonClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // Alternative container type — ChildContainer (portable default)
+    // -----------------------------------------------------------------------
+
+    public function testWorksWithChildContainer(): void
+    {
+        $parentContainer = new Container();
+        $parent          = new Valkyrja(container: $parentContainer, config: new Config());
+        $data            = $parentContainer->getData();
+        $childContainer  = new ChildContainer($parentContainer, new ContainerData(
+            deferredCallback: $data->deferredCallback,
+            singletons: $data->singletons,
+        ));
+        $child = new ChildApplication($parent, $childContainer);
+
+        self::assertSame($childContainer, $child->getContainer());
+        self::assertSame($parent->getEnvironment(), $child->getEnvironment());
+        self::assertSame($parent->getVersion(), $child->getVersion());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple children — independent containers, same parent delegation
+    // -----------------------------------------------------------------------
+
+    public function testMultipleChildrenHaveIndependentContainers(): void
+    {
+        $parentContainer = new Container();
+        $child2Container = new NativeChildContainer($parentContainer);
+        $child2          = new ChildApplication($this->parent, $child2Container);
+
+        self::assertNotSame($this->child->getContainer(), $child2->getContainer());
+        self::assertSame($this->child->getEnvironment(), $child2->getEnvironment());
+    }
+
+    public function testMultipleChildrenContainerWritesAreIsolatedFromEachOther(): void
+    {
+        $parentContainer = new Container();
+        $child2Container = new NativeChildContainer($parentContainer);
+        $child2          = new ChildApplication($this->parent, $child2Container);
+
+        $instance = new SingletonClass();
+        $this->child->getContainer()->setSingleton(SingletonClass::class, $instance);
+
+        self::assertFalse($child2->getContainer()->isSingletonInstance(SingletonClass::class));
+    }
+}

--- a/tests/Tests/Unit/Container/Manager/ChildContainerTest.php
+++ b/tests/Tests/Unit/Container/Manager/ChildContainerTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Container\Manager;
+
+use Valkyrja\Container\Data\ContainerData;
+use Valkyrja\Container\Manager\ChildContainer;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
+use Valkyrja\Dispatch\Provider\ServiceProvider;
+use Valkyrja\Tests\Classes\Container\ServiceClass;
+use Valkyrja\Tests\Classes\Container\SingletonClass;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+/**
+ * Test the ChildContainer: feature parity with NativeChildContainer via ContainerContract-only delegation.
+ */
+final class ChildContainerTest extends TestCase
+{
+    private Container $parent;
+    private ChildContainer $child;
+
+    protected function setUp(): void
+    {
+        $this->parent = new Container();
+        $this->child  = $this->createChild();
+    }
+
+    // -----------------------------------------------------------------------
+    // isAlias
+    // -----------------------------------------------------------------------
+
+    public function testIsAliasFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('myAlias', ServiceClass::class);
+
+        self::assertTrue($this->child->isAlias('myAlias'));
+        self::assertFalse($this->child->isAlias('unknown'));
+    }
+
+    public function testIsAliasFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+        $this->child->bindAlias('childAlias', ServiceClass::class);
+
+        self::assertTrue($this->child->isAlias('childAlias'));
+        self::assertFalse($this->parent->isAlias('childAlias'));
+    }
+
+    // -----------------------------------------------------------------------
+    // isCallable
+    // -----------------------------------------------------------------------
+
+    public function testIsCallableFromParent(): void
+    {
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => new SingletonClass());
+
+        self::assertTrue($this->child->isCallable(ServiceClass::class));
+        self::assertFalse($this->child->isCallable(SingletonClass::class));
+    }
+
+    public function testIsCallableFromChild(): void
+    {
+        $this->child->setCallable(ServiceClass::class, static fn ($c) => new SingletonClass());
+
+        self::assertTrue($this->child->isCallable(ServiceClass::class));
+        self::assertFalse($this->parent->isCallable(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isService
+    // -----------------------------------------------------------------------
+
+    public function testIsServiceFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+
+        self::assertTrue($this->child->isService(ServiceClass::class));
+        self::assertFalse($this->child->isService(SingletonClass::class));
+    }
+
+    public function testIsServiceFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+
+        self::assertTrue($this->child->isService(ServiceClass::class));
+        self::assertFalse($this->parent->isService(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isSingleton / isSingletonBinding / isSingletonInstance
+    // -----------------------------------------------------------------------
+
+    public function testIsSingletonBindingFromParent(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+        // Re-create child after parent setup so the copied data includes the binding
+        $child = $this->createChild();
+
+        self::assertTrue($child->isSingletonBinding(SingletonClass::class));
+        self::assertTrue($child->isSingleton(SingletonClass::class));
+        self::assertFalse($child->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testIsSingletonInstanceFromParent(): void
+    {
+        $instance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $instance);
+
+        self::assertTrue($this->child->isSingletonInstance(SingletonClass::class));
+        self::assertTrue($this->child->isSingleton(SingletonClass::class));
+    }
+
+    public function testIsSingletonBindingFromChild(): void
+    {
+        $this->child->bindSingleton(SingletonClass::class, SingletonClass::class);
+
+        self::assertTrue($this->child->isSingletonBinding(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonBinding(SingletonClass::class));
+    }
+
+    public function testIsSingletonInstanceFromChild(): void
+    {
+        $instance = new SingletonClass();
+        $this->child->setSingleton(SingletonClass::class, $instance);
+
+        self::assertTrue($this->child->isSingletonInstance(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isDeferred / isPublished / isRegistered
+    // -----------------------------------------------------------------------
+
+    public function testIsDeferredFromParent(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isDeferred(DispatcherContract::class));
+    }
+
+    public function testIsDeferredFromChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isDeferred(DispatcherContract::class));
+        self::assertFalse($this->parent->isDeferred(DispatcherContract::class));
+    }
+
+    public function testIsPublishedFromParent(): void
+    {
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => new ServiceClass($c));
+
+        self::assertTrue($this->child->isPublished(ServiceClass::class));
+    }
+
+    public function testIsPublishedFromChild(): void
+    {
+        $this->child->setCallable(ServiceClass::class, static fn ($c) => new ServiceClass($c));
+
+        self::assertTrue($this->child->isPublished(ServiceClass::class));
+        self::assertFalse($this->parent->isPublished(ServiceClass::class));
+    }
+
+    public function testIsRegisteredFromParent(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isRegistered(ServiceProvider::class));
+    }
+
+    public function testIsRegisteredFromChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isRegistered(ServiceProvider::class));
+        self::assertFalse($this->parent->isRegistered(ServiceProvider::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // getSingleton — parent fallback and child isolation
+    // -----------------------------------------------------------------------
+
+    public function testGetSingletonFromParentBinding(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+        // Re-create child so the copied data includes the binding
+        $child = $this->createChild();
+
+        $instance = $child->getSingleton(SingletonClass::class);
+
+        self::assertInstanceOf(SingletonClass::class, $instance);
+        // Resolved instance must be cached in child, NOT in parent
+        self::assertSame($instance, $child->getSingleton(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testGetSingletonFromParentInstance(): void
+    {
+        $parentInstance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $parentInstance);
+
+        $childResult = $this->child->getSingleton(SingletonClass::class);
+
+        self::assertSame($parentInstance, $childResult);
+    }
+
+    public function testGetSingletonFromChildOverridesParent(): void
+    {
+        $parentInstance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $parentInstance);
+
+        $childInstance = new SingletonClass();
+        $this->child->setSingleton(SingletonClass::class, $childInstance);
+
+        self::assertSame($childInstance, $this->child->getSingleton(SingletonClass::class));
+        self::assertNotSame($parentInstance, $this->child->getSingleton(SingletonClass::class));
+    }
+
+    public function testChildSingletonDoesNotPollutesParent(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+        // Re-create child so the copied data includes the binding
+        $child = $this->createChild();
+
+        $childInstance = $child->getSingleton(SingletonClass::class);
+
+        // Parent must remain unpolluted
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+        self::assertNotNull($childInstance);
+    }
+
+    // -----------------------------------------------------------------------
+    // getService — parent delegation and child-local
+    // -----------------------------------------------------------------------
+
+    public function testGetServiceFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+
+        $instance = $this->child->getService(ServiceClass::class);
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+        self::assertNotSame($instance, $this->child->getService(ServiceClass::class));
+    }
+
+    public function testGetServiceFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+
+        $instance = $this->child->getService(ServiceClass::class);
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+        self::assertFalse($this->parent->isService(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // getCallable — parent fallback
+    // -----------------------------------------------------------------------
+
+    public function testGetCallableFromParent(): void
+    {
+        $singleton = new SingletonClass();
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => $singleton);
+
+        $result = $this->child->getCallable(ServiceClass::class);
+
+        self::assertSame($singleton, $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // getAliased — parent fallback
+    // -----------------------------------------------------------------------
+
+    public function testGetAliasedFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('svcAlias', ServiceClass::class);
+
+        $instance = $this->child->getAliased('svcAlias');
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+    }
+
+    public function testGetAliasedFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+        $this->child->bindAlias('childAlias', ServiceClass::class);
+
+        $instance = $this->child->getAliased('childAlias');
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+        self::assertFalse($this->parent->isAlias('childAlias'));
+    }
+
+    // -----------------------------------------------------------------------
+    // Parent immutability — parent state must not change through child operations
+    // -----------------------------------------------------------------------
+
+    public function testParentStateUnchangedAfterChildOperations(): void
+    {
+        // Set up parent with each registration type
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('svcAlias', ServiceClass::class);
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+        $this->parent->setCallable(self::class, static fn ($c) => new self('test'));
+        $this->parent->register(ServiceProvider::class);
+
+        // Build child from the fully-set-up parent
+        $child = $this->createChild();
+
+        // Snapshot parent state before any child interaction
+        $dataBefore                  = $this->parent->getData();
+        $singletonInstanceBefore     = $this->parent->isSingletonInstance(SingletonClass::class);
+        $dispatcherPublishedBefore   = $this->parent->isPublished(DispatcherContract::class);
+
+        // Perform a broad set of child operations
+        $child->get(ServiceClass::class);
+        $child->getService(ServiceClass::class);
+        $child->getCallable(self::class);
+        $child->getAliased('svcAlias');
+        $child->getSingleton(SingletonClass::class);
+        $child->get(DispatcherContract::class); // triggers deferred publish in child
+
+        // Parent data maps must be identical
+        $dataAfter = $this->parent->getData();
+        self::assertSame($dataBefore->aliases, $dataAfter->aliases);
+        self::assertSame($dataBefore->services, $dataAfter->services);
+        self::assertSame($dataBefore->singletons, $dataAfter->singletons);
+        self::assertSame($dataBefore->deferred, $dataAfter->deferred);
+        self::assertSame($dataBefore->providers, $dataAfter->providers);
+
+        // Singleton resolved in child must not have been cached in parent
+        self::assertSame($singletonInstanceBefore, $this->parent->isSingletonInstance(SingletonClass::class));
+
+        // Deferred service published in child must not mark parent as published
+        self::assertSame($dispatcherPublishedBefore, $this->parent->isPublished(DispatcherContract::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // Deferred provider — published in child context
+    // -----------------------------------------------------------------------
+
+    public function testDeferredFromChildPublishedInChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->has(DispatcherContract::class));
+
+        $dispatcher = $this->child->get(DispatcherContract::class);
+        self::assertInstanceOf(DispatcherContract::class, $dispatcher);
+
+        self::assertFalse($this->parent->isPublished(DispatcherContract::class));
+    }
+
+    public function testDeferredFromParentPublishedInChild(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+        // Re-create child so deferredCallback is copied from parent
+        $child = $this->createChild();
+
+        self::assertTrue($child->has(DispatcherContract::class));
+
+        $dispatcher = $child->get(DispatcherContract::class);
+        self::assertInstanceOf(DispatcherContract::class, $dispatcher);
+
+        // Publishing must stay in child, not pollute parent
+        self::assertFalse($this->parent->isPublished(DispatcherContract::class));
+    }
+
+    /**
+     * Create a ChildContainer from the current parent state.
+     * The ContainerData is built from the parent and passed explicitly.
+     */
+    private function createChild(): ChildContainer
+    {
+        $data = $this->parent->getData();
+
+        return new ChildContainer($this->parent, new ContainerData(
+            deferredCallback: $data->deferredCallback,
+            singletons: $data->singletons,
+        ));
+    }
+}

--- a/tests/Tests/Unit/Container/Manager/NativeChildContainerTest.php
+++ b/tests/Tests/Unit/Container/Manager/NativeChildContainerTest.php
@@ -1,0 +1,362 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Container\Manager;
+
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Container\Manager\NativeChildContainer;
+use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
+use Valkyrja\Dispatch\Provider\ServiceProvider;
+use Valkyrja\Tests\Classes\Container\ServiceClass;
+use Valkyrja\Tests\Classes\Container\SingletonClass;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+/**
+ * Test the NativeChildContainer: child-first reads with parent fallback via direct field access.
+ */
+final class NativeChildContainerTest extends TestCase
+{
+    private Container $parent;
+    private NativeChildContainer $child;
+
+    protected function setUp(): void
+    {
+        $this->parent = new Container();
+        $this->child  = new NativeChildContainer($this->parent);
+    }
+
+    // -----------------------------------------------------------------------
+    // isAlias
+    // -----------------------------------------------------------------------
+
+    public function testIsAliasFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('myAlias', ServiceClass::class);
+
+        self::assertTrue($this->child->isAlias('myAlias'));
+        self::assertFalse($this->child->isAlias('unknown'));
+    }
+
+    public function testIsAliasFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+        $this->child->bindAlias('childAlias', ServiceClass::class);
+
+        self::assertTrue($this->child->isAlias('childAlias'));
+        self::assertFalse($this->parent->isAlias('childAlias'));
+    }
+
+    // -----------------------------------------------------------------------
+    // isCallable
+    // -----------------------------------------------------------------------
+
+    public function testIsCallableFromParent(): void
+    {
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => new SingletonClass());
+
+        self::assertTrue($this->child->isCallable(ServiceClass::class));
+        self::assertFalse($this->child->isCallable(SingletonClass::class));
+    }
+
+    public function testIsCallableFromChild(): void
+    {
+        $this->child->setCallable(ServiceClass::class, static fn ($c) => new SingletonClass());
+
+        self::assertTrue($this->child->isCallable(ServiceClass::class));
+        self::assertFalse($this->parent->isCallable(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isService
+    // -----------------------------------------------------------------------
+
+    public function testIsServiceFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+
+        self::assertTrue($this->child->isService(ServiceClass::class));
+        self::assertFalse($this->child->isService(SingletonClass::class));
+    }
+
+    public function testIsServiceFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+
+        self::assertTrue($this->child->isService(ServiceClass::class));
+        self::assertFalse($this->parent->isService(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isSingleton / isSingletonBinding / isSingletonInstance
+    // -----------------------------------------------------------------------
+
+    public function testIsSingletonBindingFromParent(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+
+        self::assertTrue($this->child->isSingletonBinding(SingletonClass::class));
+        self::assertTrue($this->child->isSingleton(SingletonClass::class));
+        self::assertFalse($this->child->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testIsSingletonInstanceFromParent(): void
+    {
+        $instance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $instance);
+
+        self::assertTrue($this->child->isSingletonInstance(SingletonClass::class));
+        self::assertTrue($this->child->isSingleton(SingletonClass::class));
+    }
+
+    public function testIsSingletonBindingFromChild(): void
+    {
+        $this->child->bindSingleton(SingletonClass::class, SingletonClass::class);
+
+        self::assertTrue($this->child->isSingletonBinding(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonBinding(SingletonClass::class));
+    }
+
+    public function testIsSingletonInstanceFromChild(): void
+    {
+        $instance = new SingletonClass();
+        $this->child->setSingleton(SingletonClass::class, $instance);
+
+        self::assertTrue($this->child->isSingletonInstance(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // isDeferred / isPublished / isRegistered
+    // -----------------------------------------------------------------------
+
+    public function testIsDeferredFromParent(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isDeferred(DispatcherContract::class));
+    }
+
+    public function testIsDeferredFromChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isDeferred(DispatcherContract::class));
+        self::assertFalse($this->parent->isDeferred(DispatcherContract::class));
+    }
+
+    public function testIsPublishedFromParent(): void
+    {
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => new ServiceClass($c));
+
+        self::assertTrue($this->child->isPublished(ServiceClass::class));
+    }
+
+    public function testIsPublishedFromChild(): void
+    {
+        $this->child->setCallable(ServiceClass::class, static fn ($c) => new ServiceClass($c));
+
+        self::assertTrue($this->child->isPublished(ServiceClass::class));
+        self::assertFalse($this->parent->isPublished(ServiceClass::class));
+    }
+
+    public function testIsRegisteredFromParent(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isRegistered(ServiceProvider::class));
+    }
+
+    public function testIsRegisteredFromChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->isRegistered(ServiceProvider::class));
+        self::assertFalse($this->parent->isRegistered(ServiceProvider::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // getSingleton — parent fallback and child isolation
+    // -----------------------------------------------------------------------
+
+    public function testGetSingletonFromParentBinding(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+
+        $instance = $this->child->getSingleton(SingletonClass::class);
+
+        self::assertInstanceOf(SingletonClass::class, $instance);
+        // Resolved instance must be cached in child, NOT in parent
+        self::assertSame($instance, $this->child->getSingleton(SingletonClass::class));
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+    }
+
+    public function testGetSingletonFromParentInstance(): void
+    {
+        $parentInstance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $parentInstance);
+
+        $childResult = $this->child->getSingleton(SingletonClass::class);
+
+        self::assertSame($parentInstance, $childResult);
+    }
+
+    public function testGetSingletonFromChildOverridesParent(): void
+    {
+        $parentInstance = new SingletonClass();
+        $this->parent->setSingleton(SingletonClass::class, $parentInstance);
+
+        $childInstance = new SingletonClass();
+        $this->child->setSingleton(SingletonClass::class, $childInstance);
+
+        self::assertSame($childInstance, $this->child->getSingleton(SingletonClass::class));
+        self::assertNotSame($parentInstance, $this->child->getSingleton(SingletonClass::class));
+    }
+
+    public function testChildSingletonDoesNotPollutesParent(): void
+    {
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+
+        $childInstance = $this->child->getSingleton(SingletonClass::class);
+
+        // Parent must remain unpolluted
+        self::assertFalse($this->parent->isSingletonInstance(SingletonClass::class));
+        self::assertNotNull($childInstance);
+    }
+
+    // -----------------------------------------------------------------------
+    // getService — parent fallback
+    // -----------------------------------------------------------------------
+
+    public function testGetServiceFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+
+        $instance = $this->child->getService(ServiceClass::class);
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+        // Services always create fresh instances; container passed should be the child
+        self::assertSame($this->child, $instance->getContainer());
+        self::assertNotSame($instance, $this->child->getService(ServiceClass::class));
+    }
+
+    public function testGetServiceFromChild(): void
+    {
+        $this->child->bind(ServiceClass::class, ServiceClass::class);
+
+        $instance = $this->child->getService(ServiceClass::class);
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+        self::assertFalse($this->parent->isService(ServiceClass::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // getCallable — parent fallback
+    // -----------------------------------------------------------------------
+
+    public function testGetCallableFromParent(): void
+    {
+        $singleton = new SingletonClass();
+        $this->parent->setCallable(ServiceClass::class, static fn ($c) => $singleton);
+
+        $result = $this->child->getCallable(ServiceClass::class);
+
+        self::assertSame($singleton, $result);
+    }
+
+    // -----------------------------------------------------------------------
+    // getAliased — parent fallback
+    // -----------------------------------------------------------------------
+
+    public function testGetAliasedFromParent(): void
+    {
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('svcAlias', ServiceClass::class);
+
+        $instance = $this->child->getAliased('svcAlias');
+
+        self::assertInstanceOf(ServiceClass::class, $instance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Parent immutability — parent state must not change through child operations
+    // -----------------------------------------------------------------------
+
+    public function testParentStateUnchangedAfterChildOperations(): void
+    {
+        // Set up parent with each registration type
+        $this->parent->bind(ServiceClass::class, ServiceClass::class);
+        $this->parent->bindAlias('svcAlias', ServiceClass::class);
+        $this->parent->bindSingleton(SingletonClass::class, SingletonClass::class);
+        $this->parent->setCallable(self::class, static fn ($c) => new self('test'));
+        $this->parent->register(ServiceProvider::class);
+
+        // Snapshot parent state before any child interaction
+        $dataBefore                  = $this->parent->getData();
+        $singletonInstanceBefore     = $this->parent->isSingletonInstance(SingletonClass::class);
+        $dispatcherPublishedBefore   = $this->parent->isPublished(DispatcherContract::class);
+
+        // Perform a broad set of child operations
+        $this->child->get(ServiceClass::class);
+        $this->child->getService(ServiceClass::class);
+        $this->child->getCallable(self::class);
+        $this->child->getAliased('svcAlias');
+        $this->child->getSingleton(SingletonClass::class);
+        $this->child->get(DispatcherContract::class); // triggers deferred publish in child
+
+        // Parent data maps must be identical
+        $dataAfter = $this->parent->getData();
+        self::assertSame($dataBefore->aliases, $dataAfter->aliases);
+        self::assertSame($dataBefore->services, $dataAfter->services);
+        self::assertSame($dataBefore->singletons, $dataAfter->singletons);
+        self::assertSame($dataBefore->deferred, $dataAfter->deferred);
+        self::assertSame($dataBefore->providers, $dataAfter->providers);
+
+        // Singleton resolved in child must not have been cached in parent
+        self::assertSame($singletonInstanceBefore, $this->parent->isSingletonInstance(SingletonClass::class));
+
+        // Deferred service published in child must not mark parent as published
+        self::assertSame($dispatcherPublishedBefore, $this->parent->isPublished(DispatcherContract::class));
+    }
+
+    // -----------------------------------------------------------------------
+    // Deferred provider — published in child context
+    // -----------------------------------------------------------------------
+
+    public function testDeferredFromChildPublishedInChild(): void
+    {
+        $this->child->register(ServiceProvider::class);
+
+        self::assertTrue($this->child->has(DispatcherContract::class));
+
+        $dispatcher = $this->child->get(DispatcherContract::class);
+        self::assertInstanceOf(DispatcherContract::class, $dispatcher);
+
+        self::assertFalse($this->parent->isPublished(DispatcherContract::class));
+    }
+
+    public function testDeferredFromParentPublishedInChild(): void
+    {
+        $this->parent->register(ServiceProvider::class);
+
+        // has() should see the deferred service from parent
+        self::assertTrue($this->child->has(DispatcherContract::class));
+
+        // get() should trigger publish in child and return the service
+        $dispatcher = $this->child->get(DispatcherContract::class);
+        self::assertInstanceOf(DispatcherContract::class, $dispatcher);
+
+        // Publishing in child must not pollute parent
+        self::assertFalse($this->parent->isPublished(DispatcherContract::class));
+    }
+}


### PR DESCRIPTION
# Description

Add persistent worker HTTP support

Introduces first-class support for long-running PHP worker runtimes (FrankenPHP, OpenSwoole, RoadRunner) through a parent/child isolation pattern that prevents request-scoped state from bleeding    
  between requests.

What changed

New: WorkerHttp abstract entry class (Application/Entry/Abstract/WorkerHttp)

The base class for all worker runtime integrations. Provides two static methods:                                                                                                                    
                                                                                                                                                                                                        
  - bootstrap(HttpConfig) — runs the full application bootstrap once at process start, then calls bootstrapParentServices() to force-resolve any services that should live in the frozen parent. Returns
   the parent application, which must not be written to again.                                                                                                                                          
  - handle(ApplicationContract, ContainerData, ServerRequestContract) — creates an isolated child container and child application per request, dispatches through the standard seven-stage HTTP
  pipeline, then discards the child. The parent is never mutated.

Concrete runtime integrations extend this class and supply the request loop. They are shipped as separate packages (valkyrja/frankenphp, valkyrja/openswoole, valkyrja/roadrunner).

New: ChildContainer — the default per-request container. Delegates to the parent via ContainerContract (portable, works with any implementation). Takes a ContainerData snapshot on construction; PHP
  copy-on-write means each child gets its own logical copy of the parent's maps at zero cost until it writes.

New: NativeChildContainer — a PHP-specific alternative that accesses the parent's protected fields directly instead of calling methods, eliminating any risk of accidentally triggering deferred      
  publishing or writing to parent state. Requires a concrete Container parent. Use only when profiling confirms a bottleneck at high child construction rates.

Both containers share the same invariant: neither triggers deferred resolution in the parent. A child reuses a parent singleton only if it is already a resolved instance. Services that are still in 
  the deferred map must be force-resolved in bootstrapParentServices() before the request loop begins.

New: ChildApplication — a thin per-request wrapper that owns the child container and delegates every other method (getEnvironment(), getVersion(), getProviders(), etc.) to the parent application. No
   re-bootstrapping occurs.

New: ContainerData — a readonly value object holding the two maps needed to seed a child (singletons, deferredCallback). Captured once outside the request loop and passed to every child.            


Documentation                                                                                                                                                                                         
                                                                                                                                                                                                        
  - Application/README.md — new "Persistent Worker Lifecycle" section covering the two-phase model, bootstrapParentServices(), ContainerData, ChildApplication delegation semantics, child container
  variants, and a lifecycle flowchart.                                                                                                                                                                  
  - Container/README.md — new "Child Containers" section covering the parent/child invariant, ContainerData, singleton resolution strategy (child instance → parent instance → child class binding),
  isPublished child/parent check, both implementations, and a usage example.                                                                                                                            
  - LIFECYCLE.md — updated Entry Points to cover the worker runtime option; new "Worker Mode" section with two-phase model ASCII tree and full mermaid flowchart.
  - Class-level docblocks removed from ChildContainer, NativeChildContainer, and ChildApplication — the content lives in the READMEs where it is more discoverable and maintainable.

Tests                                   
                                                                                                                                                                                                        
  - ChildApplicationTest — delegation, container isolation, multiple independent children, publishProviderCallbacks passes parent (not child) to callbacks.                                             
  - WorkerHttpTest — bootstrap called once, children created per request, each child is distinct, child singletons do not leak to parent or sibling children, run() drives the correct number of handler
   invocations.                                                                                                                                                                                         
  - ChildContainerTest — feature parity with NativeChildContainer via ContainerContract-only delegation, including parent immutability across all operation types and deferred provider publishing      
  staying in child scope.                     
  - NativeChildContainerTest — same coverage via direct field access path.  

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [X] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [ ] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->