### PR TITLE
[Cli] Add RouteContract as second parameter to route handler callable

### DIFF
--- a/src/Valkyrja/Cli/Routing/Attribute/Route.php
+++ b/src/Valkyrja/Cli/Routing/Attribute/Route.php
@@ -25,6 +25,7 @@ use Valkyrja\Cli\Middleware\Contract\RouteMatchedMiddlewareContract;
 use Valkyrja\Cli\Middleware\Contract\ThrowableCaughtMiddlewareContract;
 use Valkyrja\Cli\Routing\Data\Contract\ArgumentParameterContract;
 use Valkyrja\Cli\Routing\Data\Contract\OptionParameterContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\Route as Model;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 
@@ -36,7 +37,7 @@ class Route extends Model implements ReflectionAwareAttributeContract
     /**
      * @param non-empty-string                                  $name                      The name
      * @param non-empty-string                                  $description               The description
-     * @param (callable(ContainerContract):OutputContract)|null $handler                   The handler
+     * @param (callable(ContainerContract, RouteContract):OutputContract)|null $handler                   The handler
      * @param (callable():MessageContract)|null                 $helpText                  The help text
      * @param class-string<RouteMatchedMiddlewareContract>[]    $routeMatchedMiddleware    The command matched middleware
      * @param class-string<RouteDispatchedMiddlewareContract>[] $routeDispatchedMiddleware The command dispatched middleware
@@ -60,7 +61,7 @@ class Route extends Model implements ReflectionAwareAttributeContract
         parent::__construct(
             name: $name,
             description: $description,
-            handler: $handler ?? static fn (ContainerContract $container): OutputContract => new Output(),
+            handler: $handler ?? static fn (ContainerContract $container, RouteContract $route): OutputContract => new Output(),
             helpText: $helpText,
             routeMatchedMiddleware: $routeMatchedMiddleware,
             routeDispatchedMiddleware: $routeDispatchedMiddleware,

--- a/src/Valkyrja/Cli/Routing/Attribute/Route.php
+++ b/src/Valkyrja/Cli/Routing/Attribute/Route.php
@@ -35,16 +35,16 @@ class Route extends Model implements ReflectionAwareAttributeContract
     use ReflectionAwareAttribute;
 
     /**
-     * @param non-empty-string                                  $name                      The name
-     * @param non-empty-string                                  $description               The description
+     * @param non-empty-string                                                 $name                      The name
+     * @param non-empty-string                                                 $description               The description
      * @param (callable(ContainerContract, RouteContract):OutputContract)|null $handler                   The handler
-     * @param (callable():MessageContract)|null                 $helpText                  The help text
-     * @param class-string<RouteMatchedMiddlewareContract>[]    $routeMatchedMiddleware    The command matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[] $routeDispatchedMiddleware The command dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[] $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<ExitedMiddlewareContract>[]          $exitedMiddleware          The exited middleware
-     * @param ArgumentParameterContract[]                       $arguments                 The arguments
-     * @param OptionParameterContract[]                         $options                   The options
+     * @param (callable():MessageContract)|null                                $helpText                  The help text
+     * @param class-string<RouteMatchedMiddlewareContract>[]                   $routeMatchedMiddleware    The command matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]                $routeDispatchedMiddleware The command dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]                $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<ExitedMiddlewareContract>[]                         $exitedMiddleware          The exited middleware
+     * @param ArgumentParameterContract[]                                      $arguments                 The arguments
+     * @param OptionParameterContract[]                                        $options                   The options
      */
     public function __construct(
         protected string $name,

--- a/src/Valkyrja/Cli/Routing/Attribute/Route/RouteHandler.php
+++ b/src/Valkyrja/Cli/Routing/Attribute/Route/RouteHandler.php
@@ -15,16 +15,17 @@ namespace Valkyrja\Cli\Routing\Attribute\Route;
 
 use Attribute;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 
 #[Attribute(Attribute::TARGET_METHOD)]
 class RouteHandler
 {
-    /** @var callable(ContainerContract):OutputContract */
+    /** @var callable(ContainerContract, RouteContract):OutputContract */
     public $handler;
 
     /**
-     * @param callable(ContainerContract):OutputContract $handler
+     * @param callable(ContainerContract, RouteContract):OutputContract $handler
      */
     public function __construct(
         callable $handler,

--- a/src/Valkyrja/Cli/Routing/Data/Contract/RouteContract.php
+++ b/src/Valkyrja/Cli/Routing/Data/Contract/RouteContract.php
@@ -240,14 +240,14 @@ interface RouteContract
     /**
      * Get the handler.
      *
-     * @return callable(ContainerContract): OutputContract
+     * @return callable(ContainerContract, self): OutputContract
      */
     public function getHandler(): callable;
 
     /**
      * Create a new route with the specified handler.
      *
-     * @param callable(ContainerContract): OutputContract $handler The handler
+     * @param callable(ContainerContract, self): OutputContract $handler The handler
      */
     public function withHandler(callable $handler): static;
 }

--- a/src/Valkyrja/Cli/Routing/Data/Route.php
+++ b/src/Valkyrja/Cli/Routing/Data/Route.php
@@ -43,16 +43,16 @@ class Route implements RouteContract
     protected $handler;
 
     /**
-     * @param non-empty-string                                  $name                      The name
-     * @param non-empty-string                                  $description               The description
-     * @param callable(ContainerContract):OutputContract        $handler                   The handler
-     * @param (callable():MessageContract)|null                 $helpText                  The help text
-     * @param class-string<RouteMatchedMiddlewareContract>[]    $routeMatchedMiddleware    The command matched middleware
-     * @param class-string<RouteDispatchedMiddlewareContract>[] $routeDispatchedMiddleware The command dispatched middleware
-     * @param class-string<ThrowableCaughtMiddlewareContract>[] $throwableCaughtMiddleware The throwable caught middleware
-     * @param class-string<ExitedMiddlewareContract>[]          $exitedMiddleware          The exited middleware
-     * @param ArgumentParameterContract[]                       $arguments                 The arguments
-     * @param OptionParameterContract[]                         $options                   The options
+     * @param non-empty-string                                          $name                      The name
+     * @param non-empty-string                                          $description               The description
+     * @param callable(ContainerContract, RouteContract):OutputContract $handler                   The handler
+     * @param (callable():MessageContract)|null                         $helpText                  The help text
+     * @param class-string<RouteMatchedMiddlewareContract>[]            $routeMatchedMiddleware    The command matched middleware
+     * @param class-string<RouteDispatchedMiddlewareContract>[]         $routeDispatchedMiddleware The command dispatched middleware
+     * @param class-string<ThrowableCaughtMiddlewareContract>[]         $throwableCaughtMiddleware The throwable caught middleware
+     * @param class-string<ExitedMiddlewareContract>[]                  $exitedMiddleware          The exited middleware
+     * @param ArgumentParameterContract[]                               $arguments                 The arguments
+     * @param OptionParameterContract[]                                 $options                   The options
      */
     public function __construct(
         protected string $name,

--- a/src/Valkyrja/Cli/Routing/Data/Route.php
+++ b/src/Valkyrja/Cli/Routing/Data/Route.php
@@ -39,7 +39,7 @@ class Route implements RouteContract
      * @var (callable():MessageContract)|null
      */
     protected $helpText;
-    /** @var callable(ContainerContract): OutputContract */
+    /** @var callable(ContainerContract, RouteContract): OutputContract */
     protected $handler;
 
     /**

--- a/src/Valkyrja/Cli/Routing/Dispatcher/Router.php
+++ b/src/Valkyrja/Cli/Routing/Dispatcher/Router.php
@@ -105,7 +105,7 @@ class Router implements RouterContract
 
         $handler = $routeAfterMiddleware->getHandler();
         // Attempt to dispatch the route using any one of the callable options
-        $output = $handler($this->container);
+        $output = $handler($this->container, $routeAfterMiddleware);
 
         return $this->routeDispatchedHandler->routeDispatched(
             input: $input,

--- a/src/Valkyrja/Cli/Routing/Provider/CliRoutingCliRouteProvider.php
+++ b/src/Valkyrja/Cli/Routing/Provider/CliRoutingCliRouteProvider.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Cli\Routing\Provider;
 
 use Override;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\Contract\CliRouteProviderContract;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
@@ -50,7 +51,7 @@ class CliRoutingCliRouteProvider implements CliRouteProviderContract
     /**
      * The list command handler.
      */
-    public static function listHandler(ContainerContract $container): OutputContract
+    public static function listHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(ListCommand::class)->run();
     }
@@ -58,7 +59,7 @@ class CliRoutingCliRouteProvider implements CliRouteProviderContract
     /**
      * The list bash command handler.
      */
-    public static function listBashHandler(ContainerContract $container): OutputContract
+    public static function listBashHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(ListBashCommand::class)->run();
     }
@@ -66,7 +67,7 @@ class CliRoutingCliRouteProvider implements CliRouteProviderContract
     /**
      * The help command handler.
      */
-    public static function helpHandler(ContainerContract $container): OutputContract
+    public static function helpHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(HelpCommand::class)->run();
     }
@@ -74,7 +75,7 @@ class CliRoutingCliRouteProvider implements CliRouteProviderContract
     /**
      * The version command handler.
      */
-    public static function versionHandler(ContainerContract $container): OutputContract
+    public static function versionHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(VersionCommand::class)->run();
     }

--- a/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliRouteProvider.php
+++ b/src/Valkyrja/Http/Routing/Provider/HttpRoutingCliRouteProvider.php
@@ -16,6 +16,7 @@ namespace Valkyrja\Http\Routing\Provider;
 use Override;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\Contract\CliRouteProviderContract;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
@@ -47,7 +48,7 @@ class HttpRoutingCliRouteProvider implements CliRouteProviderContract
     /**
      * The list command handler.
      */
-    public static function listHandler(ContainerContract $container): OutputContract
+    public static function listHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return $container->getSingleton(ListCommand::class)->run(
             $container->getSingleton(VersionCommand::class),

--- a/tests/Tests/Classes/Cli/Routing/Command/CommandClass.php
+++ b/tests/Tests/Classes/Cli/Routing/Command/CommandClass.php
@@ -19,6 +19,7 @@ use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Data\ArgumentParameter;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Enum\ArgumentMode;
 use Valkyrja\Cli\Routing\Enum\OptionMode;
@@ -47,7 +48,7 @@ final class CommandClass
     /**
      * Handler for the command.
      */
-    public static function handler(ContainerContract $container): OutputContract
+    public static function handler(ContainerContract $container, RouteContract $route): OutputContract
     {
         return self::run(
             $container->getSingleton(OutputFactoryContract::class)

--- a/tests/Tests/Classes/Cli/Routing/Command/CommandWithAllAttributesClass.php
+++ b/tests/Tests/Classes/Cli/Routing/Command/CommandWithAllAttributesClass.php
@@ -23,6 +23,7 @@ use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\Middleware;
 use Valkyrja\Cli\Routing\Attribute\Route\Name;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Enum\ArgumentMode;
 use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
 use Valkyrja\Cli\Routing\Enum\OptionMode;
@@ -59,7 +60,7 @@ final class CommandWithAllAttributesClass
     /**
      * Handler for the command.
      */
-    public static function handler(ContainerContract $container): OutputContract
+    public static function handler(ContainerContract $container, RouteContract $route): OutputContract
     {
         $controller = new self();
 

--- a/tests/Tests/Classes/Cli/Routing/Command/CommandWithAllMiddlewareClass.php
+++ b/tests/Tests/Classes/Cli/Routing/Command/CommandWithAllMiddlewareClass.php
@@ -20,6 +20,7 @@ use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\Middleware;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Tests\Classes\Cli\Middleware\AllMiddlewareClass;
 
@@ -43,7 +44,7 @@ final class CommandWithAllMiddlewareClass
     /**
      * Handler for the command.
      */
-    public static function handler(ContainerContract $container): OutputContract
+    public static function handler(ContainerContract $container, RouteContract $route): OutputContract
     {
         $controller = new self();
 

--- a/tests/Tests/Functional/Application/Entry/CliTest.php
+++ b/tests/Tests/Functional/Application/Entry/CliTest.php
@@ -27,6 +27,7 @@ use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
 use Valkyrja\Cli\Routing\Collection\Contract\RouteCollectionContract;
 use Valkyrja\Cli\Routing\Data\Contract\CliRoutingConfigContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Server\Support\Exiter;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Tests\Classes\Application\Provider\CliComponentProviderClass;
@@ -47,7 +48,7 @@ final class CliTest extends TestCase
     protected static bool $handlerCalled = false;
     protected static bool $runCalled     = false;
 
-    public static function routeHandler(ContainerContract $container): OutputContract
+    public static function routeHandler(ContainerContract $container, RouteContract $route): OutputContract
     {
         self::$handlerCalled = true;
 

--- a/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
@@ -27,9 +27,9 @@ use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Data\Route;
 use Valkyrja\Cli\Routing\Dispatcher\Router;
-use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
 use Valkyrja\Container\Manager\Container;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 /**

--- a/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Dispatcher/RouterTest.php
@@ -27,6 +27,7 @@ use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Data\Route;
 use Valkyrja\Cli\Routing\Dispatcher\Router;
+use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
 use Valkyrja\Container\Manager\Container;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
@@ -36,7 +37,7 @@ use Valkyrja\Tests\Unit\Abstract\TestCase;
  */
 final class RouterTest extends TestCase
 {
-    public static function dispatch(): Output
+    public static function dispatch(ContainerContract $container, RouteContract $route): Output
     {
         return new Output(exitCode: ExitCode::SUCCESS);
     }

--- a/tests/Tests/Unit/Cli/Routing/Provider/CliRouteProviderTest.php
+++ b/tests/Tests/Unit/Cli/Routing/Provider/CliRouteProviderTest.php
@@ -15,6 +15,7 @@ namespace Valkyrja\Tests\Unit\Cli\Routing\Provider;
 
 use PHPUnit\Framework\MockObject\Exception;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\CliRoutingCliRouteProvider;
 use Valkyrja\Cli\Server\Command\HelpCommand;
 use Valkyrja\Cli\Server\Command\ListBashCommand;
@@ -55,7 +56,7 @@ final class CliRouteProviderTest extends TestCase
         $container = new Container();
         $container->setSingleton(ListCommand::class, $command);
 
-        self::assertSame($output, CliRoutingCliRouteProvider::listHandler($container));
+        self::assertSame($output, CliRoutingCliRouteProvider::listHandler($container, self::createStub(RouteContract::class)));
     }
 
     /**
@@ -70,7 +71,7 @@ final class CliRouteProviderTest extends TestCase
         $container = new Container();
         $container->setSingleton(ListBashCommand::class, $command);
 
-        self::assertSame($output, CliRoutingCliRouteProvider::listBashHandler($container));
+        self::assertSame($output, CliRoutingCliRouteProvider::listBashHandler($container, self::createStub(RouteContract::class)));
     }
 
     /**
@@ -85,7 +86,7 @@ final class CliRouteProviderTest extends TestCase
         $container = new Container();
         $container->setSingleton(HelpCommand::class, $command);
 
-        self::assertSame($output, CliRoutingCliRouteProvider::helpHandler($container));
+        self::assertSame($output, CliRoutingCliRouteProvider::helpHandler($container, self::createStub(RouteContract::class)));
     }
 
     /**
@@ -100,6 +101,6 @@ final class CliRouteProviderTest extends TestCase
         $container = new Container();
         $container->setSingleton(VersionCommand::class, $command);
 
-        self::assertSame($output, CliRoutingCliRouteProvider::versionHandler($container));
+        self::assertSame($output, CliRoutingCliRouteProvider::versionHandler($container, self::createStub(RouteContract::class)));
     }
 }

--- a/tests/Tests/Unit/Http/Routing/Provider/CliRouteProviderTest.php
+++ b/tests/Tests/Unit/Http/Routing/Provider/CliRouteProviderTest.php
@@ -16,6 +16,7 @@ namespace Valkyrja\Tests\Unit\Http\Routing\Provider;
 use PHPUnit\Framework\MockObject\Exception;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Container\Manager\Container;
 use Valkyrja\Http\Routing\Cli\Command\ListCommand;
@@ -61,6 +62,6 @@ final class CliRouteProviderTest extends TestCase
         $container->setSingleton(RouteCollectionContract::class, $collection);
         $container->setSingleton(OutputFactoryContract::class, $outputFactory);
 
-        self::assertSame($output, HttpRoutingCliRouteProvider::listHandler($container));
+        self::assertSame($output, HttpRoutingCliRouteProvider::listHandler($container, self::createStub(RouteContract::class)));
     }
 }


### PR DESCRIPTION
# Description

Adds `RouteContract` as a second parameter to the CLI route handler callable signature, giving handlers direct access to the matched and dispatched route (including its parsed arguments and options).

Previously, handlers only received the container:

```php
callable(ContainerContract): OutputContract
```

Now they also receive the dispatched route:

```php
callable(ContainerContract, RouteContract): OutputContract
```

The router's `dispatchRoute()` method now passes the post-middleware route instance alongside the container when invoking the handler. All existing handlers and tests have been updated to match the new signature.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`Cli/Routing/Data/Contract/RouteContract.php`** — updated `getHandler()` return type and `withHandler()` parameter type to `callable(ContainerContract, self): OutputContract`
- **`Cli/Routing/Data/Route.php`** — updated `$handler` property type annotation to match new callable signature
- **`Cli/Routing/Attribute/Route.php`** — updated handler docblock type and default handler closure to accept `RouteContract`
- **`Cli/Routing/Dispatcher/Router.php`** — passes `$routeAfterMiddleware` as second argument when invoking the handler
- **`Cli/Routing/Provider/CliRoutingCliRouteProvider.php`** — updated all four handler signatures to accept `RouteContract $route`
- **`Http/Routing/Provider/HttpRoutingCliRouteProvider.php`** — updated `listHandler` signature to accept `RouteContract $route`
- **`tests/.../Command/CommandClass.php`** — updated handler signature
- **`tests/.../Command/CommandWithAllAttributesClass.php`** — updated handler signature
- **`tests/.../Command/CommandWithAllMiddlewareClass.php`** — updated handler signature
- **`tests/.../Entry/CliTest.php`** — updated `routeHandler` signature
- **`tests/.../Dispatcher/RouterTest.php`** — updated dispatch signature and added missing `ContainerContract` import
- **`tests/.../Provider/CliRouteProviderTest.php`** — updated handler calls to pass a `RouteContract` stub
- **`tests/.../Http/Routing/Provider/CliRouteProviderTest.php`** — updated handler call to pass a `RouteContract` stub