### PR TITLE
[Http] Remove route arguments map in favor of ParameterContract values

### DIFF
--- a/src/Valkyrja/Http/Routing/Attribute/DynamicRoute.php
+++ b/src/Valkyrja/Http/Routing/Attribute/DynamicRoute.php
@@ -26,6 +26,7 @@ use Valkyrja\Http\Middleware\Contract\SendingResponseMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\TerminatedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddlewareContract;
 use Valkyrja\Http\Routing\Data\Contract\ParameterContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\DynamicRoute as ParentRoute;
 use Valkyrja\Http\Struct\Request\Contract\RequestStructContract;
 use Valkyrja\Http\Struct\Response\Contract\ResponseStructContract;
@@ -36,16 +37,16 @@ class DynamicRoute extends ParentRoute implements ReflectionAwareAttributeContra
     use ReflectionAwareAttribute;
 
     /**
-     * @param non-empty-string                                                          $path                      The path
-     * @param non-empty-string                                                          $name                      The name
-     * @param RequestMethod[]                                                           $requestMethods            The request methods
-     * @param ParameterContract[]                                                       $parameters                The parameters
-     * @param (callable(ContainerContract, array<string, mixed>):ResponseContract)|null $handler                   The handler
-     * @param class-string<RouteMatchedMiddlewareContract>[]                            $routeMatchedMiddleware    The route matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[]                         $routeDispatchedMiddleware The route dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[]                         $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<SendingResponseMiddlewareContract>[]                         $sendingResponseMiddleware The sending response middleware
-     * @param class-string<TerminatedMiddlewareContract>[]                              $terminatedMiddleware      The terminated middleware
+     * @param non-empty-string                                                   $path                      The path
+     * @param non-empty-string                                                   $name                      The name
+     * @param RequestMethod[]                                                    $requestMethods            The request methods
+     * @param ParameterContract[]                                                $parameters                The parameters
+     * @param (callable(ContainerContract, RouteContract):ResponseContract)|null $handler                   The handler
+     * @param class-string<RouteMatchedMiddlewareContract>[]                     $routeMatchedMiddleware    The route matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]                  $routeDispatchedMiddleware The route dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]                  $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<SendingResponseMiddlewareContract>[]                  $sendingResponseMiddleware The sending response middleware
+     * @param class-string<TerminatedMiddlewareContract>[]                       $terminatedMiddleware      The terminated middleware
      */
     public function __construct(
         protected string $path,
@@ -66,7 +67,7 @@ class DynamicRoute extends ParentRoute implements ReflectionAwareAttributeContra
             name: $name,
             regex: '',
             parameters: $parameters,
-            handler: $handler ?? static fn (ContainerContract $container, array $arguments): ResponseContract => new Response(),
+            handler: $handler ?? static fn (ContainerContract $container, RouteContract $route): ResponseContract => new Response(),
             requestMethods: $requestMethods,
             routeMatchedMiddleware: $routeMatchedMiddleware,
             routeDispatchedMiddleware: $routeDispatchedMiddleware,

--- a/src/Valkyrja/Http/Routing/Attribute/Route.php
+++ b/src/Valkyrja/Http/Routing/Attribute/Route.php
@@ -25,6 +25,7 @@ use Valkyrja\Http\Middleware\Contract\RouteMatchedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\SendingResponseMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\TerminatedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddlewareContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\Route as ParentRoute;
 use Valkyrja\Http\Struct\Request\Contract\RequestStructContract;
 use Valkyrja\Http\Struct\Response\Contract\ResponseStructContract;
@@ -35,15 +36,15 @@ class Route extends ParentRoute implements ReflectionAwareAttributeContract
     use ReflectionAwareAttribute;
 
     /**
-     * @param non-empty-string                                                          $path                      The path
-     * @param non-empty-string                                                          $name                      The name
-     * @param (callable(ContainerContract, array<string, mixed>):ResponseContract)|null $handler                   The handler
-     * @param RequestMethod[]                                                           $requestMethods            The request methods
-     * @param class-string<RouteMatchedMiddlewareContract>[]                            $routeMatchedMiddleware    The route matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[]                         $routeDispatchedMiddleware The route dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[]                         $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<SendingResponseMiddlewareContract>[]                         $sendingResponseMiddleware The sending response middleware
-     * @param class-string<TerminatedMiddlewareContract>[]                              $terminatedMiddleware      The terminated middleware
+     * @param non-empty-string                                                   $path                      The path
+     * @param non-empty-string                                                   $name                      The name
+     * @param (callable(ContainerContract, RouteContract):ResponseContract)|null $handler                   The handler
+     * @param RequestMethod[]                                                    $requestMethods            The request methods
+     * @param class-string<RouteMatchedMiddlewareContract>[]                     $routeMatchedMiddleware    The route matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]                  $routeDispatchedMiddleware The route dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]                  $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<SendingResponseMiddlewareContract>[]                  $sendingResponseMiddleware The sending response middleware
+     * @param class-string<TerminatedMiddlewareContract>[]                       $terminatedMiddleware      The terminated middleware
      */
     public function __construct(
         protected string $path,
@@ -61,7 +62,7 @@ class Route extends ParentRoute implements ReflectionAwareAttributeContract
         parent::__construct(
             path: $path,
             name: $name,
-            handler: $handler ?? static fn (ContainerContract $container, array $arguments): ResponseContract => new Response(),
+            handler: $handler ?? static fn (ContainerContract $container, RouteContract $route): ResponseContract => new Response(),
             requestMethods: $requestMethods,
             routeMatchedMiddleware: $routeMatchedMiddleware,
             routeDispatchedMiddleware: $routeDispatchedMiddleware,

--- a/src/Valkyrja/Http/Routing/Attribute/Route/RouteHandler.php
+++ b/src/Valkyrja/Http/Routing/Attribute/Route/RouteHandler.php
@@ -16,15 +16,16 @@ namespace Valkyrja\Http\Routing\Attribute\Route;
 use Attribute;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class RouteHandler
 {
-    /** @var callable(ContainerContract, array<string, mixed>):ResponseContract */
+    /** @var callable(ContainerContract, RouteContract):ResponseContract */
     public $handler;
 
     /**
-     * @param callable(ContainerContract, array<string, mixed>):ResponseContract $handler
+     * @param callable(ContainerContract, RouteContract $route):ResponseContract $handler
      */
     public function __construct(
         callable $handler,

--- a/src/Valkyrja/Http/Routing/Data/Contract/DynamicRouteContract.php
+++ b/src/Valkyrja/Http/Routing/Data/Contract/DynamicRouteContract.php
@@ -45,4 +45,18 @@ interface DynamicRouteContract extends RouteContract
      * @param ParameterContract ...$parameters The parameter
      */
     public function withAddedParameters(ParameterContract ...$parameters): static;
+
+    /**
+     * Get a parameter by name.
+     *
+     * @param non-empty-string $name The parameter name
+     */
+    public function getParameter(string $name): ParameterContract;
+
+    /**
+     * Determine if a parameter exists by name.
+     *
+     * @param non-empty-string $name The parameter name
+     */
+    public function hasParameter(string $name): bool;
 }

--- a/src/Valkyrja/Http/Routing/Data/Contract/RouteContract.php
+++ b/src/Valkyrja/Http/Routing/Data/Contract/RouteContract.php
@@ -69,30 +69,16 @@ interface RouteContract
     public function withAddedName(string $name): static;
 
     /**
-     * Get the arguments.
-     *
-     * @return array<non-empty-string, mixed>
-     */
-    public function getArguments(): array;
-
-    /**
-     * Create a new dispatch with the specified arguments.
-     *
-     * @param array<non-empty-string, mixed> $arguments The arguments
-     */
-    public function withArguments(array $arguments): static;
-
-    /**
      * Get the handler.
      *
-     * @return callable(ContainerContract, array<string, mixed>): ResponseContract
+     * @return callable(ContainerContract, self): ResponseContract
      */
     public function getHandler(): callable;
 
     /**
      * Create a new route with the specified handler.
      *
-     * @param callable(ContainerContract, array<string, mixed>): ResponseContract $handler The handler
+     * @param callable(ContainerContract, self): ResponseContract $handler The handler
      */
     public function withHandler(callable $handler): static;
 

--- a/src/Valkyrja/Http/Routing/Data/DynamicRoute.php
+++ b/src/Valkyrja/Http/Routing/Data/DynamicRoute.php
@@ -24,22 +24,24 @@ use Valkyrja\Http\Middleware\Contract\TerminatedMiddlewareContract;
 use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddlewareContract;
 use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
 use Valkyrja\Http\Routing\Data\Contract\ParameterContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
+use Valkyrja\Http\Routing\Throwable\Exception\HttpRoutingInvalidRouteParameterException;
 use Valkyrja\Http\Struct\Request\Contract\RequestStructContract;
 use Valkyrja\Http\Struct\Response\Contract\ResponseStructContract;
 
 class DynamicRoute extends Route implements DynamicRouteContract
 {
     /**
-     * @param non-empty-string                                                   $path                      The path
-     * @param non-empty-string                                                   $name                      The name
-     * @param callable(ContainerContract, array<string, mixed>):ResponseContract $handler                   The handler
-     * @param RequestMethod[]                                                    $requestMethods            The request methods
-     * @param ParameterContract[]                                                $parameters                The parameters
-     * @param class-string<RouteMatchedMiddlewareContract>[]                     $routeMatchedMiddleware    The route matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[]                  $routeDispatchedMiddleware The route dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[]                  $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<SendingResponseMiddlewareContract>[]                  $sendingResponseMiddleware The sending response middleware
-     * @param class-string<TerminatedMiddlewareContract>[]                       $terminatedMiddleware      The terminated middleware
+     * @param non-empty-string                                            $path                      The path
+     * @param non-empty-string                                            $name                      The name
+     * @param callable(ContainerContract, RouteContract):ResponseContract $handler                   The handler
+     * @param RequestMethod[]                                             $requestMethods            The request methods
+     * @param ParameterContract[]                                         $parameters                The parameters
+     * @param class-string<RouteMatchedMiddlewareContract>[]              $routeMatchedMiddleware    The route matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]           $routeDispatchedMiddleware The route dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]           $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<SendingResponseMiddlewareContract>[]           $sendingResponseMiddleware The sending response middleware
+     * @param class-string<TerminatedMiddlewareContract>[]                $terminatedMiddleware      The terminated middleware
      */
     public function __construct(
         protected string $path,
@@ -128,5 +130,35 @@ class DynamicRoute extends Route implements DynamicRouteContract
         $new->parameters = array_merge($this->parameters, $parameters);
 
         return $new;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @throws HttpRoutingInvalidRouteParameterException
+     */
+    #[Override]
+    public function getParameter(string $name): ParameterContract
+    {
+        /** @var ParameterContract $parameter */
+        $parameter = array_find(
+            $this->parameters,
+            static fn (ParameterContract $parameter): bool => $parameter->getName() === $name
+        )
+            ?? throw new HttpRoutingInvalidRouteParameterException("No parameter named '$name' exists on this route");
+
+        return $parameter;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    #[Override]
+    public function hasParameter(string $name): bool
+    {
+        return array_any(
+            $this->parameters,
+            static fn (ParameterContract $parameter): bool => $parameter->getName() === $name
+        );
     }
 }

--- a/src/Valkyrja/Http/Routing/Data/Route.php
+++ b/src/Valkyrja/Http/Routing/Data/Route.php
@@ -32,21 +32,19 @@ use function in_array;
 
 class Route implements RouteContract
 {
-    /** @var array<non-empty-string, mixed> */
-    protected array $arguments = [];
-    /** @var callable(ContainerContract, array<string, mixed>): ResponseContract */
+    /** @var callable(ContainerContract, RouteContract): ResponseContract */
     protected $handler;
 
     /**
-     * @param non-empty-string                                                   $path                      The path
-     * @param non-empty-string                                                   $name                      The name
-     * @param callable(ContainerContract, array<string, mixed>):ResponseContract $handler                   The handler
-     * @param RequestMethod[]                                                    $requestMethods            The request methods
-     * @param class-string<RouteMatchedMiddlewareContract>[]                     $routeMatchedMiddleware    The route matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[]                  $routeDispatchedMiddleware The route dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[]                  $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<SendingResponseMiddlewareContract>[]                  $sendingResponseMiddleware The sending response middleware
-     * @param class-string<TerminatedMiddlewareContract>[]                       $terminatedMiddleware      The terminated middleware
+     * @param non-empty-string                                            $path                      The path
+     * @param non-empty-string                                            $name                      The name
+     * @param callable(ContainerContract, RouteContract):ResponseContract $handler                   The handler
+     * @param RequestMethod[]                                             $requestMethods            The request methods
+     * @param class-string<RouteMatchedMiddlewareContract>[]              $routeMatchedMiddleware    The route matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]           $routeDispatchedMiddleware The route dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]           $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<SendingResponseMiddlewareContract>[]           $sendingResponseMiddleware The sending response middleware
+     * @param class-string<TerminatedMiddlewareContract>[]                $terminatedMiddleware      The terminated middleware
      */
     public function __construct(
         protected string $path,
@@ -133,28 +131,6 @@ class Route implements RouteContract
         $new = clone $this;
 
         $new->name = $this->name . $name;
-
-        return $new;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function getArguments(): array
-    {
-        return $this->arguments;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    #[Override]
-    public function withArguments(array $arguments): static
-    {
-        $new = clone $this;
-
-        $new->arguments = $arguments;
 
         return $new;
     }

--- a/src/Valkyrja/Http/Routing/Dispatcher/Router.php
+++ b/src/Valkyrja/Http/Routing/Dispatcher/Router.php
@@ -104,11 +104,10 @@ class Router implements RouterContract
         // Set the route after middleware has potentially modified it in the service container
         $this->container->setSingleton(RouteContract::class, $routeAfterMiddleware);
 
-        $handler   = $routeAfterMiddleware->getHandler();
-        $arguments = $routeAfterMiddleware->getArguments();
+        $handler = $routeAfterMiddleware->getHandler();
 
         // Attempt to dispatch the route using any one of the callable options
-        $response = $handler($this->container, $arguments);
+        $response = $handler($this->container, $routeAfterMiddleware);
 
         return $this->routeDispatchedHandler->routeDispatched(
             request: $request,

--- a/src/Valkyrja/Http/Routing/Matcher/Matcher.php
+++ b/src/Valkyrja/Http/Routing/Matcher/Matcher.php
@@ -108,7 +108,6 @@ class Matcher implements MatcherContract
             throw new HttpRoutingInvalidRoutePathException('Route parameters must not be empty');
         }
 
-        $arguments            = [];
         $parametersWithValues = [];
 
         // Iterate through the matches
@@ -123,17 +122,15 @@ class Matcher implements MatcherContract
                 continue;
             }
 
-            $arguments[$name] = $this->checkAndCastMatchValue(
+            $value = $this->checkAndCastMatchValue(
                 parameter: $parameter,
                 match: $match
             );
 
-            $parametersWithValues[] = $parameter->withValue($arguments[$name]);
+            $parametersWithValues[] = $parameter->withValue($value);
         }
 
-        return $route
-            ->withParameters(...$parametersWithValues)
-            ->withArguments($arguments);
+        return $route->withParameters(...$parametersWithValues);
     }
 
     /**

--- a/src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php
+++ b/src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php
@@ -75,22 +75,25 @@ class EntityRouteMatchedMiddleware implements RouteMatchedMiddlewareContract
      */
     protected function checkRouteForEntities(DynamicRouteContract $route): ResponseContract|DynamicRouteContract
     {
-        $arguments = $route->getArguments();
+        $updatedParameters = [];
 
         // Iterate through the params
         foreach ($route->getParameters() as $parameter) {
-            $name = $parameter->getName();
-            /** @var scalar|object|array<array-key, mixed>|resource|null $value */
-            $value = $arguments[$name];
-            $type  = $this->getParameterCastType($parameter);
+            $type = $this->getParameterCastType($parameter);
 
             $isParameterEntityType = $this->isParameterEntityType($type);
 
             if (! $isParameterEntityType) {
+                $updatedParameters[] = $parameter;
+
                 continue;
             }
 
-            /** @var class-string<EntityContract> $type */
+            /**
+             * @var class-string<EntityContract>                        $type
+             * @var scalar|object|array<array-key, mixed>|resource|null $value
+             */
+            $value = $parameter->getValue();
 
             // Check if the parameter is an entity
             $response = $this->checkParameterForEntity(
@@ -103,10 +106,10 @@ class EntityRouteMatchedMiddleware implements RouteMatchedMiddlewareContract
                 return $response;
             }
 
-            $arguments[$name] = $response;
+            $updatedParameters[] = $parameter->withValue($response);
         }
 
-        return $route->withArguments($arguments);
+        return $route->withParameters(...$updatedParameters);
     }
 
     /**

--- a/tests/Tests/Classes/Http/Routing/Controller/ControllerAttributedClass.php
+++ b/tests/Tests/Classes/Http/Routing/Controller/ControllerAttributedClass.php
@@ -19,6 +19,7 @@ use Valkyrja\Http\Message\Response\Response;
 use Valkyrja\Http\Routing\Attribute\Route;
 use Valkyrja\Http\Routing\Attribute\Route\Name;
 use Valkyrja\Http\Routing\Attribute\Route\Path;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 
 /**
  * Controller class to test routes.
@@ -32,12 +33,7 @@ final class ControllerAttributedClass
     /** @var non-empty-string */
     public const string WELCOME_NAME = 'welcome';
 
-    /**
-     * Handler for the welcome route.
-     *
-     * @param array<array-key, mixed> $arguments The arguments
-     */
-    public static function welcomeHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function welcomeHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         $controller = new self();
 

--- a/tests/Tests/Classes/Http/Routing/Provider/RouteProviderClass.php
+++ b/tests/Tests/Classes/Http/Routing/Provider/RouteProviderClass.php
@@ -17,6 +17,7 @@ use Override;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Response\Response;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Http\Routing\Data\Route;
 use Valkyrja\Http\Routing\Provider\Contract\HttpRouteProviderContract;
 
@@ -40,10 +41,7 @@ final class RouteProviderClass implements HttpRouteProviderContract
         ];
     }
 
-    /**
-     * @param array<array-key, mixed> $arguments
-     */
-    public static function handler(ContainerContract $container, array $arguments = []): ResponseContract
+    public static function handler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return new Response();
     }

--- a/tests/Tests/Functional/Application/Entry/HttpTest.php
+++ b/tests/Tests/Functional/Application/Entry/HttpTest.php
@@ -27,6 +27,7 @@ use Valkyrja\Http\Message\Response\Response;
 use Valkyrja\Http\Routing\Attribute\Route;
 use Valkyrja\Http\Routing\Attribute\Route\RouteHandler;
 use Valkyrja\Http\Routing\Collection\Contract\RouteCollectionContract;
+use Valkyrja\Http\Routing\Data\Contract\RouteContract;
 use Valkyrja\Tests\Classes\Application\Provider\HttpComponentProviderClass;
 use Valkyrja\Tests\Classes\Application\Provider\HttpRouteProviderClass;
 use Valkyrja\Tests\Classes\Application\Provider\HttpRoutingDataProviderClass;
@@ -41,10 +42,7 @@ final class HttpTest extends TestCase
 {
     protected static bool $runCalled = false;
 
-    /**
-     * @param array<array-key, mixed> $arguments
-     */
-    public static function routeHandler(ContainerContract $container, array $arguments): ResponseContract
+    public static function routeHandler(ContainerContract $container, RouteContract $route): ResponseContract
     {
         return self::routeCallback();
     }

--- a/tests/Tests/Unit/Http/Routing/Data/DynamicRouteTest.php
+++ b/tests/Tests/Unit/Http/Routing/Data/DynamicRouteTest.php
@@ -17,6 +17,7 @@ use Valkyrja\Http\Message\Enum\RequestMethod;
 use Valkyrja\Http\Routing\Constant\Regex;
 use Valkyrja\Http\Routing\Data\DynamicRoute;
 use Valkyrja\Http\Routing\Data\Parameter;
+use Valkyrja\Http\Routing\Throwable\Exception\HttpRoutingInvalidRouteParameterException;
 use Valkyrja\Tests\Classes\Http\Middleware\RouteDispatchedMiddlewareChangedClass;
 use Valkyrja\Tests\Classes\Http\Middleware\RouteDispatchedMiddlewareClass;
 use Valkyrja\Tests\Classes\Http\Middleware\RouteMatchedMiddlewareChangedClass;
@@ -312,6 +313,44 @@ final class DynamicRouteTest extends TestCase
         self::assertSame([$parameter3], $route3->getParameters());
         self::assertSame([$parameter, $parameter2], $route4->getParameters());
         self::assertSame([$parameter, $parameter3, $parameter4], $route5->getParameters());
+    }
+
+    public function testGetParameterAndHasParameter(): void
+    {
+        $path = '/';
+        $name = 'route';
+
+        $parameter  = new Parameter(name: 'test1', regex: Regex::ALPHA);
+        $parameter2 = new Parameter(name: 'test2', regex: Regex::ALPHA);
+
+        $route = new DynamicRoute(
+            path: $path,
+            name: $name,
+            regex: '',
+            parameters: [$parameter, $parameter2],
+            handler: static fn (): null => null,
+        );
+
+        self::assertTrue($route->hasParameter('test1'));
+        self::assertTrue($route->hasParameter('test2'));
+        self::assertFalse($route->hasParameter('nonexistent'));
+        self::assertSame($parameter, $route->getParameter('test1'));
+        self::assertSame($parameter2, $route->getParameter('test2'));
+    }
+
+    public function testGetParameterThrowsForMissingParameter(): void
+    {
+        $this->expectException(HttpRoutingInvalidRouteParameterException::class);
+
+        $route = new DynamicRoute(
+            path: '/',
+            name: 'route',
+            regex: '',
+            parameters: [],
+            handler: static fn (): null => null,
+        );
+
+        $route->getParameter('nonexistent');
     }
 
     public function testRouteMatchedMiddleware(): void

--- a/tests/Tests/Unit/Http/Routing/Matcher/MatcherTest.php
+++ b/tests/Tests/Unit/Http/Routing/Matcher/MatcherTest.php
@@ -17,6 +17,7 @@ use Override;
 use Valkyrja\Http\Message\Enum\RequestMethod;
 use Valkyrja\Http\Routing\Collection\RouteCollection;
 use Valkyrja\Http\Routing\Constant\Regex;
+use Valkyrja\Http\Routing\Data\Contract\DynamicRouteContract;
 use Valkyrja\Http\Routing\Data\DynamicRoute;
 use Valkyrja\Http\Routing\Data\Parameter;
 use Valkyrja\Http\Routing\Data\Route;
@@ -181,9 +182,7 @@ final class MatcherTest extends TestCase
         self::assertNotNull($matcher->matchStatic($path, RequestMethod::ANY));
         self::assertNull($matcher->matchStatic($dynamicPath, RequestMethod::ANY));
 
-        $arguments = $route->getArguments();
-
-        self::assertEmpty($arguments);
+        self::assertNotInstanceOf(DynamicRouteContract::class, $route);
     }
 
     public function testDynamicMatch(): void
@@ -199,11 +198,10 @@ final class MatcherTest extends TestCase
         self::assertNull($matcher->matchDynamic($path, RequestMethod::ANY));
         self::assertNotNull($matcher->matchDynamic($dynamicPath, RequestMethod::ANY));
 
-        $arguments = $route->getArguments();
-
-        self::assertNotEmpty($arguments);
-        self::assertIsString($arguments['dynamic']);
-        self::assertSame('dynamic', $arguments['dynamic']);
+        self::assertInstanceOf(DynamicRouteContract::class, $route);
+        self::assertTrue($route->hasParameter('dynamic'));
+        self::assertIsString($route->getParameter('dynamic')->getValue());
+        self::assertSame('dynamic', $route->getParameter('dynamic')->getValue());
     }
 
     public function testOptionalDynamicMatch(): void
@@ -217,22 +215,20 @@ final class MatcherTest extends TestCase
         self::assertNotNull($route);
         self::assertNotNull($matcher->matchDynamic($dynamicPath, RequestMethod::ANY));
 
-        $arguments = $route->getArguments();
-
-        self::assertNotEmpty($arguments);
-        self::assertIsString($arguments['dynamic']);
-        self::assertSame('default', $arguments['dynamic']);
+        self::assertInstanceOf(DynamicRouteContract::class, $route);
+        self::assertTrue($route->hasParameter('dynamic'));
+        self::assertIsString($route->getParameter('dynamic')->getValue());
+        self::assertSame('default', $route->getParameter('dynamic')->getValue());
 
         $route2 = $matcher->match($dynamicPath . '/optionalvalue', RequestMethod::ANY);
 
         self::assertNotNull($route2);
         self::assertNotNull($matcher->matchDynamic($dynamicPath . '/optionalvalue', RequestMethod::ANY));
 
-        $arguments2 = $route2->getArguments();
-
-        self::assertNotEmpty($arguments2);
-        self::assertIsString($arguments2['dynamic']);
-        self::assertSame('optionalvalue', $arguments2['dynamic']);
+        self::assertInstanceOf(DynamicRouteContract::class, $route2);
+        self::assertTrue($route2->hasParameter('dynamic'));
+        self::assertIsString($route2->getParameter('dynamic')->getValue());
+        self::assertSame('optionalvalue', $route2->getParameter('dynamic')->getValue());
     }
 
     public function testOptionalNullDefaultDynamicMatch(): void
@@ -246,21 +242,19 @@ final class MatcherTest extends TestCase
         self::assertNotNull($route);
         self::assertNotNull($matcher->matchDynamic($dynamicPath, RequestMethod::ANY));
 
-        $arguments = $route->getArguments();
-
-        self::assertEmpty($arguments);
-        self::assertNull($arguments['dynamic'] ?? null);
+        self::assertInstanceOf(DynamicRouteContract::class, $route);
+        self::assertTrue($route->hasParameter('dynamic'));
+        self::assertNull($route->getParameter('dynamic')->getValue());
 
         $route2 = $matcher->match($dynamicPath . '/optionalvalue', RequestMethod::ANY);
 
         self::assertNotNull($route2);
         self::assertNotNull($matcher->matchDynamic($dynamicPath . '/optionalvalue', RequestMethod::ANY));
 
-        $arguments2 = $route2->getArguments();
-
-        self::assertNotEmpty($arguments2);
-        self::assertIsString($arguments2['dynamic']);
-        self::assertSame('optionalvalue', $arguments2['dynamic']);
+        self::assertInstanceOf(DynamicRouteContract::class, $route2);
+        self::assertTrue($route2->hasParameter('dynamic'));
+        self::assertIsString($route2->getParameter('dynamic')->getValue());
+        self::assertSame('optionalvalue', $route2->getParameter('dynamic')->getValue());
     }
 
     public function testCastDynamicMatch(): void
@@ -274,12 +268,12 @@ final class MatcherTest extends TestCase
         self::assertNotNull($route);
         self::assertNotNull($matcher->matchDynamic($dynamicPath, RequestMethod::ANY));
 
-        $arguments = $route->getArguments();
-
-        self::assertNotEmpty($arguments);
-        self::assertIsInt($arguments['dynamic1']);
-        self::assertInstanceOf(IntT::class, $arguments['dynamic2']);
-        self::assertIsInt($arguments['dynamic2']->asValue());
+        self::assertInstanceOf(DynamicRouteContract::class, $route);
+        self::assertTrue($route->hasParameter('dynamic1'));
+        self::assertTrue($route->hasParameter('dynamic2'));
+        self::assertIsInt($route->getParameter('dynamic1')->getValue());
+        self::assertInstanceOf(IntT::class, $route->getParameter('dynamic2')->getValue());
+        self::assertIsInt($route->getParameter('dynamic2')->getValue()->asValue());
     }
 
     public function testInvalidDynamicMatch(): void

--- a/tests/Tests/Unit/Orm/Middleware/EntityRouteMatchedMiddlewareTest.php
+++ b/tests/Tests/Unit/Orm/Middleware/EntityRouteMatchedMiddlewareTest.php
@@ -126,9 +126,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast      = new Cast(type: CastType::string);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('id');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -137,8 +136,11 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
         $parameter
             ->expects($this->never())
-            ->method('getCast')
-            ->willReturn($cast);
+            ->method('getCast');
+
+        $parameter
+            ->expects($this->never())
+            ->method('getValue');
 
         $route
             ->expects($this->exactly(2))
@@ -146,9 +148,10 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->willReturn([$parameter]);
 
         $route
-            ->expects($this->exactly(2))
-            ->method('getArguments')
-            ->willReturn(['id' => '123']);
+            ->expects($this->once())
+            ->method('withParameters')
+            ->with($parameter)
+            ->willReturnSelf();
 
         $handler
             ->expects($this->once())
@@ -158,7 +161,6 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $result = $this->middleware->routeMatched($request, $route, $handler);
 
         self::assertInstanceOf(DynamicRouteContract::class, $result);
-        self::assertSame('123', $result->getArguments()['id']);
     }
 
     public function testRouteMatchedWithNonEntityParameter(): void
@@ -174,9 +176,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast      = new Cast(type: CastType::string);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('id');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -188,6 +189,10 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->never())
+            ->method('getValue');
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
@@ -195,8 +200,9 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
         $route
             ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['id' => '123']);
+            ->method('withParameters')
+            ->with($parameter)
+            ->willReturnSelf();
 
         $handler
             ->expects($this->once())
@@ -224,9 +230,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast        = new Cast(type: $entityClass);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('user');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -238,6 +243,17 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn($entity);
+
+        $parameter
+            ->expects($this->once())
+            ->method('withValue')
+            ->with($entity)
+            ->willReturnSelf();
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
@@ -245,12 +261,7 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
         $route
             ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['user' => $entity]);
-
-        $route
-            ->expects($this->once())
-            ->method('withArguments')
+            ->method('withParameters')
             ->willReturnSelf();
 
         $handler
@@ -278,9 +289,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast        = new Cast(type: $entityClass);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('user');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -292,15 +302,15 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn(999);
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn([$parameter]);
-
-        $route
-            ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['user' => 999]);
 
         $this->orm
             ->expects($this->once())
@@ -344,9 +354,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast        = new Cast(type: $entityClass);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('user');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -358,15 +367,15 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn('');
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
             ->willReturn([$parameter]);
-
-        $route
-            ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['user' => '']);
 
         $this->responseFactory
             ->expects($this->once())
@@ -399,9 +408,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast        = new EntityCast(type: $entityClass, column: 'slug');
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('user');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -413,6 +421,17 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn('john-doe');
+
+        $parameter
+            ->expects($this->once())
+            ->method('withValue')
+            ->with($entity)
+            ->willReturnSelf();
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
@@ -420,12 +439,7 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
         $route
             ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['user' => 'john-doe']);
-
-        $route
-            ->expects($this->once())
-            ->method('withArguments')
+            ->method('withParameters')
             ->willReturnSelf();
 
         $this->orm
@@ -465,9 +479,8 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
         $cast        = new Cast(type: $entityClass);
 
         $parameter
-            ->expects($this->once())
-            ->method('getName')
-            ->willReturn('user');
+            ->expects($this->never())
+            ->method('getName');
 
         $parameter
             ->expects($this->once())
@@ -479,6 +492,17 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
             ->method('getCast')
             ->willReturn($cast);
 
+        $parameter
+            ->expects($this->once())
+            ->method('getValue')
+            ->willReturn(42);
+
+        $parameter
+            ->expects($this->once())
+            ->method('withValue')
+            ->with($entity)
+            ->willReturnSelf();
+
         $route
             ->expects($this->exactly(2))
             ->method('getParameters')
@@ -486,12 +510,7 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
         $route
             ->expects($this->once())
-            ->method('getArguments')
-            ->willReturn(['user' => 42]);
-
-        $route
-            ->expects($this->once())
-            ->method('withArguments')
+            ->method('withParameters')
             ->willReturnSelf();
 
         $this->orm


### PR DESCRIPTION
## Description

Removes the flat `arguments` map from `RouteContract` and `Route`, which was a duplicate of values already stored on each `ParameterContract`. Introduces `getParameter()` and `hasParameter()` on `DynamicRouteContract` so callers can look up parameter values by name without an intermediate array. Updates the Http route handler callable signature to receive the matched `RouteContract` directly instead of an extracted arguments array.

Also fixes a latent bug in `EntityRouteMatchedMiddleware` where the flat `$arguments` array and the `ParameterContract` objects could become misaligned when entity parameters were resolved.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [x] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`src/Valkyrja/Http/Routing/Data/Contract/RouteContract.php`** — removed `getArguments()`, `withArguments()`; updated handler callable type from `callable(ContainerContract, array<string, mixed>): ResponseContract` to `callable(ContainerContract, RouteContract): ResponseContract`
- **`src/Valkyrja/Http/Routing/Data/Contract/DynamicRouteContract.php`** — added `getParameter(string $name): ParameterContract` and `hasParameter(string $name): bool`
- **`src/Valkyrja/Http/Routing/Data/Route.php`** — removed `$arguments` field, `getArguments()`, `withArguments()`; updated handler type annotations
- **`src/Valkyrja/Http/Routing/Data/DynamicRoute.php`** — added `getParameter()` and `hasParameter()` implementations; updated handler type annotation
- **`src/Valkyrja/Http/Routing/Matcher/Matcher.php`** — simplified `processArguments()` to drop the redundant `$arguments` array and `withArguments()` call; `ParameterContract::getValue()` is now the single source of truth
- **`src/Valkyrja/Http/Routing/Dispatcher/Router.php`** — updated `dispatchRoute()` to pass the route to the handler instead of extracting arguments
- **`src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php`** — rewrote `checkRouteForEntities()` to use `getValue()` / `withValue()` / `withParameters()` instead of `getArguments()` / `withArguments()`; fixes the misalignment bug
- Updated all affected tests and test handler stubs