### PR TITLE
[Validation] Rename Rule::getException() to throwException()

### DIFF
--- a/src/Valkyrja/Validation/Rule/Abstract/Rule.php
+++ b/src/Valkyrja/Validation/Rule/Abstract/Rule.php
@@ -44,14 +44,14 @@ abstract class Rule implements RuleContract
     public function validate(): void
     {
         if (! $this->isValid()) {
-            $this->getException();
+            $this->throwException();
         }
     }
 
     /**
-     * Get the exception.
+     * Throw a validation rule failure exception with the error message.
      */
-    protected function getException(): void
+    protected function throwException(): void
     {
         throw new ValidationRuleFailureException($this->errorMessage);
     }


### PR DESCRIPTION
# Description

Renames `getException()` to `throwException()` in the abstract `Rule` class to better reflect that the method throws rather than returns an exception. The method was protected and not expected to have external overrides.

## Types of changes

- [X] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`src/Valkyrja/Validation/Rule/Abstract/Rule.php`**
    - Renamed `getException()` to `throwException()`
    - Updated the call site in `validate()`
    - Updated the doc comment