### PR TITLE
[Http] Register ListCommand in HttpRoutingCliServiceProvider

### DIFF
--- a/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliServiceProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliServiceProvider.php
@@ -20,6 +20,7 @@ use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
+use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 
 class HttpRoutingCliServiceProvider implements ServiceProviderContract
 {
@@ -31,6 +32,7 @@ class HttpRoutingCliServiceProvider implements ServiceProviderContract
     {
         return [
             GenerateDataCommand::class => [self::class, 'publishGenerateDataCommand'],
+            ListCommand::class         => [self::class, 'publishListCommand'],
         ];
     }
 
@@ -46,6 +48,17 @@ class HttpRoutingCliServiceProvider implements ServiceProviderContract
                 $container->getSingleton(HttpConfigContract::class),
                 $container->getSingleton(OutputFactoryContract::class),
             )
+        );
+    }
+
+    /**
+     * Publish the list command service.
+     */
+    public static function publishListCommand(ContainerContract $container): void
+    {
+        $container->setSingleton(
+            ListCommand::class,
+            new ListCommand()
         );
     }
 }

--- a/tests/Tests/Unit/Http/Routing/Provider/CliServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/CliServiceProviderTest.php
@@ -18,6 +18,7 @@ use Valkyrja\Application\Data\HttpConfig;
 use Valkyrja\Application\Env\Env;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Http\Routing\Cli\Command\GenerateDataCommand;
+use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 use Valkyrja\Http\Routing\Provider\HttpRoutingCliServiceProvider;
 use Valkyrja\Http\Routing\Provider\HttpRoutingServiceProvider;
 use Valkyrja\Tests\Unit\Container\Provider\Abstract\ServiceProviderTestCase;
@@ -33,6 +34,7 @@ final class CliServiceProviderTest extends ServiceProviderTestCase
     public function testExpectedPublishers(): void
     {
         self::assertArrayHasKey(GenerateDataCommand::class, HttpRoutingCliServiceProvider::publishers());
+        self::assertArrayHasKey(ListCommand::class, HttpRoutingCliServiceProvider::publishers());
     }
 
     public function testGenerateDataCommand(): void
@@ -51,5 +53,19 @@ final class CliServiceProviderTest extends ServiceProviderTestCase
         self::assertTrue($container->has(GenerateDataCommand::class));
         self::assertTrue($container->isSingleton(GenerateDataCommand::class));
         self::assertInstanceOf(GenerateDataCommand::class, $container->getSingleton(GenerateDataCommand::class));
+    }
+
+    public function testListCommand(): void
+    {
+        $container = $this->container;
+
+        self::assertFalse($container->has(ListCommand::class));
+
+        $callback = HttpRoutingCliServiceProvider::publishers()[ListCommand::class];
+        $callback($this->container);
+
+        self::assertTrue($container->has(ListCommand::class));
+        self::assertTrue($container->isSingleton(ListCommand::class));
+        self::assertInstanceOf(ListCommand::class, $container->getSingleton(ListCommand::class));
     }
 }


### PR DESCRIPTION
# Description

Adds missing registration of `ListCommand` to `HttpRoutingCliServiceProvider`. The command existed but was not registered in the container, making it unavailable for resolution and CLI invocation.

## Types of changes

- [ ] Improvement _(non-breaking change which improves code)_
- [X] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

## Changes

- **`HttpRoutingCliServiceProvider`** — added `ListCommand` to `publishers()` and added `publishListCommand()` method
- **`CliServiceProviderTest`** — added assertions for `ListCommand` publisher registration and singleton resolution