### PR TITLE
[Event] Update event to use listener handler and remove dispatch

### DIFF
--- a/src/Valkyrja/Dispatch/README.md
+++ b/src/Valkyrja/Dispatch/README.md
@@ -127,48 +127,41 @@ $dispatch->getVariable(): string;
 $dispatch->withVariable(string $variable): static;
 ```
 
-## How It Connects to Events, CLI, and HTTP
+## How It Connects to CLI and HTTP
 
-The same Dispatcher underpins all three runtime contexts:
+The same Dispatcher underpins both runtime contexts:
 
-- **Events** — When an event is fired, the Dispatcher invokes each registered
-  listener's dispatch, passing the event object as the argument.
 - **CLI** — When a command is matched, the Dispatcher invokes the route's
   dispatch.
 - **HTTP** — When a route is matched, the Dispatcher invokes the route's
   dispatch.
 
-The pattern is identical in each context. Only the argument passed and the
-surrounding lifecycle differ.
+> **Note:** The event system no longer uses the Dispatcher. Event listeners are
+> invoked directly through their handler callables — see the
+> [Event README](../Event/README.md) for details.
 
 ## Return Values
 
-The Dispatcher returns whatever the invoked dispatch returns. In the context of
-events, return values can be collected by the event if it implements
-`DispatchCollectableContract`. In CLI and HTTP contexts, the return value
-becomes the response or output that the respective router passes back to the
-handler, and subsequent stepped middleware.
+The Dispatcher returns whatever the invoked dispatch returns. In CLI and HTTP
+contexts, the return value becomes the response or output that the respective
+router passes back to the handler, and subsequent stepped middleware.
 
 ## Why This Design
 
 Describing calls as data objects rather than executing them directly enables the
 framework's caching system. When the data cache is generated, the full set of
-dispatch descriptions — for every event listener, every command, every route —
-is captured in a generated PHP class. On subsequent requests, the framework
-loads that class directly and the Dispatcher can invoke any handler without any
-registration overhead.
-
-> Note: Handlers may be added in the future for direct callables to be used
-> instead, but this feature is currently not supported and so dispatches becomes
-> the way to handle a listener call or route call at this time.
+dispatch descriptions — for every command and every route — is captured in a
+generated PHP class. On subsequent requests, the framework loads that class
+directly and the Dispatcher can invoke any handler without any registration
+overhead.
 
 This is a significant part of why Valkyrja is fast. The Dispatcher does very
 little work per request when the cache is warm — it simply receives a dispatch
 description and executes it.
 
-> Note: Handlers in the future would be even faster, but may not allow for data
-> caching if closures are used instead of direct callables in the form of arrays
-> like the service provider `publishers` method for example.
+> **Note:** Array callables (e.g. `[ClassName::class, 'method']`) can be written
+> to the generated cache file. Closures cannot. Prefer array callables anywhere
+> the dispatch description may be cached.
 
 ## Service Registration
 

--- a/src/Valkyrja/Event/Attribute/Listener.php
+++ b/src/Valkyrja/Event/Attribute/Listener.php
@@ -16,10 +16,28 @@ namespace Valkyrja\Event\Attribute;
 use Attribute;
 use Valkyrja\Attribute\Contract\ReflectionAwareAttributeContract;
 use Valkyrja\Attribute\Trait\ReflectionAwareAttribute;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Data\Listener as Model;
 
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class Listener extends Model implements ReflectionAwareAttributeContract
 {
     use ReflectionAwareAttribute;
+
+    /**
+     * @param class-string                                                   $eventId The event class name
+     * @param non-empty-string                                               $name    A unique name for this listener
+     * @param (callable(ContainerContract, array<string, mixed>):mixed)|null $handler The handler
+     */
+    public function __construct(
+        protected string $eventId,
+        protected string $name,
+        callable|null $handler = null,
+    ) {
+        parent::__construct(
+            eventId: $eventId,
+            name: $name,
+            handler: $handler ?? static fn (ContainerContract $container, array $arguments): null => null,
+        );
+    }
 }

--- a/src/Valkyrja/Event/Attribute/ListenerHandler.php
+++ b/src/Valkyrja/Event/Attribute/ListenerHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Event\Attribute;
+
+use Attribute;
+use Valkyrja\Attribute\Contract\ReflectionAwareAttributeContract;
+use Valkyrja\Attribute\Trait\ReflectionAwareAttribute;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
+class ListenerHandler implements ReflectionAwareAttributeContract
+{
+    use ReflectionAwareAttribute;
+
+    /** @var callable(ContainerContract, array<string, mixed>):mixed */
+    public $handler;
+
+    /**
+     * @param callable(ContainerContract, array<string, mixed>):mixed $handler The handler
+     */
+    public function __construct(
+        callable $handler,
+    ) {
+        $this->handler = $handler;
+    }
+}

--- a/src/Valkyrja/Event/Collector/AttributeCollector.php
+++ b/src/Valkyrja/Event/Collector/AttributeCollector.php
@@ -14,30 +14,23 @@ declare(strict_types=1);
 namespace Valkyrja\Event\Collector;
 
 use Override;
-use ReflectionException;
 use ReflectionMethod;
 use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollectorContract;
-use Valkyrja\Dispatch\Data\ClassDispatch;
-use Valkyrja\Dispatch\Data\Contract\MethodDispatchContract;
-use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Event\Attribute\Listener as Attribute;
+use Valkyrja\Event\Attribute\ListenerHandler;
 use Valkyrja\Event\Collector\Contract\CollectorContract;
 use Valkyrja\Event\Data\Contract\ListenerContract;
 use Valkyrja\Event\Data\Listener;
-use Valkyrja\Reflection\Reflector\Contract\ReflectorContract;
 
 class AttributeCollector implements CollectorContract
 {
     public function __construct(
         protected AttributeCollectorContract $attributes,
-        protected ReflectorContract $reflection,
     ) {
     }
 
     /**
      * @inheritDoc
-     *
-     * @throws ReflectionException
      */
     #[Override]
     public function getListeners(string ...$classes): array
@@ -53,15 +46,13 @@ class AttributeCollector implements CollectorContract
             foreach ($attributes as $attribute) {
                 $reflection = $attribute->getReflection();
                 $method     = null;
-                $isStatic   = false;
 
                 if ($reflection instanceof ReflectionMethod) {
                     $method   = $reflection->getName();
-                    $isStatic = $reflection->isStatic();
                 }
 
                 $listener = $this->getListenerFromAttribute($attribute);
-                $listener = $this->updateDispatch($listener, $class, $method, $isStatic);
+                $listener = $this->updateHandler($listener, $class, $method);
 
                 $listeners[] = $this->setListenerProperties($listener);
             }
@@ -71,56 +62,51 @@ class AttributeCollector implements CollectorContract
     }
 
     /**
+     * Update the handler for a listener.
+     *
      * @param class-string          $class  The class name
      * @param non-empty-string|null $method The method name
      */
-    protected function updateDispatch(ListenerContract $listener, string $class, string|null $method = null, bool $isStatic = false): ListenerContract
+    protected function updateHandler(ListenerContract $listener, string $class, string|null $method = null): ListenerContract
     {
         if ($method === null) {
-            $dispatch = new ClassDispatch($class);
+            /** @var ListenerHandler[] $classHandlers */
+            $classHandlers = $this->attributes->forClass($class, ListenerHandler::class);
+            $classHandler  = $classHandlers[0] ?? null;
+
+            $handler = $classHandler->handler ?? null;
         } else {
-            $dispatch = new MethodDispatch($class, $method, isStatic: $isStatic);
+            /** @var ListenerHandler[] $routeHandlers */
+            $routeHandlers = $this->attributes->forMethod($class, $method, ListenerHandler::class);
+            $routeHandler  = $routeHandlers[0] ?? null;
+
+            $handler = $routeHandler->handler ?? null;
         }
 
-        return $listener->withDispatch($dispatch);
+        if ($handler === null) {
+            return $listener;
+        }
+
+        return $listener->withHandler($handler);
     }
 
     /**
      * Set the properties for a listener attribute.
-     *
-     * @throws ReflectionException
      */
     protected function setListenerProperties(ListenerContract $listener): ListenerContract
     {
-        $dispatch     = $listener->getDispatch();
-        $dependencies = [];
-
-        if ($dispatch instanceof MethodDispatchContract) {
-            $methodReflection = $this->reflection->forClassMethod($dispatch->getClass(), $dispatch->getMethod());
-
-            $dependencies = $this->reflection->getDependencies($methodReflection);
-        } elseif (method_exists($dispatch->getClass(), '__construct')) {
-            $methodReflection = $this->reflection->forClassMethod($dispatch->getClass(), '__construct');
-
-            $dependencies = $this->reflection->getDependencies($methodReflection);
-        }
-
-        return $listener->withDispatch(
-            $dispatch->withDependencies($dependencies)
-        );
+        return $listener;
     }
 
     /**
      * Get a listener from an attribute.
-     *
-     * @param ListenerContract $attribute The attribute
      */
     protected function getListenerFromAttribute(ListenerContract $attribute): ListenerContract
     {
         return new Listener(
             eventId: $attribute->getEventId(),
             name: $attribute->getName(),
-            dispatch: $attribute->getDispatch()
+            handler: $attribute->getHandler()
         );
     }
 }

--- a/src/Valkyrja/Event/Data/Contract/ListenerContract.php
+++ b/src/Valkyrja/Event/Data/Contract/ListenerContract.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Event\Data\Contract;
 
-use Valkyrja\Dispatch\Data\Contract\ClassDispatchContract;
-use Valkyrja\Dispatch\Data\Contract\MethodDispatchContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 
 interface ListenerContract
 {
@@ -47,14 +46,16 @@ interface ListenerContract
     public function withName(string $name): static;
 
     /**
-     * Get the dispatch.
+     * Get the handler.
+     *
+     * @return callable(ContainerContract, array<string, mixed>):mixed
      */
-    public function getDispatch(): ClassDispatchContract|MethodDispatchContract;
+    public function getHandler(): callable;
 
     /**
-     * Create new listener with the specified dispatch.
+     * Create new listener with the specified handler.
      *
-     * @param ClassDispatchContract|MethodDispatchContract $dispatch The dispatch
+     * @param callable(ContainerContract, array<string, mixed>):mixed $handler The handler
      */
-    public function withDispatch(ClassDispatchContract|MethodDispatchContract $dispatch): static;
+    public function withHandler(callable $handler): static;
 }

--- a/src/Valkyrja/Event/Data/Listener.php
+++ b/src/Valkyrja/Event/Data/Listener.php
@@ -14,22 +14,25 @@ declare(strict_types=1);
 namespace Valkyrja\Event\Data;
 
 use Override;
-use Valkyrja\Dispatch\Data\ClassDispatch;
-use Valkyrja\Dispatch\Data\Contract\ClassDispatchContract;
-use Valkyrja\Dispatch\Data\Contract\MethodDispatchContract;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Data\Contract\ListenerContract;
 
 class Listener implements ListenerContract
 {
+    /** @var callable(ContainerContract, array<string, mixed>):mixed */
+    protected $handler;
+
     /**
-     * @param class-string     $eventId The event class name
-     * @param non-empty-string $name    A unique name for this listener
+     * @param class-string                                            $eventId The event class name
+     * @param non-empty-string                                        $name    A unique name for this listener
+     * @param callable(ContainerContract, array<string, mixed>):mixed $handler The handler
      */
     public function __construct(
         protected string $eventId,
         protected string $name,
-        protected ClassDispatchContract|MethodDispatchContract $dispatch = new ClassDispatch(self::class),
+        callable $handler,
     ) {
+        $this->handler = $handler;
     }
 
     /**
@@ -80,20 +83,20 @@ class Listener implements ListenerContract
      * @inheritDoc
      */
     #[Override]
-    public function getDispatch(): ClassDispatchContract|MethodDispatchContract
+    public function getHandler(): callable
     {
-        return $this->dispatch;
+        return $this->handler;
     }
 
     /**
      * @inheritDoc
      */
     #[Override]
-    public function withDispatch(ClassDispatchContract|MethodDispatchContract $dispatch): static
+    public function withHandler(callable $handler): static
     {
         $new = clone $this;
 
-        $new->dispatch = $dispatch;
+        $new->handler = $handler;
 
         return $new;
     }

--- a/src/Valkyrja/Event/Dispatcher/EventDispatcher.php
+++ b/src/Valkyrja/Event/Dispatcher/EventDispatcher.php
@@ -16,8 +16,8 @@ namespace Valkyrja\Event\Dispatcher;
 use Override;
 use Psr\EventDispatcher\StoppableEventInterface;
 use stdClass;
-use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
-use Valkyrja\Dispatch\Dispatcher\Dispatcher;
+use Valkyrja\Container\Manager\Container;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Collection\Collection;
 use Valkyrja\Event\Collection\Contract\CollectionContract;
 use Valkyrja\Event\Contract\ArgumentsCapableEventContract;
@@ -29,7 +29,7 @@ class EventDispatcher implements EventDispatcherContract
 {
     public function __construct(
         protected CollectionContract $collection = new Collection(),
-        protected DispatcherContract $dispatcher = new Dispatcher(),
+        protected ContainerContract $container = new Container(),
     ) {
     }
 
@@ -108,9 +108,10 @@ class EventDispatcher implements EventDispatcherContract
     #[Override]
     public function dispatchListener(object $event, ListenerContract $listener): object
     {
+        $handler = $listener->getHandler();
         // Dispatch the listener with the event
         /** @var scalar|object|array<array-key, mixed>|resource|null $dispatch */
-        $dispatch = $this->dispatcher->dispatch($listener->getDispatch(), ['event' => $event]);
+        $dispatch = $handler($this->container, ['event' => $event]);
 
         // If the event is a dispatch collectable event
         if ($event instanceof DispatchCollectableEventContract) {

--- a/src/Valkyrja/Event/Provider/EventServiceProvider.php
+++ b/src/Valkyrja/Event/Provider/EventServiceProvider.php
@@ -22,7 +22,6 @@ use Valkyrja\Attribute\Collector\Contract\CollectorContract as AttributeCollecto
 use Valkyrja\Attribute\Provider\AttributeServiceProvider;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
-use Valkyrja\Dispatch\Dispatcher\Contract\DispatcherContract;
 use Valkyrja\Event\Collection\Collection;
 use Valkyrja\Event\Collection\Contract\CollectionContract;
 use Valkyrja\Event\Collector\AttributeCollector;
@@ -69,8 +68,7 @@ class EventServiceProvider implements ServiceProviderContract
         $container->setSingleton(
             CollectorContract::class,
             new AttributeCollector(
-                $container->getSingleton(AttributeCollectorContract::class),
-                $container->getSingleton(ReflectorContract::class)
+                $container->getSingleton(AttributeCollectorContract::class)
             )
         );
     }
@@ -84,7 +82,7 @@ class EventServiceProvider implements ServiceProviderContract
             EventDispatcherContract::class,
             new EventDispatcher(
                 $container->getSingleton(CollectionContract::class),
-                $container->getSingleton(DispatcherContract::class),
+                $container,
             )
         );
     }

--- a/src/Valkyrja/Event/README.md
+++ b/src/Valkyrja/Event/README.md
@@ -19,13 +19,14 @@ An **event** is a plain PHP class that represents something that has occurred in
 your application. It carries whatever data is relevant to that occurrence.
 Events are plain objects — there is no required base class.
 
-A **listener** is a class or method that responds to a specific event when it is
-dispatched. Listeners receive the event object and perform whatever action is
+A **listener** is a callable — a handler — that responds to a specific event
+when it is dispatched. The handler receives the container and an arguments array
+(with the event under the `event` key) and performs whatever action is
 appropriate.
 
 The **event dispatcher** —
-`Valkyrja\Event\Dispatcher\Contract\DispatcherContract` — is the service that
-connects events to their listeners and invokes each listener when an event is
+`Valkyrja\Event\Dispatcher\Contract\EventDispatcherContract` — is the service that
+connects events to their listeners and invokes each handler when an event is
 fired.
 
 ## Dispatching Events
@@ -34,8 +35,8 @@ The dispatcher provides six methods, giving you precise control over dispatch
 behaviour.
 
 **`dispatch(object $event): object`** — The standard PSR-14 method. Pass a
-constructed event object; the dispatcher invokes all registered listeners in
-order and returns the event.
+constructed event object; the dispatcher invokes all registered listener handlers
+in order and returns the event.
 
 ```php
 $dispatcher->dispatch(new UserRegistered($user));
@@ -75,7 +76,47 @@ $dispatcher->dispatchListeners($event, $listenerOne, $listenerTwo);
 ```
 
 **`dispatchListener(object $event, ListenerContract $listener): object`** —
-Invoke a single listener against an event.
+Invoke a single listener's handler against an event. The handler is called as:
+
+```php
+$handler($container, ['event' => $event]);
+```
+
+## Listener Handlers
+
+A listener's **handler** is a callable with the signature:
+
+```php
+callable(ContainerContract $container, array<string, mixed> $arguments): mixed
+```
+
+The `$arguments` array always contains the dispatched event under the `event`
+key. The container is passed so handlers can resolve dependencies without
+requiring them to be pre-constructed. The return value of the handler is
+collected if the event implements `DispatchCollectableEventContract`.
+
+### Caching Trade-off
+
+How you express the handler affects whether it can participate in Valkyrja's
+data file cache. The cache captures the full set of listener registrations in a
+generated PHP class so that subsequent boots pay no registration overhead.
+
+**Array callables can be cached.** A handler expressed as
+`[ClassName::class, 'method']` is a plain array — serialisable, writable to a
+file, and loadable without any loss of fidelity:
+
+```php
+handler: [NotificationService::class, 'onUserRegistered'],
+```
+
+**Closures cannot be cached.** A handler expressed as a `static fn (...)` is an
+anonymous function — it cannot be serialised or written to a generated file. Use
+closures during development or when an inline definition is clearer, but prefer
+array callables in production code that will be cached.
+
+The trade-off is explicit by design. Closures are less to type and easier to
+read inline, but array callables keep the listener set cacheable and keep the
+handler target inspectable without loading it.
 
 ## Passing Arguments to Events
 
@@ -127,7 +168,7 @@ public function addDispatch(mixed $dispatch): void;
 public function getDispatches(): array;
 ```
 
-When the dispatcher invokes a listener that returns a value, it calls
+When the dispatcher invokes a listener whose handler returns a value, it calls
 `addDispatch()` on the event with that return value. After all listeners have
 been invoked, `getDispatches()` returns the full collection in invocation order:
 
@@ -158,10 +199,9 @@ will not invoke subsequent listeners.
 
 ## Registering Listeners
 
-Listeners are registered through **event providers**. An event provider extends
-`Valkyrja\Event\Provider\Abstract\Provider` or implements
-`Valkyrja\Event\Provider\Contract\ProviderContract`. It defines two static
-methods:
+Listeners are registered through **event providers**. An event provider
+implements `Valkyrja\Event\Provider\Contract\ListenerProviderContract`. It
+defines two static methods:
 
 **`getListenerClasses(): array`** — Returns class names to scan for
 `#[Listener]` attributes.
@@ -171,8 +211,8 @@ manual registration.
 
 Event providers are wired into the application through component providers (see
 below). Listeners are deferred — they are registered into the event collection
-during component loading, but their dispatch targets are not resolved until the
-event is actually fired.
+during component loading, but their handlers are not invoked until the event is
+actually fired.
 
 ### Attribute-Based Registration
 
@@ -180,9 +220,9 @@ The recommended approach for most listeners. Add your listener class names to
 `getListenerClasses()` in your event provider:
 
 ```php
-use Valkyrja\Event\Provider\Abstract\Provider;
+use Valkyrja\Event\Provider\Contract\ListenerProviderContract;
 
-class AppEventProvider extends Provider
+class AppEventProvider implements ListenerProviderContract
 {
     public static function getListenerClasses(): array
     {
@@ -191,6 +231,11 @@ class AppEventProvider extends Provider
             NotificationService::class,
         ];
     }
+
+    public static function getListeners(): array
+    {
+        return [];
+    }
 }
 ```
 
@@ -198,14 +243,22 @@ The framework inspects each class for `#[Valkyrja\Event\Attribute\Listener]`
 attributes. The attribute is repeatable, so a single class or method can listen
 to multiple events.
 
-**Class-level attribute** — The framework creates a `ClassDispatch` for the
-listener, resolving and invoking the entire class when the event fires. The
-class should be invokable:
+The `#[Listener]` attribute takes two required parameters — the event class name
+and a unique listener name — plus an optional `handler` callable. When no
+handler is provided on the attribute itself, the framework expects a companion
+`#[ListenerHandler]` attribute to supply the callable.
+
+**Class-level attribute** — Place `#[Listener]` on the class and
+`#[ListenerHandler]` with the handler callable. The handler receives the
+container and the `['event' => $event]` arguments array:
 
 ```php
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Attribute\Listener;
+use Valkyrja\Event\Attribute\ListenerHandler;
 
-#[Listener(UserRegistered::class)]
+#[Listener(UserRegistered::class, 'send_welcome_email')]
+#[ListenerHandler(static fn (ContainerContract $c, array $args) => $c->get(SendWelcomeEmail::class)($args['event']))]
 class SendWelcomeEmail
 {
     public function __invoke(UserRegistered $event): void
@@ -215,16 +268,19 @@ class SendWelcomeEmail
 }
 ```
 
-**Method-level attribute** — The framework creates a `MethodClassDispatch` for
-that method, resolving the class from the container and calling the attributed
-method when the event fires. The method name can be anything:
+**Method-level attribute** — Place `#[Listener]` and `#[ListenerHandler]` on
+the specific method. The handler callable typically resolves the class from the
+container and calls the method:
 
 ```php
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Attribute\Listener;
+use Valkyrja\Event\Attribute\ListenerHandler;
 
 class NotificationService
 {
-    #[Listener(UserRegistered::class)]
+    #[Listener(UserRegistered::class, 'notification_service.on_user_registered')]
+    #[ListenerHandler(static fn (ContainerContract $c, array $args) => $c->get(NotificationService::class)->onUserRegistered($args['event']))]
     public function onUserRegistered(UserRegistered $event): void
     {
         // send notification
@@ -232,34 +288,47 @@ class NotificationService
 }
 ```
 
-When using class-level dispatch with a class registered as a singleton in the
-container, the same instance is reused across multiple event firings. Design
-accordingly if the listener handles state.
+Alternatively, the handler callable can be provided directly on the `#[Listener]`
+attribute instead of using `#[ListenerHandler]`:
+
+```php
+#[Listener(
+    eventId: UserRegistered::class,
+    name:    'notification_service.on_user_registered',
+    handler: static fn (ContainerContract $c, array $args) => $c->get(NotificationService::class)->onUserRegistered($args['event']),
+)]
+public function onUserRegistered(UserRegistered $event): void
+{
+    // send notification
+}
+```
 
 ### Manual Registration
 
 For cases where attribute-based registration is not suitable, return pre-built
 listener instances from `getListeners()`. Each instance is a
 `Valkyrja\Event\Data\Listener` (or any class implementing `ListenerContract`),
-constructed with an event ID, a unique name, and a dispatch:
+constructed with an event ID, a unique name, and a handler callable:
 
 ```php
-use Valkyrja\Dispatch\Data\MethodClassDispatch;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Data\Listener;
-use Valkyrja\Event\Provider\Abstract\Provider;
+use Valkyrja\Event\Provider\Contract\ListenerProviderContract;
 
-class AppEventProvider extends Provider
+class AppEventProvider implements ListenerProviderContract
 {
+    public static function getListenerClasses(): array
+    {
+        return [];
+    }
+
     public static function getListeners(): array
     {
         return [
             new Listener(
-                eventId:  UserRegistered::class,
-                name:     'notification_service.on_user_registered',
-                dispatch: new MethodClassDispatch(
-                    class:  NotificationService::class,
-                    method: 'onUserRegistered',
-                ),
+                eventId: UserRegistered::class,
+                name:    'notification_service.on_user_registered',
+                handler: static fn (ContainerContract $c, array $args) => $c->get(NotificationService::class)->onUserRegistered($args['event']),
             ),
         ];
     }
@@ -273,9 +342,9 @@ provider's `getEventProviders()` method:
 
 ```php
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-use Valkyrja\Application\Provider\Abstract\Provider;
+use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
 
-class AppComponentProvider extends Provider
+class AppComponentProvider implements ComponentProviderContract
 {
     public static function getEventProviders(ApplicationContract $app): array
     {
@@ -289,12 +358,15 @@ class AppComponentProvider extends Provider
 ## A Complete Example
 
 ```php
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Attribute\Listener;
+use Valkyrja\Event\Attribute\ListenerHandler;
 use Valkyrja\Event\Contract\ArgumentsCapableEventContract;
 use Valkyrja\Event\Contract\DispatchCollectableEventContract;
-use Valkyrja\Event\Provider\Abstract\Provider;
+use Valkyrja\Event\Data\Listener as ListenerData;
+use Valkyrja\Event\Provider\Contract\ListenerProviderContract;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
-use Valkyrja\Application\Provider\Abstract\Provider as ComponentProvider;
+use Valkyrja\Application\Provider\Contract\ComponentProviderContract;
 
 // 1. The event
 class UserRegistered implements ArgumentsCapableEventContract, DispatchCollectableEventContract
@@ -327,7 +399,8 @@ class UserRegistered implements ArgumentsCapableEventContract, DispatchCollectab
 // 2. A listener using a method-level attribute
 class NotificationService
 {
-    #[Listener(UserRegistered::class)]
+    #[Listener(UserRegistered::class, 'notification_service.on_user_registered')]
+    #[ListenerHandler(static fn (ContainerContract $c, array $args) => $c->get(NotificationService::class)->onUserRegistered($args['event']))]
     public function onUserRegistered(UserRegistered $event): string
     {
         // send notification
@@ -336,16 +409,21 @@ class NotificationService
 }
 
 // 3. The event provider
-class AppEventProvider extends Provider
+class AppEventProvider implements ListenerProviderContract
 {
     public static function getListenerClasses(): array
     {
         return [NotificationService::class];
     }
+
+    public static function getListeners(): array
+    {
+        return [];
+    }
 }
 
 // 4. The component provider
-class AppComponentProvider extends ComponentProvider
+class AppComponentProvider implements ComponentProviderContract
 {
     public static function getEventProviders(ApplicationContract $app): array
     {
@@ -354,6 +432,6 @@ class AppComponentProvider extends ComponentProvider
 }
 
 // 5. Dispatching the event
-$event = $dispatcher->dispatchById(UserRegistered::class, [$user]);
+$event   = $dispatcher->dispatchById(UserRegistered::class, [$user]);
 $results = $event->getDispatches(); // ['notification_sent']
 ```

--- a/tests/Tests/Classes/Event/Attribute/AttributedClass.php
+++ b/tests/Tests/Classes/Event/Attribute/AttributedClass.php
@@ -38,8 +38,13 @@ final class AttributedClass
         return 'Handler';
     }
 
-    #[Listener(AttributesCollectorTest::VALUE1, 'AttributedClass->methodValue1')]
-    #[Listener(AttributesCollectorTest::VALUE2, 'AttributedClass->methodValue2')]
+    public static function handler2(): string
+    {
+        return 'Handler2';
+    }
+
+    #[Listener(AttributesCollectorTest::VALUE1, 'AttributedClass->methodValue1', [self::class, 'handler2'])]
+    #[Listener(AttributesCollectorTest::VALUE2, 'AttributedClass->methodValue2', [self::class, 'handler2'])]
     public function method(): string
     {
         return 'Method';

--- a/tests/Tests/Classes/Event/Attribute/AttributedClass.php
+++ b/tests/Tests/Classes/Event/Attribute/AttributedClass.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Classes\Event\Attribute;
 
 use Valkyrja\Event\Attribute\Listener;
+use Valkyrja\Event\Attribute\ListenerHandler;
 use Valkyrja\Tests\Unit\Event\Collector\AttributesCollectorTest;
 
 /**
@@ -26,9 +27,15 @@ final class AttributedClass
 {
     #[Listener(AttributesCollectorTest::VALUE1, 'AttributedClass::staticMethodValue1')]
     #[Listener(AttributesCollectorTest::VALUE2, 'AttributedClass::staticMethodValue2')]
+    #[ListenerHandler([self::class, 'handler'])]
     public static function staticMethod(): string
     {
         return 'Static Method';
+    }
+
+    public static function handler(): string
+    {
+        return 'Handler';
     }
 
     #[Listener(AttributesCollectorTest::VALUE1, 'AttributedClass->methodValue1')]

--- a/tests/Tests/Classes/Event/Provider/ListenerProviderClass.php
+++ b/tests/Tests/Classes/Event/Provider/ListenerProviderClass.php
@@ -29,7 +29,11 @@ final class ListenerProviderClass implements ListenerProviderContract
     public static function getListeners(): array
     {
         return [
-            new Listener(eventId: self::class, name: 'listener-from-provider-name'),
+            new Listener(
+                eventId: self::class,
+                name: 'listener-from-provider-name',
+                handler: static fn () => null
+            ),
         ];
     }
 }

--- a/tests/Tests/Unit/Event/Attribute/ListenerHandlerTest.php
+++ b/tests/Tests/Unit/Event/Attribute/ListenerHandlerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Event\Attribute;
+
+use Valkyrja\Event\Attribute\Listener;
+use Valkyrja\Event\Attribute\ListenerHandler;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+/**
+ * Test the listener handler attribute.
+ */
+final class ListenerHandlerTest extends TestCase
+{
+    public function testHandler(): void
+    {
+        $handler = static fn () => null;
+
+        $listenerHandler = new ListenerHandler($handler);
+
+        self::assertSame($handler, $listenerHandler->handler);
+    }
+}

--- a/tests/Tests/Unit/Event/Attribute/ListenerHandlerTest.php
+++ b/tests/Tests/Unit/Event/Attribute/ListenerHandlerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Event\Attribute;
 
-use Valkyrja\Event\Attribute\Listener;
 use Valkyrja\Event\Attribute\ListenerHandler;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 

--- a/tests/Tests/Unit/Event/Collection/CollectionTest.php
+++ b/tests/Tests/Unit/Event/Collection/CollectionTest.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Event\Collection;
 
-use Valkyrja\Dispatch\Data\ClassDispatch;
-use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Event\Collection\Collection;
 use Valkyrja\Event\Data\EventData;
 use Valkyrja\Event\Data\Listener;
@@ -40,7 +38,8 @@ final class CollectionTest extends TestCase
         $listenerName = 'listener';
         $listener     = new Listener(
             eventId: $eventId,
-            name: $listenerName
+            name: $listenerName,
+            handler: static fn () => null
         );
 
         $collection->addListener($listener);
@@ -65,12 +64,12 @@ final class CollectionTest extends TestCase
         $listener      = new Listener(
             eventId: $eventId,
             name: $listenerName,
-            dispatch: new ClassDispatch(self::class)
+            handler: static fn () => null
         );
         $listener2     = new Listener(
             eventId: $eventId,
             name: $listenerName2,
-            dispatch: new MethodDispatch(self::class, 'test')
+            handler: static fn () => null
         );
 
         $data = new EventData(
@@ -136,7 +135,8 @@ final class CollectionTest extends TestCase
         $listenerName = 'listener';
         $listener     = new Listener(
             eventId: $eventId,
-            name: $listenerName
+            name: $listenerName,
+            handler: static fn () => null
         );
 
         self::assertFalse($collection->hasListener($listener));

--- a/tests/Tests/Unit/Event/Collector/AttributesCollectorTest.php
+++ b/tests/Tests/Unit/Event/Collector/AttributesCollectorTest.php
@@ -13,13 +13,9 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Event\Collector;
 
-use ReflectionException;
 use Valkyrja\Attribute\Collector\Collector;
-use Valkyrja\Dispatch\Data\Contract\ClassDispatchContract;
-use Valkyrja\Dispatch\Data\Contract\MethodDispatchContract;
 use Valkyrja\Event\Collector\AttributeCollector;
 use Valkyrja\Event\Data\Contract\ListenerContract;
-use Valkyrja\Reflection\Reflector\Reflector;
 use Valkyrja\Tests\Classes\Event\Attribute\Attributed2Class;
 use Valkyrja\Tests\Classes\Event\Attribute\AttributedClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -54,14 +50,10 @@ final class AttributesCollectorTest extends TestCase
     protected function setUp(): void
     {
         $this->class = new AttributeCollector(
-            new Collector(),
-            new Reflector()
+            new Collector()
         );
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testGetListeners(): void
     {
         $attributes = $this->class->getListeners(AttributedClass::class);
@@ -72,39 +64,18 @@ final class AttributesCollectorTest extends TestCase
             self::assertInstanceOf(ListenerContract::class, $attribute);
         }
 
-        self::assertSame(AttributedClass::class, $attributes[0]->getDispatch()->getClass());
-        self::assertInstanceOf(ClassDispatchContract::class, $attributes[0]->getDispatch());
-        self::assertSame(AttributedClass::class, $attributes[1]->getDispatch()->getClass());
-        self::assertInstanceOf(ClassDispatchContract::class, $attributes[1]->getDispatch());
         self::assertSame(self::VALUE1, $attributes[0]->getEventId());
         self::assertSame(self::VALUE2, $attributes[1]->getEventId());
 
-        self::assertInstanceOf(MethodDispatchContract::class, $attributes[2]->getDispatch());
-        self::assertInstanceOf(MethodDispatchContract::class, $attributes[3]->getDispatch());
-        self::assertSame(AttributedClass::class, $attributes[2]->getDispatch()->getClass());
-        self::assertSame('staticMethod', $attributes[2]->getDispatch()->getMethod());
-        self::assertSame(AttributedClass::class, $attributes[3]->getDispatch()->getClass());
-        self::assertSame('staticMethod', $attributes[3]->getDispatch()->getMethod());
-        self::assertTrue($attributes[2]->getDispatch()->isStatic());
-        self::assertTrue($attributes[3]->getDispatch()->isStatic());
         self::assertSame(self::VALUE1, $attributes[2]->getEventId());
         self::assertSame(self::VALUE2, $attributes[3]->getEventId());
+        self::assertSame([AttributedClass::class, 'handler'], $attributes[2]->getHandler());
+        self::assertSame([AttributedClass::class, 'handler'], $attributes[3]->getHandler());
 
-        self::assertInstanceOf(MethodDispatchContract::class, $attributes[4]->getDispatch());
-        self::assertInstanceOf(MethodDispatchContract::class, $attributes[5]->getDispatch());
-        self::assertSame(AttributedClass::class, $attributes[4]->getDispatch()->getClass());
-        self::assertSame('method', $attributes[4]->getDispatch()->getMethod());
-        self::assertSame(AttributedClass::class, $attributes[5]->getDispatch()->getClass());
-        self::assertSame('method', $attributes[5]->getDispatch()->getMethod());
-        self::assertFalse($attributes[4]->getDispatch()->isStatic());
-        self::assertFalse($attributes[5]->getDispatch()->isStatic());
         self::assertSame(self::VALUE1, $attributes[4]->getEventId());
         self::assertSame(self::VALUE2, $attributes[5]->getEventId());
     }
 
-    /**
-     * @throws ReflectionException
-     */
     public function testGetListeners2(): void
     {
         $attributes = $this->class->getListeners(Attributed2Class::class);
@@ -116,10 +87,8 @@ final class AttributesCollectorTest extends TestCase
         }
 
         self::assertSame(self::VALUE1, $attributes[0]->getEventId());
-        self::assertInstanceOf(ClassDispatchContract::class, $attributes[0]->getDispatch());
 
         self::assertSame(self::VALUE2, $attributes[1]->getEventId());
-        self::assertInstanceOf(ClassDispatchContract::class, $attributes[1]->getDispatch());
 
         self::assertSame(self::VALUE1, $attributes[2]->getEventId());
         self::assertSame(self::VALUE2, $attributes[3]->getEventId());

--- a/tests/Tests/Unit/Event/Collector/AttributesCollectorTest.php
+++ b/tests/Tests/Unit/Event/Collector/AttributesCollectorTest.php
@@ -74,6 +74,8 @@ final class AttributesCollectorTest extends TestCase
 
         self::assertSame(self::VALUE1, $attributes[4]->getEventId());
         self::assertSame(self::VALUE2, $attributes[5]->getEventId());
+        self::assertSame([AttributedClass::class, 'handler2'], $attributes[4]->getHandler());
+        self::assertSame([AttributedClass::class, 'handler2'], $attributes[5]->getHandler());
     }
 
     public function testGetListeners2(): void

--- a/tests/Tests/Unit/Event/Data/ListenerTest.php
+++ b/tests/Tests/Unit/Event/Data/ListenerTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Event\Data;
 
-use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Event\Data\Listener;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
@@ -26,7 +25,7 @@ final class ListenerTest extends TestCase
     {
         $class    = self::class;
         $name     = 'test';
-        $listener = new Listener(eventId: $class, name: $name);
+        $listener = new Listener(eventId: $class, name: $name, handler: static fn () => null);
 
         self::assertSame($class, $listener->getEventId());
 
@@ -41,7 +40,7 @@ final class ListenerTest extends TestCase
     {
         $class    = self::class;
         $name     = 'test';
-        $listener = new Listener(eventId: $class, name: $name);
+        $listener = new Listener(eventId: $class, name: $name, handler: static fn () => null);
 
         self::assertSame($name, $listener->getName());
 
@@ -52,19 +51,20 @@ final class ListenerTest extends TestCase
         self::assertSame($name2, $listener2->getName());
     }
 
-    public function testDispatch(): void
+    public function testHandler(): void
     {
         $class    = self::class;
         $name     = 'test';
-        $dispatch = new MethodDispatch(self::class, 'test');
-        $listener = new Listener(eventId: $class, name: $name, dispatch: $dispatch);
+        $handler  = static fn () => null;
+        $listener = new Listener(eventId: $class, name: $name, handler: $handler);
 
         self::assertSame($name, $listener->getName());
+        self::assertSame($handler, $listener->getHandler());
 
-        $dispatch2 = new MethodDispatch(self::class, 'test2');
-        $listener2 = $listener->withDispatch($dispatch2);
+        $handler2  = static fn () => 'string';
+        $listener2 = $listener->withHandler($handler2);
 
         self::assertNotSame($listener, $listener2);
-        self::assertSame($dispatch2, $listener2->getDispatch());
+        self::assertSame($handler2, $listener2->getHandler());
     }
 }

--- a/tests/Tests/Unit/Event/Dispatcher/DispatcherTest.php
+++ b/tests/Tests/Unit/Event/Dispatcher/DispatcherTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Event\Dispatcher;
 
 use stdClass;
-use Valkyrja\Dispatch\Data\MethodDispatch;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Event\Collection\Collection;
 use Valkyrja\Event\Data\Listener;
 use Valkyrja\Event\Dispatcher\EventDispatcher;
@@ -53,7 +53,7 @@ final class DispatcherTest extends TestCase
         $listener     = new Listener(
             eventId: $eventId,
             name: $listenerName,
-            dispatch: MethodDispatch::fromCallableOrArray([self::class, 'dispatchCallback'])
+            handler: static fn (ContainerContract $container, array $arguments) => self::dispatchCallback($arguments['event'])
         );
 
         $collection = new Collection();
@@ -103,7 +103,7 @@ final class DispatcherTest extends TestCase
         $listener     = new Listener(
             eventId: $eventId,
             name: $listenerName,
-            dispatch: MethodDispatch::fromCallableOrArray([self::class, 'dispatchCallback'])
+            handler: static fn (ContainerContract $container, array $arguments) => self::dispatchCallback($arguments['event'])
         );
 
         $collection = new Collection();
@@ -144,7 +144,7 @@ final class DispatcherTest extends TestCase
         $listener     = new Listener(
             eventId: $eventId,
             name: $listenerName,
-            dispatch: MethodDispatch::fromCallableOrArray([self::class, 'dispatchCallback'])
+            handler: static fn (ContainerContract $container, array $arguments) => self::dispatchCallback($arguments['event'])
         );
 
         $collection = new Collection();

--- a/tests/Tests/Unit/Event/Generator/DataFileGeneratorTest.php
+++ b/tests/Tests/Unit/Event/Generator/DataFileGeneratorTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Event\Generator;
 
 use Valkyrja\Application\Directory\Directory;
-use Valkyrja\Dispatch\Data\MethodDispatch;
 use Valkyrja\Event\Data\EventData;
 use Valkyrja\Event\Data\Listener;
 use Valkyrja\Event\Generator\DataFileGenerator;
@@ -126,7 +125,7 @@ final class DataFileGeneratorTest extends TestCase
                 'name' => new Listener(
                     eventId: 'eventId',
                     name: 'name',
-                    dispatch: new MethodDispatch('class', 'method')
+                    handler: static fn () => null
                 ),
             ]
         );
@@ -149,20 +148,11 @@ final class DataFileGeneratorTest extends TestCase
             ),
             listeners: [
                 'name' => static fn (): \Valkyrja\Event\Data\Contract\ListenerContract => new \Valkyrja\Event\Data\Listener(...array(
+               'handler' => 
+              new \Closure(...array(
+              )),
                'eventId' => 'eventId',
                'name' => 'name',
-               'dispatch' => 
-              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
-                 'class' => 'class',
-                 'arguments' => 
-                array (
-                ),
-                 'dependencies' => 
-                array (
-                ),
-                 'method' => 'method',
-                 'isStatic' => false,
-              )),
             )),
             
             ],
@@ -181,7 +171,7 @@ final class DataFileGeneratorTest extends TestCase
                 'name' => static fn (): Listener => new Listener(
                     eventId: 'eventId',
                     name: 'name',
-                    dispatch: new MethodDispatch('class', 'method')
+                    handler: static fn () => null
                 ),
             ]
         );
@@ -204,20 +194,11 @@ final class DataFileGeneratorTest extends TestCase
             ),
             listeners: [
                 'name' => static fn (): \Valkyrja\Event\Data\Contract\ListenerContract => new \Valkyrja\Event\Data\Listener(...array(
+               'handler' => 
+              new \Closure(...array(
+              )),
                'eventId' => 'eventId',
                'name' => 'name',
-               'dispatch' => 
-              new \Valkyrja\Dispatch\Data\MethodDispatch(...array(
-                 'class' => 'class',
-                 'arguments' => 
-                array (
-                ),
-                 'dependencies' => 
-                array (
-                ),
-                 'method' => 'method',
-                 'isStatic' => false,
-              )),
             )),
             
             ],

--- a/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Event/Provider/ServiceProviderTest.php
@@ -29,7 +29,6 @@ use Valkyrja\Event\Dispatcher\EventDispatcher;
 use Valkyrja\Event\Generator\Contract\DataFileGeneratorContract;
 use Valkyrja\Event\Generator\DataFileGenerator;
 use Valkyrja\Event\Provider\EventServiceProvider;
-use Valkyrja\Reflection\Reflector\Contract\ReflectorContract;
 use Valkyrja\Support\Generator\Enum\GenerateStatus;
 use Valkyrja\Tests\Classes\Event\Provider\ListenerProviderClass;
 use Valkyrja\Tests\Unit\Container\Provider\Abstract\ServiceProviderTestCase;
@@ -58,7 +57,6 @@ final class ServiceProviderTest extends ServiceProviderTestCase
     public function testPublishAttributesCollector(): void
     {
         $this->container->setSingleton(AttributeCollectorContract::class, self::createStub(AttributeCollectorContract::class));
-        $this->container->setSingleton(ReflectorContract::class, self::createStub(ReflectorContract::class));
 
         $callback = EventServiceProvider::publishers()[CollectorContract::class];
         $callback($this->container);
@@ -109,7 +107,13 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $listenerName = 'listener-name';
         $data         = new EventData(
             events: [$eventId => [$listenerName]],
-            listeners: [$listenerName => new Listener(eventId: $eventId, name: $listenerName)]
+            listeners: [
+                $listenerName => new Listener(
+                    eventId: $eventId,
+                    name: $listenerName,
+                    handler: static fn () => null
+                ),
+            ]
         );
 
         $this->container->setSingleton(ApplicationContract::class, $application = self::createStub(ApplicationContract::class));
@@ -142,7 +146,11 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $eventId      = self::class;
         $listenerName = 'listener-name';
-        $listener     = new Listener(eventId: $eventId, name: $listenerName);
+        $listener     = new Listener(
+            eventId: $eventId,
+            name: $listenerName,
+            handler: static fn () => null
+        );
 
         $collector->expects($this->once())->method('getListeners')->willReturn([$listener]);
         $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
@@ -179,7 +187,11 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $eventId      = self::class;
         $listenerName = 'listener-name';
-        $listener     = new Listener(eventId: $eventId, name: $listenerName);
+        $listener     = new Listener(
+            eventId: $eventId,
+            name: $listenerName,
+            handler: static fn () => null
+        );
 
         $collector->expects($this->once())->method('getListeners')->willReturn([$listener]);
         $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);
@@ -216,7 +228,11 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
         $eventId      = self::class;
         $listenerName = 'listener-name';
-        $listener     = new Listener(eventId: $eventId, name: $listenerName);
+        $listener     = new Listener(
+            eventId: $eventId,
+            name: $listenerName,
+            handler: static fn () => null
+        );
 
         $collector->expects($this->never())->method('getListeners')->willReturn([$listener]);
         $generator->expects($this->never())->method('generateFile')->willReturn(GenerateStatus::SUCCESS);


### PR DESCRIPTION
# Description

Update event to use listener handler and remove dispatch.

Cross language solution.

The extra burden on the developer — writing a handler method alongside their implementation method — is real and
acknowledged. The tradeoff is worth it: the handler is explicit, readable, statically checkable by the compiler or
analyzer, testable in isolation, and works identically with and without cache. The dispatch object goes away regardless
of which alternative is considered.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
    <!-- Target the lowest major affected branch -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
    <!-- Target the lowest major affected branch -->
- [ ] New feature _(non-breaking change which adds functionality)_
    <!-- Target master -->
- [ ] Deprecation _(breaking change which removes functionality)_
    <!-- Target master -->
- [X] Breaking change _(fix or feature that would cause existing functionality
  to change)_
    <!-- Target master, unless this is a bug fix in which case let's chat -->
- [ ] Documentation improvement
    <!-- Target appropriate branch -->