### PR TITLE
[View] Add missing tests

### DIFF
--- a/src/Valkyrja/View/Orka/Constant/OrkaReplacementCollection.php
+++ b/src/Valkyrja/View/Orka/Constant/OrkaReplacementCollection.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Valkyrja Framework package.
+ *
+ * (c) Melech Mizrachi <melechmizrachi@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Valkyrja\View\Orka\Constant;
+
+use Valkyrja\View\Orka\Replacement\Contract\ReplacementContract;
+
+final class OrkaReplacementCollection
+{
+    /** @var class-string<ReplacementContract>[] */
+    public const array CORE = [
+        OrkaReplacement::LAYOUT,
+        OrkaReplacement::BLOCK,
+        OrkaReplacement::END_BLOCK,
+        OrkaReplacement::START_BLOCK,
+        OrkaReplacement::TRIM_BLOCK,
+        OrkaReplacement::END_MULTILINE_COMMENT,
+        OrkaReplacement::SINGLE_LINE_COMMENT,
+        OrkaReplacement::START_MULTILINE_COMMENT,
+        OrkaReplacement::PARTIAL,
+        OrkaReplacement::PARTIAL_WITH_VARIABLES,
+        OrkaReplacement::TRIM_PARTIAL,
+        OrkaReplacement::TRIM_PARTIAL_WITH_VARIABLES,
+        OrkaReplacement::BREAK_,
+        OrkaReplacement::ELSE_HAS_BLOCK,
+        OrkaReplacement::HAS_BLOCK,
+        OrkaReplacement::UNLESS_BLOCK,
+        OrkaReplacement::ELSE_,
+        OrkaReplacement::ELSE_IF,
+        OrkaReplacement::ELSE_UNLESS,
+        OrkaReplacement::EMPTY_,
+        OrkaReplacement::END_IF,
+        OrkaReplacement::IF_,
+        OrkaReplacement::ISSET_,
+        OrkaReplacement::NOT_EMPTY,
+        OrkaReplacement::UNLESS,
+        OrkaReplacement::END_FOR,
+        OrkaReplacement::END_FOREACH,
+        OrkaReplacement::FOR_,
+        OrkaReplacement::FOREACH_,
+        OrkaReplacement::CASE_,
+        OrkaReplacement::DEFAULT_,
+        OrkaReplacement::END_SWITCH,
+        OrkaReplacement::SWITCH_,
+        OrkaReplacement::ESCAPED,
+        OrkaReplacement::SET_VARIABLE,
+        OrkaReplacement::SET_VARIABLES,
+        OrkaReplacement::UNESCAPED,
+    ];
+
+    /** @var class-string<ReplacementContract>[] */
+    public const array DEBUG = [
+        OrkaReplacement::DEBUG,
+    ];
+}

--- a/src/Valkyrja/View/Provider/ViewServiceProvider.php
+++ b/src/Valkyrja/View/Provider/ViewServiceProvider.php
@@ -26,7 +26,7 @@ use Valkyrja\Container\Provider\Contract\ServiceProviderContract;
 use Valkyrja\Http\Message\Response\Factory\Contract\ResponseFactoryContract;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Factory\ViewResponseFactory;
-use Valkyrja\View\Orka\Constant\OrkaReplacement;
+use Valkyrja\View\Orka\Constant\OrkaReplacementCollection;
 use Valkyrja\View\Orka\Replacement\Contract\ReplacementContract;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\OrkaRenderer;
@@ -193,50 +193,10 @@ class ViewServiceProvider implements ServiceProviderContract
     {
         /** @var class-string<ReplacementContract>[] $coreReplacements */
         $coreReplacements = $env::VIEW_ORKA_CORE_REPLACEMENTS
-            ?? [
-                OrkaReplacement::LAYOUT,
-                OrkaReplacement::BLOCK,
-                OrkaReplacement::END_BLOCK,
-                OrkaReplacement::START_BLOCK,
-                OrkaReplacement::TRIM_BLOCK,
-                OrkaReplacement::END_MULTILINE_COMMENT,
-                OrkaReplacement::SINGLE_LINE_COMMENT,
-                OrkaReplacement::START_MULTILINE_COMMENT,
-                OrkaReplacement::PARTIAL,
-                OrkaReplacement::PARTIAL_WITH_VARIABLES,
-                OrkaReplacement::TRIM_PARTIAL,
-                OrkaReplacement::TRIM_PARTIAL_WITH_VARIABLES,
-                OrkaReplacement::BREAK_,
-                OrkaReplacement::ELSE_HAS_BLOCK,
-                OrkaReplacement::HAS_BLOCK,
-                OrkaReplacement::UNLESS_BLOCK,
-                OrkaReplacement::ELSE_,
-                OrkaReplacement::ELSE_IF,
-                OrkaReplacement::ELSE_UNLESS,
-                OrkaReplacement::EMPTY_,
-                OrkaReplacement::END_IF,
-                OrkaReplacement::IF_,
-                OrkaReplacement::ISSET_,
-                OrkaReplacement::NOT_EMPTY,
-                OrkaReplacement::UNLESS,
-                OrkaReplacement::END_FOR,
-                OrkaReplacement::END_FOREACH,
-                OrkaReplacement::FOR_,
-                OrkaReplacement::FOREACH_,
-                OrkaReplacement::CASE_,
-                OrkaReplacement::DEFAULT_,
-                OrkaReplacement::END_SWITCH,
-                OrkaReplacement::SWITCH_,
-                OrkaReplacement::ESCAPED,
-                OrkaReplacement::SET_VARIABLE,
-                OrkaReplacement::SET_VARIABLES,
-                OrkaReplacement::UNESCAPED,
-            ];
+            ?? OrkaReplacementCollection::CORE;
         /** @var class-string<ReplacementContract>[] $replacements */
         $replacements = $env::VIEW_ORKA_REPLACEMENTS
-            ?? [
-                OrkaReplacement::DEBUG,
-            ];
+            ?? OrkaReplacementCollection::DEBUG;
 
         $allReplacements = array_merge($coreReplacements, $replacements);
 

--- a/tests/Tests/Unit/Application/Kernel/ApplicationTest.php
+++ b/tests/Tests/Unit/Application/Kernel/ApplicationTest.php
@@ -327,6 +327,21 @@ final class ApplicationTest extends TestCase
     }
 
     /**
+     * Test that the provider getters return empty arrays when there are no providers.
+     */
+    public function testProviderGettersWithNoProviders(): void
+    {
+        $config      = new Config(providers: []);
+        $application = new Valkyrja(container: new Container(), config: $config);
+
+        self::assertSame([], $application->getProviders());
+        self::assertSame([], $application->getContainerProviders());
+        self::assertSame([], $application->getEventProviders());
+        self::assertSame([], $application->getCliProviders());
+        self::assertSame([], $application->getHttpProviders());
+    }
+
+    /**
      * Test that publishProviderCallbacks with no callbacks does nothing.
      */
     public function testPublishProviderCallbacksWithNoCallbacks(): void

--- a/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
+++ b/tests/Tests/Unit/View/Provider/ServiceProviderTest.php
@@ -24,6 +24,8 @@ use Valkyrja\PhpUnit\Abstract\ServiceProviderTestCase;
 use Valkyrja\Tests\EnvClass;
 use Valkyrja\View\Factory\Contract\ViewResponseFactoryContract;
 use Valkyrja\View\Factory\ViewResponseFactory;
+use Valkyrja\View\Orka\Constant\OrkaReplacement;
+use Valkyrja\View\Orka\Replacement\Contract\ReplacementContract;
 use Valkyrja\View\Provider\ViewServiceProvider;
 use Valkyrja\View\Renderer\Contract\RendererContract;
 use Valkyrja\View\Renderer\OrkaRenderer;
@@ -71,6 +73,28 @@ final class ServiceProviderTest extends ServiceProviderTestCase
 
     public function testPublishOrkaRenderer(): void
     {
+        $callback = new ViewServiceProvider()->publishers()[OrkaRenderer::class];
+        $callback($this->container);
+
+        self::assertInstanceOf(OrkaRenderer::class, $this->container->getSingleton(OrkaRenderer::class));
+    }
+
+    public function testPublishOrkaRendererWithCustomReplacements(): void
+    {
+        $this->container->setSingleton(
+            Env::class,
+            new class extends Env {
+                /** @var class-string<ReplacementContract>[] */
+                public const array|null VIEW_ORKA_CORE_REPLACEMENTS = [
+                    OrkaReplacement::LAYOUT,
+                ];
+                /** @var class-string<ReplacementContract>[] */
+                public const array|null VIEW_ORKA_REPLACEMENTS = [
+                    OrkaReplacement::DEBUG,
+                ];
+            }
+        );
+
         $callback = new ViewServiceProvider()->publishers()[OrkaRenderer::class];
         $callback($this->container);
 


### PR DESCRIPTION
# Description

Brings the framework to 100% phpunit coverage (was 99.94%). Two classes had uncovered lines: the empty-provider branches in the application kernel, and the closing brackets of two `??`-fallback default arrays in the view service provider (which PHP never attributes coverage to).

---

## Types of Changes

- [x] Improvement _(non-breaking change which improves code)_
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Deprecation _(breaking change which removes functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
- [ ] Documentation improvement

---

## Changes

- **`src/Valkyrja/View/Orka/Constant/OrkaReplacementCollection.php`** — new constant class holding the `CORE` and `DEBUG` default Orka replacement sets
- **`src/Valkyrja/View/Provider/ViewServiceProvider.php`** — reference `OrkaReplacementCollection::CORE` / `::DEBUG` instead of inline default arrays, eliminating the uncoverable closing-bracket lines
- **`tests/Tests/Unit/Application/Kernel/ApplicationTest.php`** — added `testProviderGettersWithNoProviders()` covering the zero-provider `: []` branches in all four provider getters
- **`tests/Tests/Unit/View/Provider/ServiceProviderTest.php`** — added `testPublishOrkaRendererWithCustomReplacements()` covering the env-provided replacements branch