### PR TITLE
[Documentation] Update versioning documentation

### DIFF
--- a/src/Valkyrja/VERSIONING_AND_RELEASE_PROCESS.md
+++ b/src/Valkyrja/VERSIONING_AND_RELEASE_PROCESS.md
@@ -11,6 +11,18 @@ This cadence gives you a predictable upgrade path: you know when a new version
 is coming, how long your current version will be maintained, and what the
 support window looks like before you need to plan a migration.
 
+## Versioning
+
+Valkyrja uses a three-part version number. Each part signals what kind of
+changes are included in the release.
+
+- **Major** — Breaking changes, new features, and major internal API changes.
+  Released yearly.
+- **Minor** — New features or fixes that are breaking changes but must be
+  implemented before the next major release.
+- **Patch** — Non-breaking fixes, documentation updates, and small atomic
+  changes that don't affect existing functionality.
+
 ## Release Schedule
 
 | Version | PHP       | Release             | Bug Fixes Until | Security Fixes Until |


### PR DESCRIPTION
# Description

Update `VERSIONING_AND_RELEASE_PROCESS.md` to document the full three-part semantic versioning scheme (Major / Minor / Patch) rather than describing releases as single-integer major versions only.

## Motivation

The previous wording implied Valkyrja used only a major version number (e.g. `25`, `26`, `27`), but releases actually follow full `MAJOR.MINOR.PATCH` semver. This left contributors without clear guidance on when a change warrants a minor vs. patch release, and was inconsistent with how releases are actually tagged.

## Changes

- Added a new **Versioning** section describing what each version component signals:
  - **Major** — Breaking changes, new features, and major internal API changes. Released yearly.
  - **Minor** — New features or fixes that are breaking changes but must be implemented before the next major release.
  - **Patch** — Non-breaking fixes, documentation updates, and small atomic changes that don't affect existing functionality.
- Fixed a typo (`automic` → `atomic`).
- Left the Release Schedule, Support Policy, and Development Branches sections unchanged.

## Types of changes

- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [X] Documentation improvement