### PR TITLE
[Http] Move UploadErrorExceptionMessage constant to more exposed namespace

### DIFF
--- a/src/Valkyrja/Http/Message/File/Constant/UploadErrorExceptionMessage.php
+++ b/src/Valkyrja/Http/Message/File/Constant/UploadErrorExceptionMessage.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Http\Message\File\Throwable\Exception\Constant;
+namespace Valkyrja\Http\Message\File\Constant;
 
 final class UploadErrorExceptionMessage
 {

--- a/src/Valkyrja/Http/Message/File/Throwable/Exception/UploadedFileUploadErrorException.php
+++ b/src/Valkyrja/Http/Message/File/Throwable/Exception/UploadedFileUploadErrorException.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Valkyrja\Http\Message\File\Throwable\Exception;
 
+use Valkyrja\Http\Message\File\Constant\UploadErrorExceptionMessage;
 use Valkyrja\Http\Message\File\Enum\UploadError;
 use Valkyrja\Http\Message\File\Throwable\Contract\UploadedFileThrowable;
 use Valkyrja\Http\Message\File\Throwable\Exception\Abstract\UploadedFileRuntimeException;
-use Valkyrja\Http\Message\File\Throwable\Exception\Constant\UploadErrorExceptionMessage;
 
 class UploadedFileUploadErrorException extends UploadedFileRuntimeException
 {

--- a/tests/Tests/Unit/Http/Message/File/Constant/UploadErrorExceptionTest.php
+++ b/tests/Tests/Unit/Http/Message/File/Constant/UploadErrorExceptionTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Valkyrja\Tests\Unit\Http\Message\File\Throwable;
+namespace Valkyrja\Tests\Unit\Http\Message\File\Constant;
 
+use Valkyrja\Http\Message\File\Constant\UploadErrorExceptionMessage;
 use Valkyrja\Http\Message\File\Enum\UploadError;
-use Valkyrja\Http\Message\File\Throwable\Exception\Constant\UploadErrorExceptionMessage;
 use Valkyrja\Http\Message\File\Throwable\Exception\UploadedFileInvalidUploadErrorException;
 use Valkyrja\Http\Message\File\Throwable\Exception\UploadedFileUploadErrorException;
 use Valkyrja\Tests\Unit\Abstract\TestCase;


### PR DESCRIPTION
# Description

Moves `UploadErrorExceptionMessage` from the deeply nested `Throwable\Exception\Constant` namespace to the more accessible `File\Constant` namespace, making it available to consumers without requiring knowledge of the throwable internals. Also relocates `UploadErrorExceptionTest` to mirror the namespace of the file it tests.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Http/Message/File/Throwable/Exception/Constant/UploadErrorExceptionMessage.php`** → **`src/Valkyrja/Http/Message/File/Constant/UploadErrorExceptionMessage.php`** — moved and updated namespace to `Valkyrja\Http\Message\File\Constant`
- **`src/Valkyrja/Http/Message/File/Throwable/Exception/UploadedFileUploadErrorException.php`** — updated import to new namespace
- **`tests/Tests/Unit/Http/Message/File/Throwable/Exception/Constant/UploadErrorExceptionTest.php`** → **`tests/Tests/Unit/Http/Message/File/Constant/UploadErrorExceptionTest.php`** — moved to mirror the relocated production file