### PR TITLE
[Cli] Add Header banner message class and update all commands to use it

### DIFF
--- a/src/Valkyrja/Application/Constant/ApplicationInfo.php
+++ b/src/Valkyrja/Application/Constant/ApplicationInfo.php
@@ -42,4 +42,16 @@ final class ApplicationInfo
            \_/ \__,_|_|_|\_\\__, |_| _/ |\__,_|
                             |___/   |__/
         TEXT;
+
+    /**
+     * The default CLI banner icon (Valkyrie).
+     *
+     * @var non-empty-string
+     */
+    public const string ICON = <<<'ICON'
+        ▗▄▄▖     ▗▄▄▖
+        ▝▜██▄▄▄▄▄██▛▘
+           ▝▜███▛▘
+              █
+        ICON;
 }

--- a/src/Valkyrja/Cli/Interaction/Message/Header.php
+++ b/src/Valkyrja/Cli/Interaction/Message/Header.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Cli\Interaction\Message;
+
+use Override;
+use Valkyrja\Application\Constant\ApplicationInfo;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+
+use const PHP_VERSION;
+
+class Header extends Message
+{
+    public function __construct(
+        protected string $appName,
+        protected string $appVersion,
+        RouteContract $route,
+        protected string $icon              = ApplicationInfo::ICON,
+        protected string $valkyrjaVersion   = ApplicationInfo::VERSION,
+        protected string $valkyrjaBuildDate = ApplicationInfo::VERSION_BUILD_DATE_TIME,
+        protected string $phpVersion        = PHP_VERSION,
+        protected string $projectRoot       = '',
+        protected string $actionDescription = '',
+        protected string $commandName       = '',
+    ) {
+        parent::__construct('');
+
+        if ($this->projectRoot === '') {
+            $this->projectRoot = (string) getcwd();
+        }
+
+        if ($this->actionDescription === '') {
+            $this->actionDescription = $route->getDescription();
+        }
+
+        if ($this->commandName === '') {
+            $this->commandName = $route->getName();
+        }
+    }
+
+    public function withAppName(string $appName): static
+    {
+        $new          = clone $this;
+        $new->appName = $appName;
+
+        return $new;
+    }
+
+    public function withAppVersion(string $appVersion): static
+    {
+        $new             = clone $this;
+        $new->appVersion = $appVersion;
+
+        return $new;
+    }
+
+    public function withIcon(string $icon): static
+    {
+        $new       = clone $this;
+        $new->icon = $icon;
+
+        return $new;
+    }
+
+    public function withValkyrjaVersion(string $valkyrjaVersion): static
+    {
+        $new                  = clone $this;
+        $new->valkyrjaVersion = $valkyrjaVersion;
+
+        return $new;
+    }
+
+    public function withValkyrjaBuildDate(string $valkyrjaBuildDate): static
+    {
+        $new                    = clone $this;
+        $new->valkyrjaBuildDate = $valkyrjaBuildDate;
+
+        return $new;
+    }
+
+    public function withPhpVersion(string $phpVersion): static
+    {
+        $new             = clone $this;
+        $new->phpVersion = $phpVersion;
+
+        return $new;
+    }
+
+    public function withProjectRoot(string $projectRoot): static
+    {
+        $new              = clone $this;
+        $new->projectRoot = $projectRoot;
+
+        return $new;
+    }
+
+    public function withActionDescription(string $actionDescription): static
+    {
+        $new                    = clone $this;
+        $new->actionDescription = $actionDescription;
+
+        return $new;
+    }
+
+    public function withCommandName(string $commandName): static
+    {
+        $new              = clone $this;
+        $new->commandName = $commandName;
+
+        return $new;
+    }
+
+    #[Override]
+    public function getText(): string
+    {
+        $iconLines = array_map(
+            static fn(string $line): string => '│   ' . $line,
+            explode("\n", $this->icon)
+        );
+
+        return implode("\n", [
+            '╭── ' . $this->appName . ' v' . $this->appVersion,
+            '│',
+            ...$iconLines,
+            '│',
+            '│   Built on Valkyrja v' . $this->valkyrjaVersion . ' (date: ' . $this->valkyrjaBuildDate . ')',
+            '│   Running on PHP ' . $this->phpVersion,
+            '│   ' . $this->projectRoot,
+            '╰── ' . $this->actionDescription . ' · ' . $this->commandName,
+        ]);
+    }
+}

--- a/src/Valkyrja/Cli/Interaction/Message/Header.php
+++ b/src/Valkyrja/Cli/Interaction/Message/Header.php
@@ -124,7 +124,7 @@ class Header extends Message
     public function getText(): string
     {
         $iconLines = array_map(
-            static fn(string $line): string => '│   ' . $line,
+            static fn (string $line): string => '│   ' . $line,
             explode("\n", $this->icon)
         );
 

--- a/src/Valkyrja/Cli/Server/Command/HelpCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/HelpCommand.php
@@ -95,9 +95,14 @@ class HelpCommand
 
         $this->helpRoute = $this->collection->get($commandName);
 
+        /** @var string $namespace */
+        $namespace = $this->config->namespace;
+        /** @var string $version */
+        $version = $this->config->version;
+
         $output = $this->outputFactory
             ->createOutput()
-            ->withMessages(new Header($this->config->namespace, $this->config->version, $this->route));
+            ->withMessages(new Header($namespace, $version, $this->route));
 
         return $this->getHelpText($output);
     }

--- a/src/Valkyrja/Cli/Server/Command/HelpCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/HelpCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Server\Command;
 
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Enum\ExitCode;
 use Valkyrja\Cli\Interaction\Enum\TextColor;
 use Valkyrja\Cli\Interaction\Format\TextColorFormat;
@@ -21,6 +22,7 @@ use Valkyrja\Cli\Interaction\Formatter\HighlightedTextFormatter;
 use Valkyrja\Cli\Interaction\Message\Banner;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
 use Valkyrja\Cli\Interaction\Message\ErrorMessage;
+use Valkyrja\Cli\Interaction\Message\Header;
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\Messages;
 use Valkyrja\Cli\Interaction\Message\NewLine;
@@ -49,7 +51,7 @@ class HelpCommand
     protected RouteContract $helpRoute;
 
     public function __construct(
-        protected VersionCommand $version,
+        protected CliConfigContract $config,
         protected RouteContract $route,
         protected RouteCollectionContract $collection,
         protected OutputFactoryContract $outputFactory,
@@ -93,7 +95,9 @@ class HelpCommand
 
         $this->helpRoute = $this->collection->get($commandName);
 
-        $output = $this->version->run();
+        $output = $this->outputFactory
+            ->createOutput()
+            ->withMessages(new Header($this->config->namespace, $this->config->version, $this->route));
 
         return $this->getHelpText($output);
     }

--- a/src/Valkyrja/Cli/Server/Command/ListCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/ListCommand.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Valkyrja\Cli\Server\Command;
 
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Enum\ExitCode;
 use Valkyrja\Cli\Interaction\Enum\TextColor;
 use Valkyrja\Cli\Interaction\Format\TextColorFormat;
@@ -21,6 +22,7 @@ use Valkyrja\Cli\Interaction\Formatter\HighlightedTextFormatter;
 use Valkyrja\Cli\Interaction\Message\Banner;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
 use Valkyrja\Cli\Interaction\Message\ErrorMessage;
+use Valkyrja\Cli\Interaction\Message\Header;
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
@@ -36,7 +38,7 @@ use Valkyrja\Cli\Server\Constant\CommandName;
 class ListCommand
 {
     public function __construct(
-        protected VersionCommand $version,
+        protected CliConfigContract $config,
         protected RouteContract $route,
         protected RouteCollectionContract $collection,
         protected OutputFactoryContract $outputFactory
@@ -79,7 +81,9 @@ class ListCommand
 
         $this->sortRoutes($routes);
 
-        $output = $this->version->run();
+        $output = $this->outputFactory
+            ->createOutput()
+            ->withMessages(new Header($this->config->namespace, $this->config->version, $this->route));
 
         $output = $this->addHeaderMessages($output, $namespace);
         $output = $this->addRoutesMessages($output, $routes);

--- a/src/Valkyrja/Cli/Server/Command/ListCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/ListCommand.php
@@ -81,9 +81,14 @@ class ListCommand
 
         $this->sortRoutes($routes);
 
+        /** @var string $appNamespace */
+        $appNamespace = $this->config->namespace;
+        /** @var string $appVersion */
+        $appVersion = $this->config->version;
+
         $output = $this->outputFactory
             ->createOutput()
-            ->withMessages(new Header($this->config->namespace, $this->config->version, $this->route));
+            ->withMessages(new Header($appNamespace, $appVersion, $this->route));
 
         $output = $this->addHeaderMessages($output, $namespace);
         $output = $this->addRoutesMessages($output, $routes);

--- a/src/Valkyrja/Cli/Server/Command/VersionCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/VersionCommand.php
@@ -14,16 +14,17 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Server\Command;
 
 use Valkyrja\Application\Constant\ApplicationInfo;
-use Valkyrja\Cli\Interaction\Enum\TextColor;
-use Valkyrja\Cli\Interaction\Format\TextColorFormat;
-use Valkyrja\Cli\Interaction\Formatter\Formatter;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
+use Valkyrja\Cli\Interaction\Message\Header;
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Message\NewLine;
 use Valkyrja\Cli\Interaction\Output\Contract\OutputContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Routing\Attribute\OptionParameter;
 use Valkyrja\Cli\Routing\Attribute\Route;
 use Valkyrja\Cli\Routing\Attribute\Route\RouteHandler;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Routing\Provider\CliRoutingCliRouteProvider;
 use Valkyrja\Cli\Server\Constant\CommandName;
 
@@ -32,7 +33,9 @@ use const PHP_VERSION;
 class VersionCommand
 {
     public function __construct(
-        protected OutputFactoryContract $outputFactory
+        protected OutputFactoryContract $outputFactory,
+        protected CliConfigContract $config,
+        protected RouteContract $route,
     ) {
     }
 
@@ -49,29 +52,41 @@ class VersionCommand
         description: 'Get the application version',
         helpText: [self::class, 'help'],
     )]
+    #[OptionParameter(
+        name: 'short',
+        description: 'Output the version number only',
+        shortNames: ['s'],
+    )]
+    #[OptionParameter(
+        name: 'plain',
+        description: 'Output version info without the banner',
+        shortNames: ['p'],
+    )]
     #[RouteHandler([CliRoutingCliRouteProvider::class, 'versionHandler'])]
     public function run(): OutputContract
     {
+        if ($this->route->hasOption('short')) {
+            return $this->outputFactory
+                ->createOutput()
+                ->withMessages(new Message($this->config->version));
+        }
+
+        if ($this->route->hasOption('plain')) {
+            return $this->outputFactory
+                ->createOutput()
+                ->withMessages(
+                    new Message($this->config->namespace . ' v' . $this->config->version),
+                    new NewLine(),
+                    new Message('Built on Valkyrja v' . ApplicationInfo::VERSION . ' (date: ' . ApplicationInfo::VERSION_BUILD_DATE_TIME . ')'),
+                    new NewLine(),
+                    new Message('Running on PHP ' . PHP_VERSION),
+                );
+        }
+
         return $this->outputFactory
             ->createOutput()
             ->withMessages(
-                new Message(ApplicationInfo::ASCII),
-                new NewLine(),
-                new NewLine(),
-                new Message('Valkyrja Framework', new Formatter(new TextColorFormat(TextColor::CYAN))),
-                new Message(' version '),
-                new Message(ApplicationInfo::VERSION, new Formatter(new TextColorFormat(TextColor::MAGENTA))),
-                new Message(' (built: '),
-                new Message(ApplicationInfo::VERSION_BUILD_DATE_TIME, new Formatter(new TextColorFormat(TextColor::MAGENTA))),
-                new Message(')'),
-                new NewLine(),
-                new Message('Copyright (c) Melech Mizrachi'),
-                new NewLine(),
-                new Message('GitHub https://github.com/valkyrjaio/valkyrja'),
-                new NewLine(),
-                new Message('Running on PHP ' . PHP_VERSION),
-                new NewLine(),
-                new NewLine(),
+                new Header($this->config->namespace, $this->config->version, $this->route),
             );
     }
 }

--- a/src/Valkyrja/Cli/Server/Command/VersionCommand.php
+++ b/src/Valkyrja/Cli/Server/Command/VersionCommand.php
@@ -65,17 +65,22 @@ class VersionCommand
     #[RouteHandler([CliRoutingCliRouteProvider::class, 'versionHandler'])]
     public function run(): OutputContract
     {
+        /** @var string $namespace */
+        $namespace = $this->config->namespace;
+        /** @var string $version */
+        $version = $this->config->version;
+
         if ($this->route->hasOption('short')) {
             return $this->outputFactory
                 ->createOutput()
-                ->withMessages(new Message($this->config->version));
+                ->withMessages(new Message($version));
         }
 
         if ($this->route->hasOption('plain')) {
             return $this->outputFactory
                 ->createOutput()
                 ->withMessages(
-                    new Message($this->config->namespace . ' v' . $this->config->version),
+                    new Message($namespace . ' v' . $version),
                     new NewLine(),
                     new Message('Built on Valkyrja v' . ApplicationInfo::VERSION . ' (date: ' . ApplicationInfo::VERSION_BUILD_DATE_TIME . ')'),
                     new NewLine(),
@@ -86,7 +91,7 @@ class VersionCommand
         return $this->outputFactory
             ->createOutput()
             ->withMessages(
-                new Header($this->config->namespace, $this->config->version, $this->route),
+                new Header($namespace, $version, $this->route),
             );
     }
 }

--- a/src/Valkyrja/Cli/Server/Provider/CliServerServiceProvider.php
+++ b/src/Valkyrja/Cli/Server/Provider/CliServerServiceProvider.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Valkyrja\Cli\Server\Provider;
 
 use Override;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Application\Data\Contract\ConfigContract;
 use Valkyrja\Cli\Interaction\Data\Contract\CliInteractionConfigContract;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
@@ -98,7 +99,7 @@ class CliServerServiceProvider implements ServiceProviderContract
         $container->setSingleton(
             HelpCommand::class,
             new HelpCommand(
-                version: $container->getSingleton(VersionCommand::class),
+                config: $container->getSingleton(CliConfigContract::class),
                 route: $container->getSingleton(RouteContract::class),
                 collection: $container->getSingleton(RouteCollectionContract::class),
                 outputFactory: $container->getSingleton(OutputFactoryContract::class),
@@ -129,7 +130,7 @@ class CliServerServiceProvider implements ServiceProviderContract
         $container->setSingleton(
             ListCommand::class,
             new ListCommand(
-                version: $container->getSingleton(VersionCommand::class),
+                config: $container->getSingleton(CliConfigContract::class),
                 route: $container->getSingleton(RouteContract::class),
                 collection: $container->getSingleton(RouteCollectionContract::class),
                 outputFactory: $container->getSingleton(OutputFactoryContract::class),
@@ -146,6 +147,8 @@ class CliServerServiceProvider implements ServiceProviderContract
             VersionCommand::class,
             new VersionCommand(
                 outputFactory: $container->getSingleton(OutputFactoryContract::class),
+                config: $container->getSingleton(CliConfigContract::class),
+                route: $container->getSingleton(RouteContract::class),
             )
         );
     }

--- a/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
@@ -18,34 +18,15 @@ use Valkyrja\Cli\Interaction\Message\Header;
 use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
-use const PHP_VERSION;
-
 use function getcwd;
+
+use const PHP_VERSION;
 
 /**
  * Test the Header class.
  */
 final class HeaderTest extends TestCase
 {
-    private function makeRoute(
-        string $description = 'Run command',
-        string $name = 'cmd',
-        bool $expectDescriptionCall = true,
-        bool $expectNameCall = true,
-    ): RouteContract {
-        $route = $this->createMock(RouteContract::class);
-
-        $route->expects($expectDescriptionCall ? $this->once() : $this->never())
-            ->method('getDescription')
-            ->willReturn($description);
-
-        $route->expects($expectNameCall ? $this->once() : $this->never())
-            ->method('getName')
-            ->willReturn($name);
-
-        return $route;
-    }
-
     public function testDefaults(): void
     {
         $appName     = 'TestApp';
@@ -203,5 +184,24 @@ final class HeaderTest extends TestCase
         $header = new Header('App', '1.0.0', $this->makeRoute($description, $name));
 
         self::assertStringContainsString("╰── $description · $name", $header->getText());
+    }
+
+    private function makeRoute(
+        string $description = 'Run command',
+        string $name = 'cmd',
+        bool $expectDescriptionCall = true,
+        bool $expectNameCall = true,
+    ): RouteContract {
+        $route = $this->createMock(RouteContract::class);
+
+        $route->expects($expectDescriptionCall ? $this->once() : $this->never())
+            ->method('getDescription')
+            ->willReturn($description);
+
+        $route->expects($expectNameCall ? $this->once() : $this->never())
+            ->method('getName')
+            ->willReturn($name);
+
+        return $route;
     }
 }

--- a/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
@@ -27,11 +27,21 @@ use function getcwd;
  */
 final class HeaderTest extends TestCase
 {
-    private function makeRoute(string $description = 'Run command', string $name = 'cmd'): RouteContract
-    {
+    private function makeRoute(
+        string $description = 'Run command',
+        string $name = 'cmd',
+        bool $expectDescriptionCall = true,
+        bool $expectNameCall = true,
+    ): RouteContract {
         $route = $this->createMock(RouteContract::class);
-        $route->method('getDescription')->willReturn($description);
-        $route->method('getName')->willReturn($name);
+
+        $route->expects($expectDescriptionCall ? $this->once() : $this->never())
+            ->method('getDescription')
+            ->willReturn($description);
+
+        $route->expects($expectNameCall ? $this->once() : $this->never())
+            ->method('getName')
+            ->willReturn($name);
 
         return $route;
     }
@@ -69,7 +79,7 @@ final class HeaderTest extends TestCase
         $header = new Header(
             appName: $appName,
             appVersion: $appVersion,
-            route: $this->makeRoute(),
+            route: $this->makeRoute(expectDescriptionCall: false, expectNameCall: false),
             icon: $icon,
             valkyrjaVersion: $valkyrjaVersion,
             valkyrjaBuildDate: $valkyrjaBuildDate,
@@ -160,7 +170,7 @@ final class HeaderTest extends TestCase
 
     public function testWithActionDescription(): void
     {
-        $original = new Header('App', '1.0.0', $this->makeRoute(), actionDescription: 'Old action');
+        $original = new Header('App', '1.0.0', $this->makeRoute(expectDescriptionCall: false), actionDescription: 'Old action');
         $updated  = $original->withActionDescription('New action');
 
         self::assertNotSame($original, $updated);
@@ -170,7 +180,7 @@ final class HeaderTest extends TestCase
 
     public function testWithCommandName(): void
     {
-        $original = new Header('App', '1.0.0', $this->makeRoute(), commandName: 'old:cmd');
+        $original = new Header('App', '1.0.0', $this->makeRoute(expectNameCall: false), commandName: 'old:cmd');
         $updated  = $original->withCommandName('new:cmd');
 
         self::assertNotSame($original, $updated);

--- a/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
+++ b/tests/Tests/Unit/Cli/Interaction/Message/HeaderTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\Tests\Unit\Cli\Interaction\Message;
+
+use Valkyrja\Application\Constant\ApplicationInfo;
+use Valkyrja\Cli\Interaction\Message\Header;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
+use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+use const PHP_VERSION;
+
+use function getcwd;
+
+/**
+ * Test the Header class.
+ */
+final class HeaderTest extends TestCase
+{
+    private function makeRoute(string $description = 'Run command', string $name = 'cmd'): RouteContract
+    {
+        $route = $this->createMock(RouteContract::class);
+        $route->method('getDescription')->willReturn($description);
+        $route->method('getName')->willReturn($name);
+
+        return $route;
+    }
+
+    public function testDefaults(): void
+    {
+        $appName     = 'TestApp';
+        $appVersion  = '2.0.0';
+        $description = 'Run the test command';
+        $name        = 'test:run';
+
+        $header = new Header($appName, $appVersion, $this->makeRoute($description, $name));
+        $text   = $header->getText();
+
+        self::assertStringContainsString("╭── $appName v$appVersion", $text);
+        self::assertStringContainsString('│   ▗▄▄▖     ▗▄▄▖', $text);
+        self::assertStringContainsString('│   Built on Valkyrja v' . ApplicationInfo::VERSION, $text);
+        self::assertStringContainsString('│   Running on PHP ' . PHP_VERSION, $text);
+        self::assertStringContainsString('│   ' . (string) getcwd(), $text);
+        self::assertStringContainsString("╰── $description · $name", $text);
+    }
+
+    public function testExplicitSlots(): void
+    {
+        $appName           = 'MyApp';
+        $appVersion        = '3.1.0';
+        $icon              = 'custom-icon';
+        $valkyrjaVersion   = '99.0.0';
+        $valkyrjaBuildDate = 'January 1 2030';
+        $phpVersion        = '9.0.0';
+        $projectRoot       = '/custom/path';
+        $actionDescription = 'Custom action';
+        $commandName       = 'custom:cmd';
+
+        $header = new Header(
+            appName: $appName,
+            appVersion: $appVersion,
+            route: $this->makeRoute(),
+            icon: $icon,
+            valkyrjaVersion: $valkyrjaVersion,
+            valkyrjaBuildDate: $valkyrjaBuildDate,
+            phpVersion: $phpVersion,
+            projectRoot: $projectRoot,
+            actionDescription: $actionDescription,
+            commandName: $commandName,
+        );
+        $text = $header->getText();
+
+        self::assertStringContainsString("╭── $appName v$appVersion", $text);
+        self::assertStringContainsString('│   ' . $icon, $text);
+        self::assertStringContainsString("│   Built on Valkyrja v$valkyrjaVersion (date: $valkyrjaBuildDate)", $text);
+        self::assertStringContainsString("│   Running on PHP $phpVersion", $text);
+        self::assertStringContainsString("│   $projectRoot", $text);
+        self::assertStringContainsString("╰── $actionDescription · $commandName", $text);
+    }
+
+    public function testWithAppName(): void
+    {
+        $original = new Header('OldApp', '1.0.0', $this->makeRoute());
+        $updated  = $original->withAppName('NewApp');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('╭── OldApp v1.0.0', $original->getText());
+        self::assertStringContainsString('╭── NewApp v1.0.0', $updated->getText());
+    }
+
+    public function testWithAppVersion(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute());
+        $updated  = $original->withAppVersion('2.0.0');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('╭── App v1.0.0', $original->getText());
+        self::assertStringContainsString('╭── App v2.0.0', $updated->getText());
+    }
+
+    public function testWithIcon(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), icon: 'old-icon');
+        $updated  = $original->withIcon('new-icon');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('│   old-icon', $original->getText());
+        self::assertStringContainsString('│   new-icon', $updated->getText());
+    }
+
+    public function testWithValkyrjaVersion(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), valkyrjaVersion: '10.0.0');
+        $updated  = $original->withValkyrjaVersion('20.0.0');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('Built on Valkyrja v10.0.0', $original->getText());
+        self::assertStringContainsString('Built on Valkyrja v20.0.0', $updated->getText());
+    }
+
+    public function testWithValkyrjaBuildDate(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), valkyrjaBuildDate: 'Jan 1 2025');
+        $updated  = $original->withValkyrjaBuildDate('Jan 1 2030');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('(date: Jan 1 2025)', $original->getText());
+        self::assertStringContainsString('(date: Jan 1 2030)', $updated->getText());
+    }
+
+    public function testWithPhpVersion(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), phpVersion: '8.4.0');
+        $updated  = $original->withPhpVersion('9.0.0');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('Running on PHP 8.4.0', $original->getText());
+        self::assertStringContainsString('Running on PHP 9.0.0', $updated->getText());
+    }
+
+    public function testWithProjectRoot(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), projectRoot: '/old/path');
+        $updated  = $original->withProjectRoot('/new/path');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('│   /old/path', $original->getText());
+        self::assertStringContainsString('│   /new/path', $updated->getText());
+    }
+
+    public function testWithActionDescription(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), actionDescription: 'Old action');
+        $updated  = $original->withActionDescription('New action');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('╰── Old action ·', $original->getText());
+        self::assertStringContainsString('╰── New action ·', $updated->getText());
+    }
+
+    public function testWithCommandName(): void
+    {
+        $original = new Header('App', '1.0.0', $this->makeRoute(), commandName: 'old:cmd');
+        $updated  = $original->withCommandName('new:cmd');
+
+        self::assertNotSame($original, $updated);
+        self::assertStringContainsString('· old:cmd', $original->getText());
+        self::assertStringContainsString('· new:cmd', $updated->getText());
+    }
+
+    public function testProjectRootFallsBackToGetcwd(): void
+    {
+        $header = new Header('App', '1.0.0', $this->makeRoute());
+
+        self::assertStringContainsString('│   ' . (string) getcwd(), $header->getText());
+    }
+
+    public function testActionDescriptionAndCommandNameFromRoute(): void
+    {
+        $description = 'Specific description';
+        $name        = 'specific:name';
+
+        $header = new Header('App', '1.0.0', $this->makeRoute($description, $name));
+
+        self::assertStringContainsString("╰── $description · $name", $header->getText());
+    }
+}

--- a/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
@@ -39,7 +39,7 @@ final class HelpCommandTest extends TestCase
     private function makeOutputFactory(): OutputFactoryContract
     {
         $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
 
         return $outputFactory;
     }

--- a/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
@@ -13,11 +13,12 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Cli\Server\Command;
 
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Cli\Interaction\Enum\ExitCode;
 use Valkyrja\Cli\Interaction\Message\Contract\MessageContract;
 use Valkyrja\Cli\Interaction\Message\Message;
 use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
-use Valkyrja\Cli\Interaction\Output\Output;
+use Valkyrja\Cli\Interaction\Output\PlainOutput;
 use Valkyrja\Cli\Routing\Collection\Contract\RouteCollectionContract;
 use Valkyrja\Cli\Routing\Data\ArgumentParameter;
 use Valkyrja\Cli\Routing\Data\Contract\OptionParameterContract;
@@ -28,16 +29,25 @@ use Valkyrja\Cli\Routing\Enum\ArgumentValueMode;
 use Valkyrja\Cli\Routing\Enum\OptionMode;
 use Valkyrja\Cli\Routing\Enum\OptionValueMode;
 use Valkyrja\Cli\Server\Command\HelpCommand;
-use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
+
+use function ob_get_clean;
+use function ob_start;
 
 final class HelpCommandTest extends TestCase
 {
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
+    }
+
     public function testRunWithNonExistentCommandName(): void
     {
         $commandName = 'foo';
 
-        $output = new Output();
         $option = $this->createMock(OptionParameterContract::class);
         $option->expects($this->once())
             ->method('getFirstValue')
@@ -54,19 +64,12 @@ final class HelpCommandTest extends TestCase
             ->willReturn(false);
         $collection->expects($this->never())
             ->method('get');
-        $version = $this->createMock(VersionCommand::class);
-        $version->expects($this->never())
-            ->method('run');
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->once())
-            ->method('createOutput')
-            ->willReturn($output);
 
         $helpCommand   = new HelpCommand(
-            version: $version,
+            config: new CliConfig(),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $this->makeOutputFactory(),
         );
         $outputFromRun = $helpCommand->run();
 
@@ -80,10 +83,10 @@ final class HelpCommandTest extends TestCase
 
     public function testRun(): void
     {
+        $appName     = 'TestApp';
+        $appVersion  = '1.0.0';
         $commandName = 'foo';
         $description = 'description here';
-        $versionText = 'Version Command Output';
-        $helpText    = 'Help Command Output';
         $helpRoute   = new Route(
             name: $commandName,
             description: $description,
@@ -127,7 +130,6 @@ final class HelpCommandTest extends TestCase
             ]
         );
 
-        $output = new Output();
         $option = $this->createMock(OptionParameterContract::class);
         $option->expects($this->once())
             ->method('getFirstValue')
@@ -137,6 +139,12 @@ final class HelpCommandTest extends TestCase
             ->method('getOption')
             ->with('command')
             ->willReturn($option);
+        $route->expects($this->once())
+            ->method('getDescription')
+            ->willReturn('Help for a command');
+        $route->expects($this->once())
+            ->method('getName')
+            ->willReturn('help');
         $collection = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('has')
@@ -146,19 +154,12 @@ final class HelpCommandTest extends TestCase
             ->method('get')
             ->with($commandName)
             ->willReturn($helpRoute);
-        $version = $this->createMock(VersionCommand::class);
-        $version->expects($this->once())
-            ->method('run')
-            ->willReturn($output->withMessages(new Message($versionText)));
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->never())
-            ->method('createOutput');
 
         $helpCommand   = new HelpCommand(
-            version: $version,
+            config: new CliConfig(namespace: $appName, version: $appVersion),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $this->makeOutputFactory(),
         );
         $outputFromRun = $helpCommand->run();
 
@@ -167,11 +168,11 @@ final class HelpCommandTest extends TestCase
         $obOutput = ob_get_clean();
 
         self::assertSame(ExitCode::SUCCESS, $outputFromRun->getExitCode());
+        self::assertStringContainsString("╭── $appName v$appVersion", $obOutput);
         self::assertStringContainsString('foo [options] [global options] [argument1] [argument2...]', $obOutput);
-        self::assertStringContainsString($versionText, $obOutput);
         self::assertStringContainsString($commandName, $obOutput);
         self::assertStringContainsString($description, $obOutput);
-        self::assertStringContainsString($helpText, $obOutput);
+        self::assertStringContainsString('Help Command Output', $obOutput);
         self::assertStringContainsString('argument1', $obOutput);
         self::assertStringContainsString('Argument 1 description', $obOutput);
         self::assertStringContainsString('argument2', $obOutput);
@@ -196,18 +197,17 @@ final class HelpCommandTest extends TestCase
 
     public function testRunWithNoHelpText(): void
     {
+        $appName     = 'TestApp';
+        $appVersion  = '1.0.0';
         $commandName = 'bar';
         $description = 'command without help text';
-        $versionText = 'Version Command Output';
 
-        // Create a route WITHOUT helpText to trigger line 199 (return new Messages())
         $helpRoute = new Route(
             name: $commandName,
             description: $description,
             handler: static fn (): null => null,
         );
 
-        $output = new Output();
         $option = $this->createMock(OptionParameterContract::class);
         $option->expects($this->once())
             ->method('getFirstValue')
@@ -217,6 +217,12 @@ final class HelpCommandTest extends TestCase
             ->method('getOption')
             ->with('command')
             ->willReturn($option);
+        $route->expects($this->once())
+            ->method('getDescription')
+            ->willReturn('Help for a command');
+        $route->expects($this->once())
+            ->method('getName')
+            ->willReturn('help');
         $collection = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('has')
@@ -226,19 +232,12 @@ final class HelpCommandTest extends TestCase
             ->method('get')
             ->with($commandName)
             ->willReturn($helpRoute);
-        $version = $this->createMock(VersionCommand::class);
-        $version->expects($this->once())
-            ->method('run')
-            ->willReturn($output->withMessages(new Message($versionText)));
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->never())
-            ->method('createOutput');
 
         $helpCommand   = new HelpCommand(
-            version: $version,
+            config: new CliConfig(namespace: $appName, version: $appVersion),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $this->makeOutputFactory(),
         );
         $outputFromRun = $helpCommand->run();
 
@@ -247,10 +246,9 @@ final class HelpCommandTest extends TestCase
         $obOutput = ob_get_clean();
 
         self::assertSame(ExitCode::SUCCESS, $outputFromRun->getExitCode());
-        self::assertStringContainsString($versionText, $obOutput);
+        self::assertStringContainsString("╭── $appName v$appVersion", $obOutput);
         self::assertStringContainsString($commandName, $obOutput);
         self::assertStringContainsString($description, $obOutput);
-        // Should NOT contain "Help:" section since there's no help text
         self::assertStringNotContainsString('Help:', $obOutput);
     }
 

--- a/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/HelpCommandTest.php
@@ -36,14 +36,6 @@ use function ob_start;
 
 final class HelpCommandTest extends TestCase
 {
-    private function makeOutputFactory(): OutputFactoryContract
-    {
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
-
-        return $outputFactory;
-    }
-
     public function testRunWithNonExistentCommandName(): void
     {
         $commandName = 'foo';
@@ -266,5 +258,13 @@ final class HelpCommandTest extends TestCase
     public function getHelpText(): MessageContract
     {
         return new Message(text: 'Help Command Output');
+    }
+
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
     }
 }

--- a/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
@@ -30,7 +30,7 @@ final class ListCommandTest extends TestCase
     private function makeOutputFactory(): OutputFactoryContract
     {
         $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
 
         return $outputFactory;
     }

--- a/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
@@ -27,14 +27,6 @@ use function ob_start;
 
 final class ListCommandTest extends TestCase
 {
-    private function makeOutputFactory(): OutputFactoryContract
-    {
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
-
-        return $outputFactory;
-    }
-
     public function testRunWithNoRoutes(): void
     {
         $outputFactory = $this->makeOutputFactory();
@@ -248,5 +240,13 @@ final class ListCommandTest extends TestCase
 
         self::assertSame($text, ListCommand::help()->getText());
         self::assertSame($text, ListCommand::help()->getFormattedText());
+    }
+
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
     }
 }

--- a/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/ListCommandTest.php
@@ -13,14 +13,13 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Cli\Server\Command;
 
-use Valkyrja\Cli\Interaction\Message\Message;
-use Valkyrja\Cli\Interaction\Output\Factory\OutputFactory;
-use Valkyrja\Cli\Interaction\Output\Output;
+use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Interaction\Output\PlainOutput;
 use Valkyrja\Cli\Routing\Collection\Contract\RouteCollectionContract;
 use Valkyrja\Cli\Routing\Data\OptionParameter;
 use Valkyrja\Cli\Routing\Data\Route;
 use Valkyrja\Cli\Server\Command\ListCommand;
-use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 use function ob_get_clean;
@@ -28,17 +27,18 @@ use function ob_start;
 
 final class ListCommandTest extends TestCase
 {
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
+    }
+
     public function testRunWithNoRoutes(): void
     {
-        $output        = new Output();
-        $outputFactory = $this->createMock(OutputFactory::class);
-        $outputFactory->expects($this->once())
-            ->method('createOutput')
-            ->willReturn($output);
-        $versionCommand = $this->createMock(VersionCommand::class);
-        $versionCommand->expects($this->never())
-            ->method('run');
-        $collection = $this->createMock(RouteCollectionContract::class);
+        $outputFactory = $this->makeOutputFactory();
+        $collection    = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('all')
             ->willReturn([]);
@@ -50,10 +50,10 @@ final class ListCommandTest extends TestCase
             ->method('getOption');
 
         $command = new ListCommand(
-            version: $versionCommand,
+            config: new CliConfig(),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $outputFactory,
         );
 
         $outputFromRun = $command->run();
@@ -67,15 +67,8 @@ final class ListCommandTest extends TestCase
 
     public function testRunNonExistentNamespace(): void
     {
-        $output        = new Output();
-        $outputFactory = $this->createMock(OutputFactory::class);
-        $outputFactory->expects($this->once())
-            ->method('createOutput')
-            ->willReturn($output);
-        $versionCommand = $this->createMock(VersionCommand::class);
-        $versionCommand->expects($this->never())
-            ->method('run');
-        $collection = $this->createMock(RouteCollectionContract::class);
+        $outputFactory = $this->makeOutputFactory();
+        $collection    = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('all')
             ->willReturn([]);
@@ -92,10 +85,10 @@ final class ListCommandTest extends TestCase
             ->willReturn($option);
 
         $command = new ListCommand(
-            version: $versionCommand,
+            config: new CliConfig(),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $outputFactory,
         );
 
         $outputFromRun = $command->run();
@@ -109,6 +102,9 @@ final class ListCommandTest extends TestCase
 
     public function testRun(): void
     {
+        $appName    = 'TestApp';
+        $appVersion = '1.0.0';
+
         $listRouteName        = 'Route1name';
         $listRouteDescription = 'Route 1 description';
         $listRoute            = $this->createMock(Route::class);
@@ -129,16 +125,8 @@ final class ListCommandTest extends TestCase
             ->method('getDescription')
             ->willReturn($listRoute2Description);
 
-        $versionText   = 'Version Command Output';
-        $output        = new Output();
-        $outputFactory = $this->createMock(OutputFactory::class);
-        $outputFactory->expects($this->never())
-            ->method('createOutput');
-        $versionCommand = $this->createMock(VersionCommand::class);
-        $versionCommand->expects($this->once())
-            ->method('run')
-            ->willReturn($output->withMessages(new Message($versionText)));
-        $collection = $this->createMock(RouteCollectionContract::class);
+        $outputFactory = $this->makeOutputFactory();
+        $collection    = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('all')
             ->willReturn([$listRoute, $listRoute2]);
@@ -148,12 +136,18 @@ final class ListCommandTest extends TestCase
             ->willReturn(false);
         $route->expects($this->never())
             ->method('getOption');
+        $route->expects($this->once())
+            ->method('getDescription')
+            ->willReturn('List all commands');
+        $route->expects($this->once())
+            ->method('getName')
+            ->willReturn('list');
 
         $command = new ListCommand(
-            version: $versionCommand,
+            config: new CliConfig(namespace: $appName, version: $appVersion),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $outputFactory,
         );
 
         $outputFromRun = $command->run();
@@ -162,7 +156,7 @@ final class ListCommandTest extends TestCase
         $outputFromRun->writeMessages();
         $obOutput = ob_get_clean();
 
-        self::assertStringContainsString($versionText, $obOutput);
+        self::assertStringContainsString("╭── $appName v$appVersion", $obOutput);
         self::assertStringContainsString('Commands:', $obOutput);
         self::assertStringContainsString($listRouteName, $obOutput);
         self::assertStringContainsString($listRouteDescription, $obOutput);
@@ -172,7 +166,9 @@ final class ListCommandTest extends TestCase
 
     public function testRunWithNamespace(): void
     {
-        $namespace = 'namespace';
+        $appName    = 'TestApp';
+        $appVersion = '1.0.0';
+        $namespace  = 'namespace';
 
         $listRouteName        = "$namespace:Route1name";
         $listRouteDescription = 'Route 1 description';
@@ -202,16 +198,8 @@ final class ListCommandTest extends TestCase
         $listRoute3->expects($this->never())
             ->method('getDescription');
 
-        $versionText   = 'Version Command Output';
-        $output        = new Output();
-        $outputFactory = $this->createMock(OutputFactory::class);
-        $outputFactory->expects($this->never())
-            ->method('createOutput');
-        $versionCommand = $this->createMock(VersionCommand::class);
-        $versionCommand->expects($this->once())
-            ->method('run')
-            ->willReturn($output->withMessages(new Message($versionText)));
-        $collection = $this->createMock(RouteCollectionContract::class);
+        $outputFactory = $this->makeOutputFactory();
+        $collection    = $this->createMock(RouteCollectionContract::class);
         $collection->expects($this->once())
             ->method('all')
             ->willReturn([$listRoute, $listRoute2, $listRoute3]);
@@ -226,12 +214,18 @@ final class ListCommandTest extends TestCase
         $route->expects($this->once())
             ->method('getOption')
             ->willReturn($option);
+        $route->expects($this->once())
+            ->method('getDescription')
+            ->willReturn('List all commands');
+        $route->expects($this->once())
+            ->method('getName')
+            ->willReturn('list');
 
         $command = new ListCommand(
-            version: $versionCommand,
+            config: new CliConfig(namespace: $appName, version: $appVersion),
             route: $route,
             collection: $collection,
-            outputFactory: $outputFactory
+            outputFactory: $outputFactory,
         );
 
         $outputFromRun = $command->run();
@@ -240,7 +234,7 @@ final class ListCommandTest extends TestCase
         $outputFromRun->writeMessages();
         $obOutput = ob_get_clean();
 
-        self::assertStringContainsString($versionText, $obOutput);
+        self::assertStringContainsString("╭── $appName v$appVersion", $obOutput);
         self::assertStringContainsString("Commands [$namespace]:", $obOutput);
         self::assertStringContainsString($listRouteName, $obOutput);
         self::assertStringContainsString($listRouteDescription, $obOutput);

--- a/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
@@ -22,43 +22,13 @@ use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
-use const PHP_VERSION;
-
 use function ob_get_clean;
 use function ob_start;
 
+use const PHP_VERSION;
+
 final class VersionCommandTest extends TestCase
 {
-    private function makeRoute(bool $isShort = false, bool $isPlain = false): RouteContract
-    {
-        $route = $this->createMock(RouteContract::class);
-
-        $route->expects($this->exactly($isShort ? 1 : 2))
-            ->method('hasOption')
-            ->willReturnMap([
-                ['short', $isShort],
-                ['plain', $isPlain],
-            ]);
-
-        if (! $isShort && ! $isPlain) {
-            $route->expects($this->once())->method('getDescription')->willReturn('Get the application version');
-            $route->expects($this->once())->method('getName')->willReturn('version');
-        } else {
-            $route->expects($this->never())->method('getDescription');
-            $route->expects($this->never())->method('getName');
-        }
-
-        return $route;
-    }
-
-    private function makeOutputFactory(): OutputFactoryContract
-    {
-        $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
-
-        return $outputFactory;
-    }
-
     public function testRun(): void
     {
         $appName    = 'TestApp';
@@ -130,5 +100,35 @@ final class VersionCommandTest extends TestCase
 
         self::assertSame($text, VersionCommand::help()->getText());
         self::assertSame($text, VersionCommand::help()->getFormattedText());
+    }
+
+    private function makeRoute(bool $isShort = false, bool $isPlain = false): RouteContract
+    {
+        $route = $this->createMock(RouteContract::class);
+
+        $route->expects($this->exactly($isShort ? 1 : 2))
+            ->method('hasOption')
+            ->willReturnMap([
+                ['short', $isShort],
+                ['plain', $isPlain],
+            ]);
+
+        if (! $isShort && ! $isPlain) {
+            $route->expects($this->once())->method('getDescription')->willReturn('Get the application version');
+            $route->expects($this->once())->method('getName')->willReturn('version');
+        } else {
+            $route->expects($this->never())->method('getDescription');
+            $route->expects($this->never())->method('getName');
+        }
+
+        return $route;
+    }
+
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
     }
 }

--- a/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
@@ -14,39 +14,110 @@ declare(strict_types=1);
 namespace Valkyrja\Tests\Unit\Cli\Server\Command;
 
 use Valkyrja\Application\Constant\ApplicationInfo;
-use Valkyrja\Cli\Interaction\Message\NewLine;
-use Valkyrja\Cli\Interaction\Output\Factory\OutputFactory;
+use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Cli\Interaction\Message\Header;
+use Valkyrja\Cli\Interaction\Output\Factory\Contract\OutputFactoryContract;
+use Valkyrja\Cli\Interaction\Output\PlainOutput;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Tests\Unit\Abstract\TestCase;
 
 use const PHP_VERSION;
 
+use function ob_get_clean;
+use function ob_start;
+
 final class VersionCommandTest extends TestCase
 {
+    private function makeRoute(bool $isShort = false, bool $isPlain = false): RouteContract
+    {
+        $route = $this->createMock(RouteContract::class);
+
+        $route->method('hasOption')
+            ->willReturnMap([
+                ['short', $isShort],
+                ['plain', $isPlain],
+            ]);
+
+        if (! $isShort && ! $isPlain) {
+            $route->method('getDescription')->willReturn('Get the application version');
+            $route->method('getName')->willReturn('version');
+        }
+
+        return $route;
+    }
+
+    private function makeOutputFactory(): OutputFactoryContract
+    {
+        $outputFactory = $this->createMock(OutputFactoryContract::class);
+        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+
+        return $outputFactory;
+    }
+
     public function testRun(): void
     {
-        $outputFactory = new OutputFactory();
-        $command       = new VersionCommand($outputFactory);
+        $appName    = 'TestApp';
+        $appVersion = '2.0.0';
 
-        $output = $command->run();
+        $command = new VersionCommand(
+            $this->makeOutputFactory(),
+            new CliConfig(namespace: $appName, version: $appVersion),
+            $this->makeRoute(),
+        );
+        $output  = $command->run();
 
-        self::assertSame(ApplicationInfo::ASCII, $output->getMessages()[0]->getText());
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[1]);
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[2]);
-        self::assertSame('Valkyrja Framework', $output->getMessages()[3]->getText());
-        self::assertSame(' version ', $output->getMessages()[4]->getText());
-        self::assertSame(ApplicationInfo::VERSION, $output->getMessages()[5]->getText());
-        self::assertSame(' (built: ', $output->getMessages()[6]->getText());
-        self::assertSame(ApplicationInfo::VERSION_BUILD_DATE_TIME, $output->getMessages()[7]->getText());
-        self::assertSame(')', $output->getMessages()[8]->getText());
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[9]);
-        self::assertSame('Copyright (c) Melech Mizrachi', $output->getMessages()[10]->getText());
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[11]);
-        self::assertSame('GitHub https://github.com/valkyrjaio/valkyrja', $output->getMessages()[12]->getText());
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[13]);
-        self::assertSame('Running on PHP ' . PHP_VERSION, $output->getMessages()[14]->getText());
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[15]);
-        self::assertInstanceOf(NewLine::class, $output->getMessages()[16]);
+        self::assertInstanceOf(Header::class, $output->getMessages()[0]);
+
+        ob_start();
+        $output->writeMessages();
+        $obOutput = ob_get_clean();
+
+        self::assertStringContainsString("╭── $appName v$appVersion", $obOutput);
+        self::assertStringContainsString('│   Built on Valkyrja v' . ApplicationInfo::VERSION, $obOutput);
+        self::assertStringContainsString('│   Running on PHP ' . PHP_VERSION, $obOutput);
+    }
+
+    public function testRunShort(): void
+    {
+        $appVersion = '3.0.0';
+
+        $command = new VersionCommand(
+            $this->makeOutputFactory(),
+            new CliConfig(namespace: 'App', version: $appVersion),
+            $this->makeRoute(isShort: true),
+        );
+        $output  = $command->run();
+
+        ob_start();
+        $output->writeMessages();
+        $obOutput = ob_get_clean();
+
+        self::assertStringContainsString($appVersion, $obOutput);
+        self::assertStringNotContainsString('╭──', $obOutput);
+        self::assertStringNotContainsString('Built on Valkyrja', $obOutput);
+    }
+
+    public function testRunPlain(): void
+    {
+        $appName    = 'PlainApp';
+        $appVersion = '4.0.0';
+
+        $command = new VersionCommand(
+            $this->makeOutputFactory(),
+            new CliConfig(namespace: $appName, version: $appVersion),
+            $this->makeRoute(isPlain: true),
+        );
+        $output  = $command->run();
+
+        ob_start();
+        $output->writeMessages();
+        $obOutput = ob_get_clean();
+
+        self::assertStringContainsString("$appName v$appVersion", $obOutput);
+        self::assertStringContainsString('Built on Valkyrja v' . ApplicationInfo::VERSION, $obOutput);
+        self::assertStringContainsString('Running on PHP ' . PHP_VERSION, $obOutput);
+        self::assertStringNotContainsString('╭──', $obOutput);
     }
 
     public function testHelp(): void

--- a/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
+++ b/tests/Tests/Unit/Cli/Server/Command/VersionCommandTest.php
@@ -33,15 +33,19 @@ final class VersionCommandTest extends TestCase
     {
         $route = $this->createMock(RouteContract::class);
 
-        $route->method('hasOption')
+        $route->expects($this->exactly($isShort ? 1 : 2))
+            ->method('hasOption')
             ->willReturnMap([
                 ['short', $isShort],
                 ['plain', $isPlain],
             ]);
 
         if (! $isShort && ! $isPlain) {
-            $route->method('getDescription')->willReturn('Get the application version');
-            $route->method('getName')->willReturn('version');
+            $route->expects($this->once())->method('getDescription')->willReturn('Get the application version');
+            $route->expects($this->once())->method('getName')->willReturn('version');
+        } else {
+            $route->expects($this->never())->method('getDescription');
+            $route->expects($this->never())->method('getName');
         }
 
         return $route;
@@ -50,7 +54,7 @@ final class VersionCommandTest extends TestCase
     private function makeOutputFactory(): OutputFactoryContract
     {
         $outputFactory = $this->createMock(OutputFactoryContract::class);
-        $outputFactory->method('createOutput')->willReturn(new PlainOutput());
+        $outputFactory->expects($this->once())->method('createOutput')->willReturn(new PlainOutput());
 
         return $outputFactory;
     }

--- a/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/Cli/Server/Provider/ServiceProviderTest.php
@@ -15,6 +15,8 @@ namespace Valkyrja\Tests\Unit\Cli\Server\Provider;
 
 use PHPUnit\Framework\MockObject\Exception;
 use ReflectionProperty;
+use Valkyrja\Application\Data\CliConfig;
+use Valkyrja\Application\Data\Contract\CliConfigContract;
 use Valkyrja\Application\Data\Contract\ConfigContract;
 use Valkyrja\Cli\Interaction\Data\CliInteractionConfig;
 use Valkyrja\Cli\Interaction\Data\Contract\CliInteractionConfigContract;
@@ -87,7 +89,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
      */
     public function testPublishHelpCommand(): void
     {
-        $this->container->setSingleton(VersionCommand::class, self::createStub(VersionCommand::class));
+        $this->container->setSingleton(CliConfigContract::class, new CliConfig());
         $this->container->setSingleton(RouteContract::class, self::createStub(RouteContract::class));
         $this->container->setSingleton(RouteCollectionContract::class, self::createStub(RouteCollectionContract::class));
         $this->container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
@@ -118,7 +120,7 @@ final class ServiceProviderTest extends ServiceProviderTestCase
      */
     public function testPublishListCommand(): void
     {
-        $this->container->setSingleton(VersionCommand::class, self::createStub(VersionCommand::class));
+        $this->container->setSingleton(CliConfigContract::class, new CliConfig());
         $this->container->setSingleton(RouteContract::class, self::createStub(RouteContract::class));
         $this->container->setSingleton(RouteCollectionContract::class, self::createStub(RouteCollectionContract::class));
         $this->container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
@@ -135,6 +137,8 @@ final class ServiceProviderTest extends ServiceProviderTestCase
     public function testPublishVersionCommand(): void
     {
         $this->container->setSingleton(OutputFactoryContract::class, self::createStub(OutputFactoryContract::class));
+        $this->container->setSingleton(CliConfigContract::class, new CliConfig());
+        $this->container->setSingleton(RouteContract::class, self::createStub(RouteContract::class));
 
         $callback = CliServerServiceProvider::publishers()[VersionCommand::class];
         $callback($this->container);

--- a/tests/Tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
+++ b/tests/Tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Valkyrja\Tests\Unit\Http\Routing\Cli\Command;
 
+use Valkyrja\Application\Data\CliConfig;
 use Valkyrja\Cli\Interaction\Output\Factory\OutputFactory;
+use Valkyrja\Cli\Routing\Data\Contract\RouteContract;
 use Valkyrja\Cli\Server\Command\VersionCommand;
 use Valkyrja\Http\Routing\Cli\Command\ListCommand;
 use Valkyrja\Http\Routing\Collection\RouteCollection;
@@ -40,7 +42,7 @@ final class ListCommandTest extends TestCase
         );
 
         $outputFactory = new OutputFactory();
-        $version       = new VersionCommand($outputFactory);
+        $version       = new VersionCommand($outputFactory, new CliConfig(), $this->createStub(RouteContract::class));
         $collection    = new RouteCollection();
 
         $listCommand = new ListCommand();
@@ -65,7 +67,7 @@ final class ListCommandTest extends TestCase
     public function testNoRoutes(): void
     {
         $outputFactory = new OutputFactory();
-        $version       = new VersionCommand($outputFactory);
+        $version       = new VersionCommand($outputFactory, new CliConfig(), $this->createStub(RouteContract::class));
         $collection    = new RouteCollection();
 
         $listCommand = new ListCommand();

--- a/tests/Tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
+++ b/tests/Tests/Unit/Http/Routing/Cli/Command/ListCommandTest.php
@@ -42,7 +42,7 @@ final class ListCommandTest extends TestCase
         );
 
         $outputFactory = new OutputFactory();
-        $version       = new VersionCommand($outputFactory, new CliConfig(), $this->createStub(RouteContract::class));
+        $version       = new VersionCommand($outputFactory, new CliConfig(), self::createStub(RouteContract::class));
         $collection    = new RouteCollection();
 
         $listCommand = new ListCommand();
@@ -67,7 +67,7 @@ final class ListCommandTest extends TestCase
     public function testNoRoutes(): void
     {
         $outputFactory = new OutputFactory();
-        $version       = new VersionCommand($outputFactory, new CliConfig(), $this->createStub(RouteContract::class));
+        $version       = new VersionCommand($outputFactory, new CliConfig(), self::createStub(RouteContract::class));
         $collection    = new RouteCollection();
 
         $listCommand = new ListCommand();


### PR DESCRIPTION
# Description

Adds an `ICON` nowdoc constant (Valkyrie figure) to `ApplicationInfo` and introduces a new `Valkyrja\Cli\Interaction\Message\Header` reusable framed banner. Updates `VersionCommand`, `ListCommand`, and `HelpCommand` to use it directly.

`VersionCommand` gains `--short` (bare version number) and `--plain` (no-banner three-line format) options, with the default output rendering the full `Header` banner.

---

## Types of Changes

- [ ] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [x] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [x] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`ApplicationInfo`** — added `ICON` nowdoc constant (Valkyrie figure)
- **`Valkyrja\Cli\Interaction\Message\Header`** — new reusable framed banner message; all slots are constructor-promoted properties with sensible defaults (`ApplicationInfo::ICON`, `getcwd()` for project root, framework/PHP version constants); each slot has a `with*` immutable setter
- **`VersionCommand`** — injects `CliConfigContract` + `RouteContract`; adds `--short` (bare version number) and `--plain` (no-banner three-line format) options; default output renders the `Header` banner
- **`ListCommand`** — replaces `VersionCommand` dependency with `CliConfigContract`; uses `new Header(...)` directly
- **`HelpCommand`** — replaces `VersionCommand` dependency with `CliConfigContract`; uses `new Header(...)` directly