### PR TITLE
[View] Rename response factory

### DIFF
--- a/src/Valkyrja/Http/Server/Middleware/ThrowableCaught/ViewThrowableCaughtMiddleware.php
+++ b/src/Valkyrja/Http/Server/Middleware/ThrowableCaught/ViewThrowableCaughtMiddleware.php
@@ -19,8 +19,8 @@ use Valkyrja\Http\Message\Request\Contract\ServerRequestContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Middleware\Contract\ThrowableCaughtMiddlewareContract;
 use Valkyrja\Http\Middleware\Handler\Contract\ThrowableCaughtHandlerContract;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
-use Valkyrja\View\Factory\ResponseFactory;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+use Valkyrja\View\Factory\ViewResponseFactory;
 
 class ViewThrowableCaughtMiddleware implements ThrowableCaughtMiddlewareContract
 {
@@ -32,7 +32,7 @@ class ViewThrowableCaughtMiddleware implements ThrowableCaughtMiddlewareContract
     protected string $errorsTemplateDir = 'errors';
 
     public function __construct(
-        protected ResponseFactoryContract $viewResponseFactory = new ResponseFactory(),
+        protected ViewResponseFactoryContract $viewResponseFactory = new ViewResponseFactory(),
     ) {
     }
 

--- a/src/Valkyrja/Http/Server/Provider/HttpServerServiceProvider.php
+++ b/src/Valkyrja/Http/Server/Provider/HttpServerServiceProvider.php
@@ -33,7 +33,7 @@ use Valkyrja\Http\Server\Middleware\RouteNotMatched\ViewRouteNotMatchedMiddlewar
 use Valkyrja\Http\Server\Middleware\ThrowableCaught\LogThrowableCaughtMiddleware;
 use Valkyrja\Http\Server\Middleware\ThrowableCaught\ViewThrowableCaughtMiddleware;
 use Valkyrja\Log\Logger\Contract\LoggerContract;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 
 class HttpServerServiceProvider implements ServiceProviderContract
@@ -104,7 +104,7 @@ class HttpServerServiceProvider implements ServiceProviderContract
         $container->setSingleton(
             ViewThrowableCaughtMiddleware::class,
             new ViewThrowableCaughtMiddleware(
-                viewResponseFactory: $container->getSingleton(ResponseFactoryContract::class),
+                viewResponseFactory: $container->getSingleton(ViewResponseFactoryContract::class),
             )
         );
     }

--- a/src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php
+++ b/src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php
@@ -29,7 +29,7 @@ use Valkyrja\Orm\Data\Where;
 use Valkyrja\Orm\Entity\Contract\EntityContract;
 use Valkyrja\Orm\Manager\Contract\ManagerContract;
 use Valkyrja\Type\Contract\TypeContract;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 
 use function is_a;
 use function is_int;
@@ -47,7 +47,7 @@ class EntityRouteMatchedMiddleware implements RouteMatchedMiddlewareContract
     public function __construct(
         protected ContainerContract $container,
         protected ManagerContract $orm,
-        protected ResponseFactoryContract $responseFactory,
+        protected ViewResponseFactoryContract $responseFactory,
     ) {
     }
 

--- a/src/Valkyrja/View/Factory/Contract/ViewResponseFactoryContract.php
+++ b/src/Valkyrja/View/Factory/Contract/ViewResponseFactoryContract.php
@@ -17,7 +17,7 @@ use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Header\Collection\Contract\HeaderCollectionContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 
-interface ResponseFactoryContract
+interface ViewResponseFactoryContract
 {
     /**
      * View response builder.

--- a/src/Valkyrja/View/Factory/ViewResponseFactory.php
+++ b/src/Valkyrja/View/Factory/ViewResponseFactory.php
@@ -19,11 +19,11 @@ use Valkyrja\Http\Message\Header\Collection\Contract\HeaderCollectionContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactoryContract;
 use Valkyrja\Http\Message\Response\Factory\ResponseFactory as HttpMessageResponseFactory;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\PhpRenderer;
 
-class ResponseFactory implements ResponseFactoryContract
+class ViewResponseFactory implements ViewResponseFactoryContract
 {
     public function __construct(
         protected HttpMessageResponseFactoryContract $responseFactory = new HttpMessageResponseFactory(),

--- a/src/Valkyrja/View/Factory/ViewResponseFactory.php
+++ b/src/Valkyrja/View/Factory/ViewResponseFactory.php
@@ -17,8 +17,8 @@ use Override;
 use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Header\Collection\Contract\HeaderCollectionContract;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
-use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactoryContract;
-use Valkyrja\Http\Message\Response\Factory\ResponseFactory as HttpMessageResponseFactory;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\Http\Message\Response\Factory\ResponseFactory;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\PhpRenderer;
@@ -26,7 +26,7 @@ use Valkyrja\View\Renderer\PhpRenderer;
 class ViewResponseFactory implements ViewResponseFactoryContract
 {
     public function __construct(
-        protected HttpMessageResponseFactoryContract $responseFactory = new HttpMessageResponseFactory(),
+        protected ResponseFactoryContract $responseFactory = new ResponseFactory(),
         protected RendererContract $renderer = new PhpRenderer('resources/views')
     ) {
     }

--- a/src/Valkyrja/View/Provider/ViewServiceProvider.php
+++ b/src/Valkyrja/View/Provider/ViewServiceProvider.php
@@ -23,7 +23,7 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
-use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactory;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Factory\ViewResponseFactory;
 use Valkyrja\View\Orka\Constant\OrkaReplacement;
@@ -194,7 +194,7 @@ class ViewServiceProvider implements ServiceProviderContract
         $container->setSingleton(
             ViewResponseFactoryContract::class,
             new ViewResponseFactory(
-                $container->getSingleton(HttpMessageResponseFactory::class),
+                $container->getSingleton(ResponseFactoryContract::class),
                 $container->getSingleton(RendererContract::class)
             )
         );

--- a/src/Valkyrja/View/Provider/ViewServiceProvider.php
+++ b/src/Valkyrja/View/Provider/ViewServiceProvider.php
@@ -24,8 +24,8 @@ use Valkyrja\Application\Kernel\Contract\ApplicationContract;
 use Valkyrja\Container\Manager\Contract\ContainerContract;
 use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactory;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
-use Valkyrja\View\Factory\ResponseFactory;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+use Valkyrja\View\Factory\ViewResponseFactory;
 use Valkyrja\View\Orka\Constant\OrkaReplacement;
 use Valkyrja\View\Orka\Replacement\Contract\ReplacementContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
@@ -42,12 +42,12 @@ class ViewServiceProvider implements ServiceProviderContract
     public static function publishers(): array
     {
         return [
-            RendererContract::class        => [self::class, 'publishRenderer'],
-            PhpRenderer::class             => [self::class, 'publishPhpRenderer'],
-            OrkaRenderer::class            => [self::class, 'publishOrkaRenderer'],
-            TwigRenderer::class            => [self::class, 'publishTwigRenderer'],
-            Environment::class             => [self::class, 'publishTwigEnvironment'],
-            ResponseFactoryContract::class => [self::class, 'publishResponseFactory'],
+            RendererContract::class            => [self::class, 'publishRenderer'],
+            PhpRenderer::class                 => [self::class, 'publishPhpRenderer'],
+            OrkaRenderer::class                => [self::class, 'publishOrkaRenderer'],
+            TwigRenderer::class                => [self::class, 'publishTwigRenderer'],
+            Environment::class                 => [self::class, 'publishTwigEnvironment'],
+            ViewResponseFactoryContract::class => [self::class, 'publishResponseFactory'],
         ];
     }
 
@@ -192,8 +192,8 @@ class ViewServiceProvider implements ServiceProviderContract
     public static function publishResponseFactory(ContainerContract $container): void
     {
         $container->setSingleton(
-            ResponseFactoryContract::class,
-            new ResponseFactory(
+            ViewResponseFactoryContract::class,
+            new ViewResponseFactory(
                 $container->getSingleton(HttpMessageResponseFactory::class),
                 $container->getSingleton(RendererContract::class)
             )

--- a/tests/Tests/Classes/Application/Data/HttpTestContainerDataClass.php
+++ b/tests/Tests/Classes/Application/Data/HttpTestContainerDataClass.php
@@ -59,7 +59,7 @@ use Valkyrja\Log\Logger\PsrLogger;
 use Valkyrja\Log\Provider\LogServiceProvider;
 use Valkyrja\Tests\Classes\Application\Provider\HttpContainerDataProviderClass;
 use Valkyrja\Tests\Classes\Application\Provider\HttpRoutingDataProviderClass;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract as ViewResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Provider\ViewServiceProvider;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\OrkaRenderer;

--- a/tests/Tests/Unit/Http/Server/Middleware/ThrowableCaught/ViewExceptionMiddlewareTest.php
+++ b/tests/Tests/Unit/Http/Server/Middleware/ThrowableCaught/ViewExceptionMiddlewareTest.php
@@ -20,7 +20,7 @@ use Valkyrja\Http\Middleware\Handler\ThrowableCaughtHandler;
 use Valkyrja\Http\Server\Middleware\ThrowableCaught\ViewThrowableCaughtMiddleware;
 use Valkyrja\Tests\Classes\Throwable\Exception\ValkyrjaRuntimeExceptionClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\View\Factory\ResponseFactory;
+use Valkyrja\View\Factory\ViewResponseFactory;
 
 /**
  * Class ViewExceptionMiddlewareTest.
@@ -44,7 +44,7 @@ final class ViewExceptionMiddlewareTest extends TestCase
 
         $viewResponse = Response::create(content: $templateText, statusCode: $statusCode);
 
-        $view = $this->createMock(ResponseFactory::class);
+        $view = $this->createMock(ViewResponseFactory::class);
         $view->expects($this->once())
             ->method('createResponseFromView')
             ->with(

--- a/tests/Tests/Unit/Http/Server/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Http/Server/Provider/ServiceProviderTest.php
@@ -28,7 +28,7 @@ use Valkyrja\Http\Server\Middleware\ThrowableCaught\ViewThrowableCaughtMiddlewar
 use Valkyrja\Http\Server\Provider\HttpServerServiceProvider;
 use Valkyrja\Log\Logger\Contract\LoggerContract;
 use Valkyrja\PhpUnit\Abstract\ServiceProviderTestCase;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 
 /**
@@ -104,7 +104,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
     {
         $container = $this->container;
 
-        $container->setSingleton(ResponseFactoryContract::class, self::createStub(ResponseFactoryContract::class));
+        $container->setSingleton(ViewResponseFactoryContract::class, self::createStub(ViewResponseFactoryContract::class));
 
         $callback = HttpServerServiceProvider::publishers()[ViewThrowableCaughtMiddleware::class];
         $callback($this->container);

--- a/tests/Tests/Unit/Orm/Middleware/EntityRouteMatchedMiddlewareTest.php
+++ b/tests/Tests/Unit/Orm/Middleware/EntityRouteMatchedMiddlewareTest.php
@@ -32,7 +32,7 @@ use Valkyrja\Tests\Classes\Orm\Entity\EntityClass;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\Type\Data\Cast;
 use Valkyrja\Type\Enum\CastType;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 
 final class EntityRouteMatchedMiddlewareTest extends TestCase
 {
@@ -40,7 +40,7 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
 
     protected ManagerContract&MockObject $orm;
 
-    protected ResponseFactoryContract&MockObject $responseFactory;
+    protected ViewResponseFactoryContract&MockObject $responseFactory;
 
     protected EntityRouteMatchedMiddleware $middleware;
 
@@ -48,7 +48,7 @@ final class EntityRouteMatchedMiddlewareTest extends TestCase
     {
         $this->container       = $this->createMock(ContainerContract::class);
         $this->orm             = $this->createMock(ManagerContract::class);
-        $this->responseFactory = $this->createMock(ResponseFactoryContract::class);
+        $this->responseFactory = $this->createMock(ViewResponseFactoryContract::class);
 
         $this->middleware = new EntityRouteMatchedMiddleware(
             $this->container,

--- a/tests/Tests/Unit/View/Factory/ResponseFactoryTest.php
+++ b/tests/Tests/Unit/View/Factory/ResponseFactoryTest.php
@@ -20,8 +20,8 @@ use Valkyrja\Http\Message\Header\Header;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactoryContract;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
-use Valkyrja\View\Factory\ResponseFactory;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+use Valkyrja\View\Factory\ViewResponseFactory;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Template\Contract\TemplateContract;
 
@@ -35,9 +35,9 @@ final class ResponseFactoryTest extends TestCase
      */
     public function testImplementsContract(): void
     {
-        $factory = new ResponseFactory();
+        $factory = new ViewResponseFactory();
 
-        self::assertInstanceOf(ResponseFactoryContract::class, $factory);
+        self::assertInstanceOf(ViewResponseFactoryContract::class, $factory);
     }
 
     /**
@@ -67,7 +67,7 @@ final class ResponseFactoryTest extends TestCase
             ->with($templateContent, StatusCode::OK, null)
             ->willReturn($response);
 
-        $factory = new ResponseFactory($httpResponseFactory, $renderer);
+        $factory = new ViewResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName);
 
         self::assertSame($response, $result);
@@ -101,7 +101,7 @@ final class ResponseFactoryTest extends TestCase
             ->with($templateContent, StatusCode::OK, null)
             ->willReturn($response);
 
-        $factory = new ResponseFactory($httpResponseFactory, $renderer);
+        $factory = new ViewResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, $data);
 
         self::assertSame($response, $result);
@@ -135,7 +135,7 @@ final class ResponseFactoryTest extends TestCase
             ->with($templateContent, $statusCode, null)
             ->willReturn($response);
 
-        $factory = new ResponseFactory($httpResponseFactory, $renderer);
+        $factory = new ViewResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, statusCode: $statusCode);
 
         self::assertSame($response, $result);
@@ -169,7 +169,7 @@ final class ResponseFactoryTest extends TestCase
             ->with($templateContent, StatusCode::OK, $headers)
             ->willReturn($response);
 
-        $factory = new ResponseFactory($httpResponseFactory, $renderer);
+        $factory = new ViewResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, headers: $headers);
 
         self::assertSame($response, $result);
@@ -205,7 +205,7 @@ final class ResponseFactoryTest extends TestCase
             ->with($templateContent, $statusCode, $headers)
             ->willReturn($response);
 
-        $factory = new ResponseFactory($httpResponseFactory, $renderer);
+        $factory = new ViewResponseFactory($httpResponseFactory, $renderer);
         $result  = $factory->createResponseFromView($templateName, $data, $statusCode, $headers);
 
         self::assertSame($response, $result);

--- a/tests/Tests/Unit/View/Factory/ResponseFactoryTest.php
+++ b/tests/Tests/Unit/View/Factory/ResponseFactoryTest.php
@@ -18,7 +18,7 @@ use Valkyrja\Http\Message\Enum\StatusCode;
 use Valkyrja\Http\Message\Header\Collection\HeaderCollection;
 use Valkyrja\Http\Message\Header\Header;
 use Valkyrja\Http\Message\Response\Contract\ResponseContract;
-use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactoryContract;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Factory\ViewResponseFactory;
@@ -61,7 +61,7 @@ final class ResponseFactoryTest extends TestCase
 
         $response = self::createStub(ResponseContract::class);
 
-        $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
+        $httpResponseFactory = $this->createMock(ResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
             ->method('createResponse')
             ->with($templateContent, StatusCode::OK, null)
@@ -95,7 +95,7 @@ final class ResponseFactoryTest extends TestCase
 
         $response = self::createStub(ResponseContract::class);
 
-        $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
+        $httpResponseFactory = $this->createMock(ResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
             ->method('createResponse')
             ->with($templateContent, StatusCode::OK, null)
@@ -129,7 +129,7 @@ final class ResponseFactoryTest extends TestCase
 
         $response = self::createStub(ResponseContract::class);
 
-        $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
+        $httpResponseFactory = $this->createMock(ResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
             ->method('createResponse')
             ->with($templateContent, $statusCode, null)
@@ -163,7 +163,7 @@ final class ResponseFactoryTest extends TestCase
 
         $response = self::createStub(ResponseContract::class);
 
-        $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
+        $httpResponseFactory = $this->createMock(ResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
             ->method('createResponse')
             ->with($templateContent, StatusCode::OK, $headers)
@@ -199,7 +199,7 @@ final class ResponseFactoryTest extends TestCase
 
         $response = self::createStub(ResponseContract::class);
 
-        $httpResponseFactory = $this->createMock(HttpMessageResponseFactoryContract::class);
+        $httpResponseFactory = $this->createMock(ResponseFactoryContract::class);
         $httpResponseFactory->expects($this->once())
             ->method('createResponse')
             ->with($templateContent, $statusCode, $headers)

--- a/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
@@ -19,7 +19,7 @@ use Twig\Error\LoaderError;
 use Twig\Extension\DebugExtension;
 use Twig\Extension\ExtensionInterface;
 use Valkyrja\Application\Env\Env;
-use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactory;
+use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\PhpUnit\Abstract\ServiceProviderTestCase;
 use Valkyrja\Tests\EnvClass;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
@@ -133,7 +133,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
      */
     public function testPublishResponseFactory(): void
     {
-        $this->container->setSingleton(HttpMessageResponseFactory::class, self::createStub(HttpMessageResponseFactory::class));
+        $this->container->setSingleton(ResponseFactoryContract::class, self::createStub(ResponseFactoryContract::class));
         $this->container->setSingleton(RendererContract::class, self::createStub(RendererContract::class));
 
         $callback = ViewServiceProvider::publishers()[ViewResponseFactoryContract::class];

--- a/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
@@ -22,8 +22,8 @@ use Valkyrja\Application\Env\Env;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract as HttpMessageResponseFactory;
 use Valkyrja\PhpUnit\Abstract\ServiceProviderTestCase;
 use Valkyrja\Tests\EnvClass;
-use Valkyrja\View\Factory\Contract\ResponseFactoryContract;
-use Valkyrja\View\Factory\ResponseFactory;
+use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
+use Valkyrja\View\Factory\ViewResponseFactory;
 use Valkyrja\View\Provider\ViewServiceProvider;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\OrkaRenderer;
@@ -45,7 +45,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         self::assertArrayHasKey(OrkaRenderer::class, ViewServiceProvider::publishers());
         self::assertArrayHasKey(TwigRenderer::class, ViewServiceProvider::publishers());
         self::assertArrayHasKey(Environment::class, ViewServiceProvider::publishers());
-        self::assertArrayHasKey(ResponseFactoryContract::class, ViewServiceProvider::publishers());
+        self::assertArrayHasKey(ViewResponseFactoryContract::class, ViewServiceProvider::publishers());
     }
 
     /**
@@ -136,9 +136,9 @@ final class ServiceProviderTest extends ServiceProviderTestCase
         $this->container->setSingleton(HttpMessageResponseFactory::class, self::createStub(HttpMessageResponseFactory::class));
         $this->container->setSingleton(RendererContract::class, self::createStub(RendererContract::class));
 
-        $callback = ViewServiceProvider::publishers()[ResponseFactoryContract::class];
+        $callback = ViewServiceProvider::publishers()[ViewResponseFactoryContract::class];
         $callback($this->container);
 
-        self::assertInstanceOf(ResponseFactory::class, $this->container->getSingleton(ResponseFactoryContract::class));
+        self::assertInstanceOf(ViewResponseFactory::class, $this->container->getSingleton(ViewResponseFactoryContract::class));
     }
 }


### PR DESCRIPTION
## Description

Renames `ResponseFactoryContract` → `ViewResponseFactoryContract` and `ResponseFactory` → `ViewResponseFactory` in the `Valkyrja\View\Factory` namespace to avoid ambiguity with the HTTP-layer `ResponseFactoryContract` that lives alongside it in the same codebases.

All consumers — `ViewThrowableCaughtMiddleware`, `HttpServerServiceProvider`, `EntityRouteMatchedMiddleware`, `ViewServiceProvider`, and their tests — are updated to reference the new names.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`src/Valkyrja/View/Factory/Contract/ViewResponseFactoryContract.php`** — renamed from `ResponseFactoryContract`; interface name updated to match
- **`src/Valkyrja/View/Factory/ViewResponseFactory.php`** — renamed from `ResponseFactory`; class name and implemented interface updated to match
- **`src/Valkyrja/View/Provider/ViewServiceProvider.php`** — updated imports, publishers key, and `publishResponseFactory` to use the new names
- **`src/Valkyrja/Http/Server/Middleware/ThrowableCaught/ViewThrowableCaughtMiddleware.php`** — updated import and constructor type hint
- **`src/Valkyrja/Http/Server/Provider/HttpServerServiceProvider.php`** — updated import and container lookup in `publishViewThrowableCaughtMiddleware`
- **`src/Valkyrja/Orm/Middleware/EntityRouteMatchedMiddleware.php`** — updated import and constructor type hint
- **`tests/Tests/Classes/Application/Data/HttpTestContainerDataClass.php`** — removed aliased import; now uses `ViewResponseFactoryContract` directly
- **`tests/Tests/Unit/View/Factory/ResponseFactoryTest.php`** — updated all references to `ViewResponseFactory` and `ViewResponseFactoryContract`
- **`tests/Tests/Unit/View/Provider/ServiceProviderTest.php`** — updated publishers key assertions and singleton lookups
- **`tests/Tests/Unit/Http/Server/Middleware/ThrowableCaught/ViewExceptionMiddlewareTest.php`** — updated mock target to `ViewResponseFactory`
- **`tests/Tests/Unit/Http/Server/Provider/ServiceProviderTest.php`** — updated container stub registration to `ViewResponseFactoryContract`
- **`tests/Tests/Unit/Orm/Middleware/EntityRouteMatchedMiddlewareTest.php`** — updated mock type to `ViewResponseFactoryContract`