### PR TITLE
[Cli/Http] Resolve config singletons by contract in service providers

### DIFF
--- a/src/Valkyrja/Cli/Server/Provider/CliServerServiceProvider.php
+++ b/src/Valkyrja/Cli/Server/Provider/CliServerServiceProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Server\Provider;
 
 use Override;
-use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Application\Data\Contract\ConfigContract;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Data\Contract\CliInteractionConfigContract;
@@ -163,7 +163,7 @@ class CliServerServiceProvider implements ServiceProviderContract
             GenerateDataCommand::class,
             new GenerateDataCommand(
                 env: $container->getSingleton(Env::class),
-                config: $container->getSingleton(CliConfig::class),
+                config: $container->getSingleton(CliConfigContract::class),
                 outputFactory: $container->getSingleton(OutputFactoryContract::class),
             )
         );

--- a/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliServiceProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliServiceProvider.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Http\Routing\Provider;
 
 use Override;
-use Valkyrja\Application\Data\HttpConfig;
+use Valkyrja\Application\Data\Contract\HttpConfigContract;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -43,7 +43,7 @@ class HttpRoutingCliServiceProvider implements ServiceProviderContract
             GenerateDataCommand::class,
             new GenerateDataCommand(
                 $container->getSingleton(Env::class),
-                $container->getSingleton(HttpConfig::class),
+                $container->getSingleton(HttpConfigContract::class),
                 $container->getSingleton(OutputFactoryContract::class),
             )
         );

--- a/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
@@ -16,6 +16,7 @@ namespace Valkyrja\Tests\Unit\Cli\Server\Provider;
 use PHPUnit\Framework\MockObject\Exception;
 use ReflectionProperty;
 use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Application\Data\Contract\ConfigContract;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Data\CliInteractionConfig;
@@ -328,7 +329,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $container = $this->container;
 
         $container->setSingleton(Env::class, self::createStub(Env::class));
-        $container->setSingleton(CliConfig::class, self::createStub(CliConfig::class));
+        $container->setSingleton(CliConfigContract::class, self::createStub(CliConfig::class));
         $container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
 
         self::assertFalse($container->has(GenerateDataCommand::class));

--- a/tests/Tests/Unit/Http/Routing/Provider/CliServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/CliServiceProviderTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Provider;
 
+use Valkyrja\Application\Data\Contract\HttpConfigContract;
 use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
@@ -39,7 +40,7 @@ final class CliServiceProviderTest extends ServiceProviderTestCase
         $container = $this->container;
 
         $container->setSingleton(Env::class, self::createStub(Env::class));
-        $container->setSingleton(HttpConfig::class, self::createStub(HttpConfig::class));
+        $container->setSingleton(HttpConfigContract::class, self::createStub(HttpConfig::class));
         $container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
 
         self::assertFalse($container->has(GenerateDataCommand::class));


### PR DESCRIPTION
# Description

Updates service providers to resolve config singletons by their contract interfaces rather than concrete classes, aligning with the interface-based config refactor.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`CliServerServiceProvider`** — resolve `CliConfigContract` instead of `CliConfig`
- **`HttpRoutingCliServiceProvider`** — resolve `HttpConfigContract` instead of `HttpConfig`
- **`Cli\Server\Provider\ServiceProviderTest`** — register singleton under `CliConfigContract`
- **`Http\Routing\Provider\CliServiceProviderTest`** — register singleton under `HttpConfigContract`